### PR TITLE
Fix ROS2 Buildin Type Parsing and Missing Logging Topic Type

### DIFF
--- a/src/convert/ros2msg/parse.py
+++ b/src/convert/ros2msg/parse.py
@@ -346,7 +346,7 @@ def struct(lines: list[lark.tree.Tree]) -> definition.Struct:
     return definition.Struct(type_=type_name, fields=fields)
 
 
-def fully_qualified_type_name(
+def fully_qualified_type_name(  # noqa: PLR0911
     type_name: str, namespace: str | None, dependencies: dict[str, definition.Struct]
 ) -> str:
     """Return the fully qualified type name for a given short type name."""
@@ -361,6 +361,12 @@ def fully_qualified_type_name(
         and "builtin_interfaces/msg/Duration" in dependencies
     ):
         return "builtin_interfaces/msg/Duration"
+    elif (
+        "/" in type_name
+        and len(type_name.split("/")) == 2  # noqa: PLR2004
+        and f"{type_name.split('/')[0]}/msg/{type_name.split('/')[1]}" in dependencies
+    ):
+        return f"{type_name.split('/')[0]}/msg/{type_name.split('/')[1]}"
     elif namespace and f"{namespace}/{type_name}" in dependencies:
         return f"{namespace}/{type_name}"
     elif struct_type := next((t for t in dependencies if t.endswith(f"/{type_name}")), None):

--- a/src/reader/ros2/reader.py
+++ b/src/reader/ros2/reader.py
@@ -1,5 +1,6 @@
 """Base class for ROS2 bag readers."""
 
+import logging
 import pathlib
 from collections.abc import Iterator
 from typing import Any
@@ -103,6 +104,14 @@ class Ros2Reader(reader.Reader):
             for topic, type_name in self.type_names.items()
             if type_name == LOGGING_MESSAGE_TYPE_NAME
         ]
+
+        if not topics:
+            logging.warning(
+                "No logging messages found since %s topic type is not present.",
+                LOGGING_MESSAGE_TYPE_NAME,
+            )
+            return
+
         reader.set_filter(rosbag2_py.StorageFilter(topics))
 
         while reader.has_next():

--- a/test/convert/ros2msg/test_ros2msg_sample_full_text.py
+++ b/test/convert/ros2msg/test_ros2msg_sample_full_text.py
@@ -137,3 +137,151 @@ def test_should_parse_sample_full_text() -> None:
             default=None,
         ),
     ]
