### PR TITLE
Added Cursor Support and Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ preferred LLMs with Bagel.
 
 ### Tutorials
 
-- [MCP Tutorial - Claude Code](./doc/tutorials/mcp/0_claude_code_px4.ipynb)
-- [MCP Tutorial - Gemini CLI](./doc/tutorials/mcp/1_gemini_cli_ros2.ipynb)
+- [Claude Code Tutorial with a PX4 ULog](./doc/tutorials/mcp/0_claude_code_px4.ipynb)
+- [Gemini CLI Tutorial with a ROS2 Bag](./doc/tutorials/mcp/1_gemini_cli_ros2.ipynb)
+- [Cursor Tutorial with a PX4 ULog](./doc/tutorials/mcp/2_cursor_px4.ipynb)
 - [Build a Data Pipeline from a PX4 ULog](./doc/tutorials/pipelines/0_basics.ipynb)
-- [Read Topic Messages from a ROS 2 Bag](./doc/tutorials/readers/1_read_by_topic.ipynb)
+- [Read Topic Messages from a ROS2 Bag](./doc/tutorials/readers/1_read_by_topic.ipynb)
 
 ### Running in Docker 🐳
 

--- a/doc/tutorials/mcp/2_cursor_px4.ipynb
+++ b/doc/tutorials/mcp/2_cursor_px4.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0c6222f7",
+   "metadata": {},
+   "source": [
+    "To launch this notebook, run this under the repo root:\n",
+    "\n",
+    "```sh\n",
+    "uv run jupyter lab\n",
+    "```\n",
+    "\n",
+    "In the Jupyter Lab, navigate to the \"doc/tutorials/mcp/2_cursor_px4.ipynb\" and proceed with the\n",
+    "rest of the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ad7211c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the working directory to the Bagel repo root.\n",
+    "# Please replace with your actual repo root if different.\n",
+    "%cd /Users/arunvenkatadri/projects/bagel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "416a1d37",
+   "metadata": {},
+   "source": [
+    "## Install Cursor 💻\n",
+    "\n",
+    "To install Cursor, please visit: [https://cursor.com/downloads](https://cursor.com/downloads)\n",
+    "\n",
+    "### Flexibility with LLMs ✨\n",
+    "\n",
+    "While we currently use Cursor for its ease of integration, **the Bagel MCP server is not exclusively tied to Cursor.** You're free to integrate your preferred Large Language Models (LLMs) with Bagel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de866627",
+   "metadata": {},
+   "source": [
+    "## Run Local Bagel MCP Server\n",
+    "\n",
+    "First, let's install required PX4 PyPI dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5096768d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv sync --group px4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e4c73bb",
+   "metadata": {},
+   "source": [
+    "Let's spin up a Bagel MCP server running on localhost:8000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1f282c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run main.py up mcp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b58dfba",
+   "metadata": {},
+   "source": [
+    "If you go to http://0.0.0.0:8000/sse in your browser, you should see something like:\n",
+    "\n",
+    "```\n",
+    "event: endpoint\n",
+    "data: /messages/?session_id=83b3948265a34a27983d97b984710f30\n",
+    "```\n",
+    "\n",
+    ":tada: This means that the Bagel MCP Server is running."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e543a4a",
+   "metadata": {},
+   "source": [
+    "## Open Cursor App\n",
+    "\n",
+    "Connect Bagel MCP Server to Cursor 🔗. Go to FILE > PREFERENCES > CURSOR SETTINGS > TOOLS AND INTEGRATIONS,\n",
+    "and click \"New MCP Server.\" This opens the file `~/.cursor/mcp.json`.\n",
+    "\n",
+    "Add Bagel to the MCP server list `mcpServers`:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"mcpServers\": {\n",
+    "    \"bagel\": {\n",
+    "      \"url\": \"http://localhost:8000/sse\"\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Make sure Bagel is connected to Cursor by checking if the status bubble is green."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68e4ed64",
+   "metadata": {},
+   "source": [
+    "# Let's Chat 💬"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7aec3917",
+   "metadata": {},
+   "source": [
+    "> Summarize the metadata of robolog \"/Users/arunvenkatadri/projects/bagel/doc/tutorials/data/px4.ulg\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f2903ae",
+   "metadata": {},
+   "source": [
+    "> List all the topics in the robolog. By the way, I want to know their message types and counts too."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f04d1f2",
+   "metadata": {},
+   "source": [
+    "> Are there any errors in this log? Explain the errors if exist."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61fbdf32",
+   "metadata": {},
+   "source": [
+    "> Are there any hard-landings you can detect from vehicle IMU topic \"vehicle_imu_0\"?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bagel",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR closes #33.

Cursor made it easy to integrate MCP servers. We just need to lightly modify the `~/.cursor/mcp.json` file to add Bagel.

Also added a Jypyter notebook tutorial of how to set up Bagel with Cursor.