### PR TITLE
Fixed docker entrypoints to spin up MCP server

### DIFF
--- a/docker/Dockerfile.ardupilot
+++ b/docker/Dockerfile.ardupilot
@@ -79,5 +79,5 @@ COPY --chown=${USERNAME}:${USERNAME} test/logging/ardupilot ./test/logging/ardup
 
 RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
 
-# By default, the webapp will be launched
-CMD ["uv", "run", "main.py", "up", "webapp"]
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.betaflight
+++ b/docker/Dockerfile.betaflight
@@ -79,5 +79,5 @@ COPY --chown=${USERNAME}:${USERNAME} test/logging/betaflight ./test/logging/beta
 
 RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
 
-# By default, the webapp will be launched
-CMD ["uv", "run", "main.py", "up", "webapp"]
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.px4
+++ b/docker/Dockerfile.px4
@@ -78,5 +78,5 @@ COPY --chown=${USERNAME}:${USERNAME} test/logging/px4 ./test/logging/px4
 
 RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
 
-# By default, the webapp will be launched
-CMD ["uv", "run", "main.py", "up", "webapp"]
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.ros1
+++ b/docker/Dockerfile.ros1
@@ -132,5 +132,5 @@ COPY --chown=${USERNAME}:${USERNAME} test/logging/ros1 ./test/logging/ros1
 
 RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
 
-# By default, the webapp will be launched
-CMD ["uv", "run", "main.py", "up", "webapp"]
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -83,5 +83,5 @@ COPY --chown=${USERNAME}:${USERNAME} test/logging/ros2 ./test/logging/ros2
 
 RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
 
-# By default, the webapp will be launched
-CMD ["uv", "run", "main.py", "up", "webapp"]
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]


### PR DESCRIPTION
There was a bug in docker images where they still referred to the old main.py. This mistake was due to the bad rebase.