+
+
+def test_should_parse_sample_full_text_with_builtin_types() -> None:
+    # GIVEN
+    full_text = """
+    # This represents an estimate of a position and velocity in free space.
+    # The pose in this message should be specified in the coordinate frame given by header.frame_id
+    # The twist in this message should be specified in the coordinate frame given by the
+    # child_frame_id
+
+    # Includes the frame id of the pose parent.
+    std_msgs/Header header
+
+    # Frame id the pose points to. The twist is in this coordinate frame.
+    string child_frame_id
+
+    # Estimated pose that is typically relative to a fixed world frame.
+    geometry_msgs/PoseWithCovariance pose
+
+    # Estimated linear and angular velocity relative to child_frame_id.
+    geometry_msgs/TwistWithCovariance twist
+
+    ================================================================================
+    MSG: geometry_msgs/msg/TwistWithCovariance
+    # This expresses velocity in free space with uncertainty.
+
+    Twist twist
+
+    # Row-major representation of the 6x6 covariance matrix
+    # The orientation parameters use a fixed-axis representation.
+    # In order, the parameters are:
+    # (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+    float64[36] covariance
+
+    ================================================================================
+    MSG: geometry_msgs/msg/Twist
+    # This expresses velocity in free space broken into its linear and angular parts.
+
+    Vector3  linear
+    Vector3  angular
+
+    ================================================================================
+    MSG: geometry_msgs/msg/Vector3
+    # This represents a vector in free space.
+
+    # This is semantically different than a point.
+    # A vector is always anchored at the origin.
+    # When a transform is applied to a vector, only the rotational component is applied.
+
+    float64 x
+    float64 y
+    float64 z
+
+    ================================================================================
+    MSG: geometry_msgs/msg/PoseWithCovariance
+    # This represents a pose in free space with uncertainty.
+
+    Pose pose
+
+    # Row-major representation of the 6x6 covariance matrix
+    # The orientation parameters use a fixed-axis representation.
+    # In order, the parameters are:
+    # (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+    float64[36] covariance
+
+    ================================================================================
+    MSG: geometry_msgs/msg/Pose
+    # A representation of pose in free space, composed of position and orientation.
+
+    Point position
+    Quaternion orientation
+
+    ================================================================================
+    MSG: geometry_msgs/msg/Quaternion
+    # This represents an orientation in free space in quaternion form.
+
+    float64 x 0
+    float64 y 0
+    float64 z 0
+    float64 w 1
+
+    ================================================================================
+    MSG: geometry_msgs/msg/Point
+    # This contains the position of a point in free space
+    float64 x
+    float64 y
+    float64 z
+
+    ================================================================================
+    MSG: std_msgs/msg/Header
+    # Standard metadata for higher-level stamped data types.
+    # This is generally used to communicate timestamped data
+    # in a particular coordinate frame.
+
+    # Two-integer timestamp that is expressed as seconds and nanoseconds.
+    builtin_interfaces/Time stamp
+
+    # Transform frame with which this data is associated.
+    string frame_id
+
+    ================================================================================
+    MSG: builtin_interfaces/msg/Time
+    # This message communicates ROS Time defined here:
+    # https://design.ros2.org/articles/clock_and_time.html
+
+    # The seconds component, valid over all int32 values.
+    int32 sec
+
+    # The nanoseconds component, valid in the range [0, 1e9).
+    uint32 nanosec
+    """
+
+    # WHEN
+    struct, _ = parse.parse(textwrap.dedent(full_text))
+
+    # THEN
+    assert struct.fields == [
+        definition.ComplexField(
+            name="header",
+            type_="std_msgs/msg/Header",
+            is_array=False,
+            array_size=None,
+            array_size_upper_bound=None,
+        ),
+        definition.StringField(
+            name="child_frame_id",
+            type_="string",
+            is_array=False,
+            array_size=None,
+            array_size_upper_bound=None,
+            string_size_upper_bound=None,
+            default=None,
+        ),
+        definition.ComplexField(
+            name="pose",
+            type_="geometry_msgs/msg/PoseWithCovariance",
+            is_array=False,
+            array_size=None,
+            array_size_upper_bound=None,
+        ),
+        definition.ComplexField(
+            name="twist",
+            type_="geometry_msgs/msg/TwistWithCovariance",
+            is_array=False,
+            array_size=None,
+            array_size_upper_bound=None,
+        ),
+    ]


### PR DESCRIPTION
Fixes #37 .

Credits to @Fathy071, the user discovered two types of exceptions.

### First, ROS2's buildin type names in .msg

In the test [rosbag](https://drive.google.com/file/d/12lzx7huwVWXpUITNg8F3gDZxRlBfRCgd/view) shared by the user, the header has the type name of `std_msgs/Header`. However, looking at the rest of the .msg, this type was actually named `std_msgs/msg/Header`. Please see the snippet:

```
# Includes the frame id of the pose parent.
std_msgs/Header header

# Frame id the pose points to. The twist is in this coordinate frame.
string child_frame_id

# Estimated pose that is typically relative to a fixed world frame.
geometry_msgs/PoseWithCovariance pose

# Estimated linear and angular velocity relative to child_frame_id.
geometry_msgs/TwistWithCovariance twist

... many type definition later...

================================================================================
MSG: std_msgs/msg/Header
# Standard metadata for higher-level stamped data types.
# This is generally used to communicate timestamped data
# in a particular coordinate frame.

# Two-integer timestamp that is expressed as seconds and nanoseconds.
builtin_interfaces/Time stamp

# Transform frame with which this data is associated.
string frame_id
```

Bagel wasn't able to handle this corner case before. We are glad that the community caught it.

### Second, ambiguous exception when accessing the ROS2 logging messages

The other exception was about an ambiguous exception. When the user was trying to access the logging messages, Bagel is trying to read from all the topics of the type `rcl_interfaces/msg/Log`. However, the rosbag is missing the topics of that type, therefore, a cryptic error was raised that confused user. Such scenario should be handled explicitly. 
