### PR TITLE
Support File-based Pipeline

### DIFF
--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -1,14 +1,24 @@
-"""Base classes and interfaces for pipelines, tasks, and gates, etc."""
+"""Base classes and utilities for defining and running data processing pipelines."""
 
 import abc
 import importlib
-import inspect
+import logging
+import pathlib
+from collections.abc import Iterator
 from enum import Enum
 from typing import Any
 
+import yaml
 from pydantic import BaseModel
 
+from settings import settings
 from src.di import module
+from src.di.types.base_module import BaseModule
+from src.di.types.data_source import DataSource, resolve
+from src.image.base import ImageDataset
+from src.message.base import MessageDataset
+from src.source.base import SourceFactory
+from src.topic.base import TopicRegistry
 
 SECOND = 1
 MINUTE = 60 * SECOND
@@ -16,11 +26,11 @@ HOUR = 60 * MINUTE
 
 
 class MissingRequiredKeyError(Exception):
-    """Raised when a required key is missing in the pipeline definition."""
+    """Raised when a required key is missing in the pipeline YAML configuration."""
 
 
 class Unit(Enum):
-    """Unit of a time window."""
+    """Unit of a cadence interval."""
 
     FRAME = "frame"
     SECOND = "second"
@@ -28,28 +38,35 @@ class Unit(Enum):
     HOUR = "hour"
 
 
-def _to_seconds(value: int, unit: Unit) -> float:
+def to_seconds(value: int, unit: Unit) -> float:
+    """Cast a value in the given unit to seconds."""
     match unit:
         case Unit.SECOND:
-            return float(value * SECOND)
+            return value * SECOND
         case Unit.MINUTE:
-            return float(value * MINUTE)
+            return value * MINUTE
         case Unit.HOUR:
-            return float(value * HOUR)
+            return value * HOUR
         case _:
             raise ValueError(f"Cannot convert {unit} to seconds")
 
 
-class Cadence(BaseModel):
-    """Base class for pipeline execution cadence."""
+class OnceAtEnd(BaseModel):
+    """A `cadence.when` option that triggers the pipeline at the natural end of the data source.
 
-    pass
+    Examples:
+        - For a bounded source (e.g., a ROS 2 bag), the pipeline runs once at the final timestamp.
+        - For a live stream, the pipeline runs once when the stream terminates.
+
+    """
 
 
-class Frequency(Cadence):
-    """A cadence type indicating a pipeline should run at a fixed frequency.
+class Frequency(BaseModel):
+    """A `cadence.when` option that triggers the pipeline at a fixed frequency.
 
-    For example, every 5 minutes, every 30 frames, etc.
+    Examples:
+        - Every 5 minutes.
+        - Every 30 frames.
 
     """
 
@@ -57,30 +74,16 @@ class Frequency(Cadence):
     unit: Unit
 
     def to_seconds(self) -> float:
-        """Return the frequency in seconds, if applicable."""
-        return _to_seconds(self.every, self.unit)
-
-    @staticmethod
-    def build(every: int, unit: str) -> "Frequency":
-        """Return a Frequency object from the given configuration."""
-        return Frequency(every=every, unit=Unit(unit))
-
-
-class AtTheEnd(Cadence):
-    """A cadence type indicating a pipeline should run at the natural end of the data source.
-
-    For example, if the data source is ROS2 bag, the pipeline will run when the bag reaches the end.
-    If the data source is a live data stream, the pipeline will run when the stream is closed.
-
-    """
-
-    pass
+        """Convert the frequency interval to seconds, if applicable."""
+        return to_seconds(self.every, self.unit)
 
 
 class Lookback(BaseModel):
-    """Lookback window for a task or gate.
+    """A lookback window defining how far back in time to consider data for gates and tasks.
 
-    For example, last 10 seconds, last 100 frames, etc.
+    Examples:
+        - The last 10 frames.
+        - The last 5 minutes.
 
     """
 
@@ -88,143 +91,357 @@ class Lookback(BaseModel):
     unit: Unit
 
     def to_seconds(self) -> float:
-        """Return the lookback window in seconds, if applicable."""
-        return _to_seconds(self.last, self.unit)
+        """Convert the lookback window to seconds, if applicable."""
+        return to_seconds(self.last, self.unit)
 
     @staticmethod
-    def build(last: int | None, unit: str | None) -> "Lookback | None":
-        """Return a Lookback object from the given configuration."""
-        match last, unit:
-            case None, None:
-                return None
-            case int(), str():
+    def build(config: dict[str, Any]) -> "Lookback":
+        """Build a Lookback instance from the value of a 'lookback' key."""
+        match config:
+            case {"last": int(last), "unit": str(unit)}:
                 return Lookback(last=last, unit=Unit(unit))
             case _:
-                raise ValueError("Both 'last' and 'unit' must be provided or not at all")
+                raise ValueError(f"Invalid 'lookback' value: {config}")
 
 
-class Gate(abc.ABC):
-    """Abstract base class for gates that check whether a pipeline should run at a given time."""
+class Cadence(BaseModel):
+    """Specify how often the pipeline runs and which topic determines its cadence.
 
-    @abc.abstractmethod
-    def evaluate(self, asof_seconds: float) -> bool:
-        """Evaluate the gate at the given time."""
-
-    @staticmethod
-    @abc.abstractmethod
-    def build(args: dict[str, Any]) -> "Gate":
-        """Build a Gate object from the given configuration."""
-
-
-class Task(abc.ABC):
-    """Abstract base class for tasks that can be executed in a pipeline."""
-
-    @abc.abstractmethod
-    def execute(self, asof_seconds: float) -> None:
-        """Execute the task at the given time."""
-
-    @staticmethod
-    @abc.abstractmethod
-    def build(args: dict[str, Any]) -> "Task":
-        """Build a Task object from the given configuration."""
-
-
-class Pipeline:
-    """A data processing pipeline consisting of tasks and gates.
-
-    Gates are used to determine whether the pipeline should run at a given time,
-    i.e., if all gates evaluate to True. Then all tasks in the pipeline will be executed.
+    Examples:
+        - Run the pipeline once every 30 frames of the `/camera/image` topic.
+        - Run the pipeline once at the final timestamp of the `/lidar/points` topic.
 
     """
 
-    def __init__(
+    topic: str
+    when: OnceAtEnd | Frequency
+
+    @staticmethod
+    def build(config: dict[str, Any]) -> "Cadence":
+        """Build a Cadence instance from the value of a 'cadence' key."""
+        match config["when"]:
+            case "once_at_end":
+                when = OnceAtEnd()
+            case {"every": int(every), "unit": str(unit)}:
+                when = Frequency(every=every, unit=Unit(unit))
+            case when:
+                raise ValueError(f"Invalid 'when' value: {when}")
+        return Cadence(topic=config["topic"], when=when)
+
+
+class Operator(abc.ABC):
+    """Abstract base class for gate and task operators."""
+
+    @abc.abstractmethod
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        """Initialize the operator using the given data source.
+
+        Called immediately after construction to set up any resources that depend on
+        the data source, such as a SourceFactory, TopicRegistry, etc.
+
+        Args:
+            path: Filesystem path or URL to the data source.
+            **kwargs: Additional parameters for setup.
+
+        """
+
+    @staticmethod
+    def build(path: str, config: dict[str, Any]) -> "Operator":
+        """Build an Operator instance from a config dictionary of a gate or task.
+
+        Args:
+            path (str): Filesystem path or URL to the data source.
+            config (dict[str, Any]): Configuration dictionary for the operator.
+
+        Returns:
+            Operator: The constructed Operator instance.
+
+        """
+        importlib.import_module(config["module"]).register()
+        cls = module.global_registry[config["module"]]
+        instance: Operator = cls(**config.get("args", {}))
+        instance.setup(path=path, **config.get("setup_args", {}))
+        return instance
+
+
+class TopicMessageMixin:
+    """Mixin for operators that work on messages in a topic."""
+
+    _factory: SourceFactory
+    _registry: TopicRegistry
+    _dataset: MessageDataset
+
+    @property
+    def factory(self) -> SourceFactory:  # noqa: D102
+        return self._factory
+
+    @property
+    def registry(self) -> TopicRegistry:  # noqa: D102
+        return self._registry
+
+    @property
+    def dataset(self) -> MessageDataset:  # noqa: D102
+        return self._dataset
+
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003, D102
+        ds_type = resolve(path)
+
+        factory_module = f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}"
+        registry_module = f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}"
+        dataset_module = f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}"
+
+        self._factory = module.provide(factory_module, {"path": path, **kwargs})
+        self._registry = module.provide(registry_module, {**kwargs})
+        self._dataset = module.provide(dataset_module, {**kwargs})
+
+
+class TopicImageMixin:
+    """Mixin for operators that work on images in a topic."""
+
+    _factory: SourceFactory
+    _registry: TopicRegistry
+    _dataset: ImageDataset
+
+    @property
+    def factory(self) -> SourceFactory:  # noqa: D102
+        return self._factory
+
+    @property
+    def registry(self) -> TopicRegistry:  # noqa: D102
+        return self._registry
+
+    @property
+    def dataset(self) -> ImageDataset:  # noqa: D102
+        return self._dataset
+
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003, D102
+        ds_type = resolve(path)
+
+        factory_module = f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}"
+        registry_module = f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}"
+        dataset_module = None
+        match ds_type:
+            case DataSource.ROS1_BAG:
+                dataset_module = f"{BaseModule.IMAGE_DATASET.value}.ros1.bag"
+            case DataSource.BAGEL_SINK:
+                metadata_file = pathlib.Path(path) / "metadata.yaml"
+                metadata = yaml.safe_load(metadata_file.read_text())
+                dataset_module = metadata.get("image_dataset_module")
+        if dataset_module is None:
+            raise ValueError(f"{ds_type} not supported")
+
+        self._factory = module.provide(factory_module, {"path": path, **kwargs})
+        self._registry = module.provide(registry_module, {**kwargs})
+        self._dataset = module.provide(dataset_module, {**kwargs})
+
+
+class Gate(Operator):
+    """Abstract base class for gating operators.
+
+    A gate determines whether downstream tasks should be executed based on evaluated criteria.
+
+    """
+
+    @abc.abstractmethod
+    def evaluate(self, asof_seconds: float, lookback: Lookback | None) -> bool:
+        """Evaluate the gating criteria at a specific point in time.
+
+        Args:
+            asof_seconds (float): The timestamp (in seconds) at which to evaluate the gate.
+            lookback (Lookback | None): The lookback window defining how far back to consider data.
+                If None, all available data up to `asof_seconds` should be considered. Some gates
+                may not support lookback and will ignore this argument.
+
+        Returns:
+            True if the gate criteria is met.
+
+        """
+
+
+class Task(Operator):
+    """Abstract base class for task operators.
+
+    A task performs a specific action when executed, such as sending an email or generating a GIF.
+
+    """
+
+    @abc.abstractmethod
+    def execute(self, asof_seconds: float, lookback: Lookback | None) -> None:
+        """Execute the task at a specific point in time.
+
+        Args:
+            asof_seconds (float): The timestamp (in seconds) at which to execute the task.
+            lookback (Lookback | None): The lookback window defining how far back to consider data.
+                If None, all available data up to `asof_seconds` should be considered. Some tasks
+                may not support lookback and will ignore this argument.
+
+        """
+
+
+class Pipeline:
+    """A data processing pipeline consisting of gates and tasks.
+
+    It runs at specified intervals based on a cadence, evaluates gates,
+    and executes tasks if the gates pass.
+
+    """
+
+    def __init__(  # noqa: PLR0913
         self,
         name: str,
+        path: str,
+        allow_failure: bool,
         cadence: Cadence,
-        gates: list[Gate],
-        tasks: list[Task],
-        allow_failure: bool = False,
+        gates: list[tuple[Gate, Lookback | None]],
+        tasks: list[tuple[Task, Lookback | None]],
     ) -> None:
-        """Initialize the Pipeline.
+        """Initialize a Pipeline instance.
 
         Args:
             name (str): The name of the pipeline.
-            cadence (Cadence): The execution cadence of the pipeline. It can be either:
-                - Frequency: The pipeline runs at a regular interval.
-                - AtTheEnd: The pipeline runs at the natural end of the data source.
-            gates (list[Gate]): A list of gates to evaluate before running the pipeline.
-            tasks (list[Task]): A list of tasks to execute in the pipeline.
-            allow_failure (bool, optional): Whether to allow task failures. Defaults to False.
-                The caller of the pipeline should handle failures accordingly.
-
-        Raises:
-            ValueError: If no tasks are provided.
+            path (str): Filesystem path or URL to the data source.
+            allow_failure (bool): Whether to continue executing pipeline runs if a run fails.
+            cadence (Cadence): How often to run the pipeline.
+            gates (list[tuple[Gate, Lookback  |  None]]): List of gating operators and their
+                lookback windows.
+            tasks (list[tuple[Task, Lookback  |  None]]): List of task operators and their
+                lookback windows.
 
         """
-        if not tasks:
-            raise ValueError("At least one task must be provided")
         self._name = name
+        self._path = path
+        self._allow_failure = allow_failure
         self._cadence = cadence
         self._gates = gates
         self._tasks = tasks
-        self._allow_failure = allow_failure
 
     @property
     def name(self) -> str:
-        """Return the name of the pipeline."""
+        """The name of the pipeline."""
         return self._name
 
     @property
     def cadence(self) -> Cadence:
-        """Return the execution cadence of the pipeline."""
+        """How often to run the pipeline."""
         return self._cadence
 
-    @property
-    def allow_failure(self) -> bool:
-        """Return whether task failures are allowed."""
-        return self._allow_failure
+    def _asof_timestamps(self) -> Iterator[float]:
+        ds_type = resolve(self._path)
 
-    def run(self, asof_seconds: float) -> bool:
-        """Run the pipeline at the given time. Return True if gates pass and tasks are executed."""
-        if all(gate.evaluate(asof_seconds) for gate in self._gates) if self._gates else True:
-            for task in self._tasks:
-                task.execute(asof_seconds)
-            return True
-        return False
-
-    @staticmethod
-    def build(args: dict[str, Any]) -> "Pipeline":
-        """Return a Pipeline object from the given configuration."""
-        if "cadence" not in args:
-            raise MissingRequiredKeyError("cadence")
-        match args["cadence"]:
-            case {"every": every, "unit": unit}:
-                cadence = Frequency.build(every, unit)
-            case "at_the_end":
-                cadence = AtTheEnd()
-            case _:
-                raise ValueError("Invalid cadence configuration")
-
-        gates = [
-            Pipeline._provide(gate_args["module"], gate_args.get("args", {}))
-            for gate_args in args.get("gates", [])
-        ]
-
-        if "tasks" not in args:
-            raise MissingRequiredKeyError("tasks")
-        tasks = [
-            Pipeline._provide(task_args["module"], task_args.get("args", {}))
-            for task_args in args["tasks"]
-        ]
-
-        allow_failure = args.get(
-            "allow_failure",
-            inspect.signature(Pipeline.__init__).parameters["allow_failure"].default,
+        factory = module.provide(
+            f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": self._path}
         )
+        registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
+        dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
 
-        return Pipeline(cadence=cadence, gates=gates, tasks=tasks, allow_failure=allow_failure)
+        relation = dataset.to_duckdb(
+            factory=factory,
+            registry=registry,
+            topics=[self.cadence.topic],
+            start_seconds=None,
+            end_seconds=None,
+        )
+        rows = relation.project(settings.TIMESTAMP_SECONDS_COLUMN_NAME).fetchall()
+        timestamps = [float(row[0]) for row in rows]
+
+        if not timestamps:
+            return
+
+        if isinstance(self.cadence.when, OnceAtEnd):
+            yield timestamps[-1]
+        else:
+            last_run_at = None
+            for i, timestamp_seconds in enumerate(timestamps):
+                match self.cadence.when.unit:
+                    case Unit.FRAME:
+                        if i % self.cadence.when.every == 0:
+                            yield timestamp_seconds
+                    case _:
+                        if (
+                            last_run_at is None
+                            or timestamp_seconds - last_run_at >= self.cadence.when.to_seconds()
+                        ):
+                            last_run_at = timestamp_seconds
+                            yield timestamp_seconds
+
+    def run_at(self, asof_seconds: float) -> None:
+        """Run the pipeline at the given timestamp (in seconds)."""
+        try:
+            if all(gate.evaluate(asof_seconds, lookback) for gate, lookback in self._gates):
+                for task, lookback in self._tasks:
+                    task.execute(asof_seconds, lookback)
+                logging.info(
+                    "Pipeline '%s' executed successfully when topic '%s' received message at %.4f seconds",  # noqa: E501
+                    self.name,
+                    self.cadence.topic,
+                    asof_seconds,
+                )
+            else:
+                logging.info(
+                    "Pipeline '%s' didn't pass the gating criteria when topic '%s' received message at %.4f seconds",  # noqa: E501
+                    self.name,
+                    self.cadence.topic,
+                    asof_seconds,
+                )
+        except Exception as e:
+            if not self._allow_failure:
+                raise e
+            logging.error(
+                "Pipeline '%s' execution failed when topic '%s' received message at %.4f seconds: %s",  # noqa: E501
+                self.name,
+                self.cadence.topic,
+                asof_seconds,
+                str(e),
+            )
+
+    def run_all(self) -> None:
+        """Run the pipeline at all applicable timestamps based on its cadence."""
+        for asof_seconds in self._asof_timestamps():
+            self.run_at(asof_seconds)
+        logging.info("Pipeline '%s' completed.", self.name)
 
     @staticmethod
-    def _provide(name: str, args: dict[str, Any]) -> object:
-        importlib.import_module(name).register()
-        return module.global_registry[name].build(args)
+    def build(config: dict[str, Any]) -> "Pipeline":
+        """Build a Pipeline instance from a YAML definition."""
+        if "name" not in config:
+            raise MissingRequiredKeyError("name")
+        name = config["name"]
+
+        if "path" not in config:
+            raise MissingRequiredKeyError("path")
+        path = config["path"]
+
+        if "allow_failure" not in config:
+            raise MissingRequiredKeyError("allow_failure")
+        allow_failure = config["allow_failure"]
+
+        if "cadence" not in config:
+            raise MissingRequiredKeyError("cadence")
+        cadence = Cadence.build(config["cadence"])
+
+        gates = []
+        for gate_config in config.get("gates", []):
+            gate = Gate.build(path, gate_config)
+            lookback = None
+            if "lookback" in gate_config:
+                lookback = Lookback.build(gate_config["lookback"])
+            gates.append((gate, lookback))
+
+        if "tasks" not in config:
+            raise MissingRequiredKeyError("tasks")
+        tasks = []
+        for task_config in config["tasks"]:
+            task = Task.build(path, task_config)
+            lookback = None
+            if "lookback" in task_config:
+                lookback = Lookback.build(task_config["lookback"])
+            tasks.append((task, lookback))
+
+        return Pipeline(
+            name=name,
+            path=path,
+            allow_failure=allow_failure,
+            cadence=cadence,
+            gates=gates,
+            tasks=tasks,
+        )

--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -40,8 +40,14 @@ def _to_seconds(value: int, unit: Unit) -> float:
             raise ValueError(f"Cannot convert {unit} to seconds")
 
 
-class Frequency(BaseModel):
-    """Execution frequency of a pipeline.
+class Cadence(BaseModel):
+    """Base class for pipeline execution cadence."""
+
+    pass
+
+
+class Frequency(Cadence):
+    """A cadence type indicating a pipeline should run at a fixed frequency.
 
     For example, every 5 minutes, every 30 frames, etc.
 
@@ -58,6 +64,17 @@ class Frequency(BaseModel):
     def build(every: int, unit: str) -> "Frequency":
         """Return a Frequency object from the given configuration."""
         return Frequency(every=every, unit=Unit(unit))
+
+
+class AtTheEnd(Cadence):
+    """A cadence type indicating a pipeline should run at the natural end of the data source.
+
+    For example, if the data source is ROS2 bag, the pipeline will run when the bag reaches the end.
+    If the data source is a live data stream, the pipeline will run when the stream is closed.
+
+    """
+
+    pass
 
 
 class Lookback(BaseModel):
@@ -122,7 +139,8 @@ class Pipeline:
 
     def __init__(
         self,
-        frequency: Frequency,
+        name: str,
+        cadence: Cadence,
         gates: list[Gate],
         tasks: list[Task],
         allow_failure: bool = False,
@@ -130,7 +148,10 @@ class Pipeline:
         """Initialize the Pipeline.
 
         Args:
-            frequency (Frequency): How often the pipeline should run.
+            name (str): The name of the pipeline.
+            cadence (Cadence): The execution cadence of the pipeline. It can be either:
+                - Frequency: The pipeline runs at a regular interval.
+                - AtTheEnd: The pipeline runs at the natural end of the data source.
             gates (list[Gate]): A list of gates to evaluate before running the pipeline.
             tasks (list[Task]): A list of tasks to execute in the pipeline.
             allow_failure (bool, optional): Whether to allow task failures. Defaults to False.
@@ -142,16 +163,21 @@ class Pipeline:
         """
         if not tasks:
             raise ValueError("At least one task must be provided")
-
-        self._frequency = frequency
+        self._name = name
+        self._cadence = cadence
         self._gates = gates
         self._tasks = tasks
         self._allow_failure = allow_failure
 
     @property
-    def frequency(self) -> Frequency:
-        """Return the frequency of the pipeline."""
-        return self._frequency
+    def name(self) -> str:
+        """Return the name of the pipeline."""
+        return self._name
+
+    @property
+    def cadence(self) -> Cadence:
+        """Return the execution cadence of the pipeline."""
+        return self._cadence
 
     @property
     def allow_failure(self) -> bool:
@@ -169,9 +195,15 @@ class Pipeline:
     @staticmethod
     def build(args: dict[str, Any]) -> "Pipeline":
         """Return a Pipeline object from the given configuration."""
-        if "frequency" not in args:
-            raise MissingRequiredKeyError("frequency")
-        frequency = Frequency.build(args["frequency"]["every"], args["frequency"]["unit"])
+        if "cadence" not in args:
+            raise MissingRequiredKeyError("cadence")
+        match args["cadence"]:
+            case {"every": every, "unit": unit}:
+                cadence = Frequency.build(every, unit)
+            case "at_the_end":
+                cadence = AtTheEnd()
+            case _:
+                raise ValueError("Invalid cadence configuration")
 
         gates = [
             Pipeline._provide(gate_args["module"], gate_args.get("args", {}))
@@ -190,7 +222,7 @@ class Pipeline:
             inspect.signature(Pipeline.__init__).parameters["allow_failure"].default,
         )
 
-        return Pipeline(frequency=frequency, gates=gates, tasks=tasks, allow_failure=allow_failure)
+        return Pipeline(cadence=cadence, gates=gates, tasks=tasks, allow_failure=allow_failure)
 
     @staticmethod
     def _provide(name: str, args: dict[str, Any]) -> object:

--- a/src/pipeline/gates/cv/object_too_close.py
+++ b/src/pipeline/gates/cv/object_too_close.py
@@ -1,8 +1,6 @@
-"""A gate that evaluates whether an object of certain labels is too close in images."""
+"""Estimate depth on detected objects to determine whether they are too close."""
 
-import inspect
 import logging
-from typing import Any
 
 import numpy as np
 import torch
@@ -14,10 +12,7 @@ from transformers import (
 )
 
 from src.di import module
-from src.image.base import ImageDataset
 from src.pipeline import base, images
-from src.source.base import SourceFactory
-from src.topic.base import TopicRegistry
 
 YOLO_MODEL_ID = "hustvl/yolos-tiny"
 DEPTH_MODEL_ID = "depth-anything/Depth-Anything-V2-Small-hf"
@@ -28,44 +23,32 @@ depth_processor = AutoImageProcessor.from_pretrained(DEPTH_MODEL_ID)
 depth_model = AutoModelForDepthEstimation.from_pretrained(DEPTH_MODEL_ID)
 
 
-class Gate(base.Gate):
-    """A gate that evaluates whether an object of certain labels is too close in images.
+class ObjectTooCloseGate(base.TopicImageMixin, base.Gate):
+    """Estimate depth on detected objects to determine whether they are too close.
 
-    It uses a pre-trained YOLO model for object detection and a depth estimation model to determine
-    the closeness of detected objects.
-
-    If any object in the lookback window matches the criteria, the gate evaluates to True.
+    The lookback window may include multiple images, each with several detected objects.
+    The gate returns True if any detected object is too close.
 
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
-        factory: SourceFactory,
-        registry: TopicRegistry,
-        dataset: ImageDataset,
         topic: str,
         labels: list[str] | None = None,
         probability: float = 0.5,
         closeness: float | None = None,
-        last: int | None = None,
-        unit: str | None = None,
     ) -> None:
-        """Initialize a gate for detecting if an object of certain labels is too close.
+        """Initialize the gate.
 
         Args:
-            factory (SourceFactory): A data source factory.
-            registry (TopicRegistry): A topic registry.
-            dataset (ImageDataset): An image dataset.
             topic (str): The image topic to evaluate.
             labels (list[str] | None, optional): The YOLO labels to detect, e.g., ["person", "car"].
                 If None, all available labels are used. Defaults to None.
             probability (float, optional): The minimum probability for a detection to be considered.
                 Must be between 0 and 1. Defaults to 0.5.
             closeness (float | None, optional): The closeness threshold. Must be between 0 and 1.
-                1 means very close, 0 means very far. If None, the median closeness of the depth map
-                is used. Defaults to None.
-            last (int | None, optional): Value of the lookback window. Defaults to None.
-            unit (str | None, optional): The unit of the lookback window. Defaults to None.
+                1 means very close, 0 means very far. If None, the median closeness of the
+                entire image is used. Defaults to None.
 
         Raises:
             ValueError: If the labels is an empty list.
@@ -74,11 +57,7 @@ class Gate(base.Gate):
             ValueError: If closeness is not between 0 and 1.
 
         """
-        self._factory = factory
-        self._registry = registry
-        self._dataset = dataset
         self._topic = topic
-        self._lookback = base.Lookback.build(last, unit)
 
         if labels is not None and not labels:
             raise ValueError("Labels list cannot be empty")
@@ -100,15 +79,15 @@ class Gate(base.Gate):
             raise ValueError("Closeness must be between 0 and 1")
         self._closeness = closeness
 
-    def evaluate(self, asof_seconds: float) -> bool:
-        """Evaluate if any object of the specified labels is too close at the given time."""
+    def evaluate(self, asof_seconds: float, lookback: base.Lookback | None) -> bool:
+        """Evaluate whether the gating criteria is met at the given time."""
         for _, _, image in images.to_images(
-            self._factory,
-            self._registry,
-            self._dataset,
-            [self._topic],
-            asof_seconds,
-            self._lookback,
+            factory=self.factory,
+            registry=self.registry,
+            dataset=self.dataset,
+            topics=[self._topic],
+            asof_seconds=asof_seconds,
+            lookback=lookback,
         ):
             # Object detection
             yolo_inputs = yolo_processor(images=image, return_tensors="pt")
@@ -151,28 +130,7 @@ class Gate(base.Gate):
 
         return False
 
-    @staticmethod
-    def build(args: dict[str, Any]) -> "Gate":
-        """Build a gate from configuration."""
-        factory = module.provide(args["factory"]["module"], args["factory"].get("args", {}))
-        registry = module.provide(args["registry"]["module"], args["registry"].get("args", {}))
-        dataset = module.provide(args["dataset"]["module"], args["dataset"].get("args", {}))
-        return Gate(
-            factory=factory,
-            registry=registry,
-            dataset=dataset,
-            topic=args["topic"],
-            labels=args.get("labels"),
-            probability=args.get(
-                "probability",
-                inspect.signature(Gate.__init__).parameters["probability"].default,
-            ),
-            closeness=args.get("closeness"),
-            last=args.get("last"),
-            unit=args.get("unit"),
-        )
-
 
 def register() -> None:
     """Register module for dependency injection."""
-    module.global_registry[__name__] = Gate
+    module.global_registry[__name__] = ObjectTooCloseGate

--- a/src/pipeline/gates/sql.py
+++ b/src/pipeline/gates/sql.py
@@ -1,89 +1,51 @@
-"""A gate that evaluates whether a SQL statement passes on messages."""
-
-from typing import Any
+"""Run a SQL query on topic messages at a given time to determine if gating criteria is met."""
 
 import duckdb
 
 from src.di import module
-from src.message.base import MessageDataset
 from src.pipeline import base, messages
-from src.source.base import SourceFactory
-from src.topic.base import TopicRegistry
 
 
-class Gate(base.Gate):
-    """A gate that evaluates whether a SQL statement passes on messages."""
+class SqlQueryGate(base.TopicMessageMixin, base.Gate):
+    """Run a SQL query on topic messages at a given time to determine if gating criteria is met."""
 
-    def __init__(  # noqa: PLR0913
-        self,
-        factory: SourceFactory,
-        registry: TopicRegistry,
-        dataset: MessageDataset,
-        topic: str,
-        statement: str,
-        last: int | None = None,
-        unit: str | None = None,
-    ) -> None:
-        """Initialize a SQL gate.
+    def __init__(self, topic: str, statement: str) -> None:
+        """Initialize the gate.
 
         Args:
-            factory (SourceFactory): A data source factory.
-            registry (TopicRegistry): A topic registry.
-            dataset (MessageDataset): A message dataset.
-            topic (str): The topic to evaluate.
-            statement (str): The SQL statement to evaluate. The statement **must** return a single
-                boolean value.
-            last (int | None, optional): Value of the lookback window. Defaults to None.
-            unit (str | None, optional): The unit of the lookback window. Defaults to None.
+            topic (str): The topic to run the SQL query on.
+            statement (str): The SQL query to execute. The `FROM` clause must refer to
+                the topic name as a table. It must return a **single** boolean value to
+                indicate whether the gating criteria is met.
 
         """
-        self._factory = factory
-        self._registry = registry
-        self._dataset = dataset
         self._topic = topic
         self._statement = statement
-        self._lookback = base.Lookback.build(last, unit)
 
-    def evaluate(self, asof_seconds: float) -> bool:
-        """Evaluate if the SQL statement is true at the given time."""
+    def evaluate(self, asof_seconds: float, lookback: base.Lookback | None) -> bool:
+        """Evaluate whether the gating criteria is met at the given time."""
         relation = messages.to_duckdb(
-            factory=self._factory,
-            registry=self._registry,
-            dataset=self._dataset,
+            factory=self.factory,
+            registry=self.registry,
+            dataset=self.dataset,
             topics=[self._topic],
             asof_seconds=asof_seconds,
-            lookback=self._lookback,
+            lookback=lookback,
         )
         duckdb.register(self._topic, relation)
         result = duckdb.sql(self._statement).fetchall()
         if len(result) != 1:
-            raise ValueError(f"SQL statement must return exactly one row, got {len(result)} rows")
+            raise ValueError(f"SQL query must return one row, got {len(result)} rows")
         elif len(result[0]) != 1:
             raise ValueError(
-                f"SQL statement must return exactly one row with one column, got {len(result[0])} columns"  # noqa: E501
+                f"SQL query must return one row with one column, got {len(result[0])} columns"
             )
         elif not isinstance(result[0][0], bool):
-            raise ValueError(f"SQL statement must return a boolean value, got {type(result[0][0])}")
+            raise ValueError(f"SQL query must return a boolean value, got {type(result[0][0])}")
         duckdb.unregister(self._topic)
-        return result[0][0]
-
-    @staticmethod
-    def build(args: dict[str, Any]) -> "Gate":
-        """Build a gate from configuration."""
-        factory = module.provide(args["factory"]["module"], args["factory"].get("args", {}))
-        registry = module.provide(args["registry"]["module"], args["registry"].get("args", {}))
-        dataset = module.provide(args["dataset"]["module"], args["dataset"].get("args", {}))
-        return Gate(
-            factory=factory,
-            registry=registry,
-            dataset=dataset,
-            topic=args["topic"],
-            statement=args["statement"],
-            last=args.get("last"),
-            unit=args.get("unit"),
-        )
+        return bool(result[0][0])
 
 
 def register() -> None:
     """Register module for dependency injection."""
-    module.global_registry[__name__] = Gate
+    module.global_registry[__name__] = SqlQueryGate

--- a/src/pipeline/images.py
+++ b/src/pipeline/images.py
@@ -28,8 +28,8 @@ def to_images(  # noqa: PLR0913
         start_seconds = asof_seconds - lookback.to_seconds()
 
     images = dataset.images(
-        factory,
-        registry,
+        factory=factory,
+        registry=registry,
         topics=topics,
         start_seconds=start_seconds,
         end_seconds=asof_seconds,

--- a/src/pipeline/tasks/generate_gif.py
+++ b/src/pipeline/tasks/generate_gif.py
@@ -1,48 +1,30 @@
-"""A task that generates GIF files from images in a topic over a lookback window."""
+"""Generate a GIF file from images in a topic."""
 
 import logging
 import pathlib
-from typing import Any
 
 from PIL import Image, ImageDraw, ImageFont
 
 from src.di import module
-from src.image.base import ImageDataset
 from src.pipeline import base, images
-from src.source.base import SourceFactory
-from src.topic.base import TopicRegistry
 
 
-class Task(base.Task):
-    """A task that generates GIF files from images in a topic over a lookback window."""
+class GenerateGifTask(base.TopicImageMixin, base.Task):
+    """Generate a GIF file from images in a topic."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
-        factory: SourceFactory,
-        registry: TopicRegistry,
-        dataset: ImageDataset,
         topic: str,
         output_directory: str,
-        last: int | None = None,
-        unit: str | None = None,
     ) -> None:
-        """Initialize the GIF generation task.
+        """Initialize the task.
 
         Args:
-            factory (SourceFactory): A data source factory.
-            registry (TopicRegistry): A topic registry.
-            dataset (ImageDataset): An image dataset.
-            topic (str): The image topic to generate GIFs from.
-            output_directory (str): The directory to save the generated GIFs.
-            last (int | None, optional): Value of the lookback window. Defaults to None.
-            unit (str | None, optional): The unit of the lookback window. Defaults to None.
+            topic (str): The image topic to generate a GIF file from.
+            output_directory (str): The directory to save the generated GIF file.
 
         """
-        self._factory = factory
-        self._registry = registry
-        self._dataset = dataset
         self._topic = topic
-        self._lookback = base.Lookback.build(last, unit)
         self._output_directory = pathlib.Path(output_directory)
 
         # Styling options for the text box below each image
@@ -51,8 +33,8 @@ class Task(base.Task):
         self._font = ImageFont.load_default()
         self._fill_text = (255, 255, 255, 255)
 
-    def execute(self, asof_seconds: float) -> None:
-        """Generate GIF files and save to the output directory."""
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
+        """Execute the task at the given time."""
 
         def _text_size(draw, text, font) -> tuple[int, int]:  # noqa: ANN001
             bbox = draw.textbbox((0, 0), text, font=font)
@@ -62,12 +44,12 @@ class Task(base.Task):
         first_timestamp_text, first_image = None, None
 
         for _, timestamp_seconds, image in images.to_images(
-            self._factory,
-            self._registry,
-            self._dataset,
-            [self._topic],
-            asof_seconds,
-            self._lookback,
+            factory=self.factory,
+            registry=self.registry,
+            dataset=self.dataset,
+            topics=[self._topic],
+            asof_seconds=asof_seconds,
+            lookback=lookback,
         ):
             timestamp_text = f"{timestamp_seconds:.8f}"
 
@@ -117,23 +99,7 @@ class Task(base.Task):
             )
             logging.info("Generated %s from %d frames", self._output_directory, len(frames))
 
-    @staticmethod
-    def build(args: dict[str, Any]) -> "Task":
-        """Build a task from configuration."""
-        factory = module.provide(args["factory"]["module"], args["factory"].get("args", {}))
-        registry = module.provide(args["registry"]["module"], args["registry"].get("args", {}))
-        dataset = module.provide(args["dataset"]["module"], args["dataset"].get("args", {}))
-        return Task(
-            factory=factory,
-            registry=registry,
-            dataset=dataset,
-            topic=args["topic"],
-            output_directory=args["output_directory"],
-            last=args.get("last"),
-            unit=args.get("unit"),
-        )
-
 
 def register() -> None:
     """Register module for dependency injection."""
-    module.global_registry[__name__] = Task
+    module.global_registry[__name__] = GenerateGifTask

--- a/src/pipeline/tasks/send_email.py
+++ b/src/pipeline/tasks/send_email.py
@@ -1,17 +1,16 @@
-"""A task that sends an email with a specified subject and body."""
+"""Send emails to specified recipients."""
 
 import logging
 import smtplib
 from email.message import EmailMessage
 from email.utils import formatdate
-from typing import Any
 
 from src.di import module
 from src.pipeline import base
 
 
 class Task(base.Task):
-    """A task that sends an email with a specified subject and body."""
+    """Send emails to specified recipients."""
 
     def __init__(  # noqa: PLR0913
         self,
@@ -23,7 +22,7 @@ class Task(base.Task):
         smtp_port: int,
         password: str,
     ) -> None:
-        """Initialize the email sending task.
+        """Initialize the task.
 
         Args:
             sender (str): The sender email address.
@@ -43,34 +42,22 @@ class Task(base.Task):
         self._smtp_port = smtp_port
         self._password = password
 
-    def execute(self, asof_seconds: float) -> None:
-        """Send an email with the specified subject and body."""
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        """Nothing to setup in this task."""
+
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
+        """Execute the task at the given time."""
         msg = EmailMessage()
         msg["From"] = self._sender
         msg["To"] = ", ".join(self._recipients)
         msg["Date"] = formatdate(localtime=True)
         msg["Subject"] = f"{self._subject} (asof_seconds={asof_seconds:.8f})"
         msg.set_content(self._body)
-
         with smtplib.SMTP(self._smtp_server, self._smtp_port) as server:
             server.starttls()
             server.login(self._sender, self._password)
             server.send_message(msg)
-
-        logging.info("Sent email to %s", self._recipients)
-
-    @staticmethod
-    def build(args: dict[str, Any]) -> "Task":
-        """Build a task from configuration."""
-        return Task(
-            sender=args["sender"],
-            recipients=args["recipients"],
-            subject=args["subject"],
-            body=args["body"],
-            smtp_server=args["smtp_server"],
-            smtp_port=args["smtp_port"],
-            password=args["password"],
-        )
+            logging.info("Sent email to %s", self._recipients)
 
 
 def register() -> None:

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -13,7 +13,7 @@ import yaml
 
 from settings import settings
 from src import artifacts
-from src.pipeline.base import AtTheEnd, Pipeline
+from src.pipeline.base import OnceAtEnd, Pipeline
 from src.sink.buffer import TopicBufferWriter
 
 # A global registry to hold singleton instances of TopicSink instances.
@@ -209,7 +209,7 @@ class TopicSink(abc.ABC):
             extract_timestamp=extract_timestamp,
         )
 
-        if overwrite:
+        if topic in self._buffers and overwrite:
             self._unsubscribe(self._buffers[topic])
 
         self._subscribe(self._buffers[topic])
@@ -250,44 +250,25 @@ class TopicSink(abc.ABC):
 
             while self._buffers:
                 topic, writer = self._buffers.popitem()
-                if writer.pipeline is not None and isinstance(writer.pipeline.cadence, AtTheEnd):
+                if writer.pipeline is not None and isinstance(
+                    writer.pipeline.cadence.when, OnceAtEnd
+                ):
                     if writer.last_timestamp_seconds is None:
                         logging.info(
-                            "No messages received on topic %s, skipping pipeline execution", topic
+                            "No messages received on topic '%s', skipping pipeline '%s'",
+                            topic,
+                            writer.pipeline.name,
                         )
-                        continue
                     elif writer.last_run_at == writer.last_timestamp_seconds:
                         logging.info(
                             "Pipeline '%s' already executed on topic '%s' at the end, skipping",
-                            writer.pipeline.name,
                             topic,
-                        )
-                        continue
-                try:
-                    if writer.pipeline.run(writer.last_timestamp_seconds):
-                        logging.info(
-                            "Pipeline '%s' executed successfully when topic '%s' received message at %.4f seconds",  # noqa: E501
                             writer.pipeline.name,
-                            topic,
-                            writer.last_timestamp_seconds,
                         )
                     else:
-                        logging.debug(
-                            "Pipeline '%s' didn't pass the gating criteria when topic '%s' received message at %.4f seconds",  # noqa: E501
-                            writer.pipeline.name,
-                            topic,
-                            writer.last_timestamp_seconds,
-                        )
-                except Exception as e:
-                    if not writer.pipeline.allow_failure:
-                        raise e
-                    logging.error(
-                        "Pipeline '%s' execution failed when topic '%s' received message at %.4f seconds: %s",  # noqa: E501
-                        writer.pipeline.name,
-                        topic,
-                        writer.last_timestamp_seconds,
-                        str(e),
-                    )
+                        writer.pipeline.run_at(writer.last_timestamp_seconds)
+                if writer.pipeline is not None:
+                    logging.info("Pipeline '%s' completed.", writer.pipeline.name)
 
     def __enter__(self) -> "TopicSink":  # noqa: D105
         return self

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for topic sinks."""
 
 import abc
+import logging
 import pathlib
 import uuid
 import weakref
@@ -12,7 +13,7 @@ import yaml
 
 from settings import settings
 from src import artifacts
-from src.pipeline.base import Pipeline
+from src.pipeline.base import AtTheEnd, Pipeline
 from src.sink.buffer import TopicBufferWriter
 
 # A global registry to hold singleton instances of TopicSink instances.
@@ -21,6 +22,10 @@ _global_sink_singletons: dict[tuple[str, int], "TopicSink"] = {}  # (host, port)
 
 class TopicNotFoundError(Exception):
     """Raised when topic is not found."""
+
+
+class TopicAlreadySubscribedError(Exception):
+    """Raised when topic is already subscribed."""
 
 
 class TopicSink(abc.ABC):
@@ -168,11 +173,14 @@ class TopicSink(abc.ABC):
     ) -> None:
         """Subscribe to a topic.
 
+        A topic can only be subscribed once, unless using `overwrite=True` to re-subscribe.
+
         Args:
             topic (str): The topic to subscribe to.
             pipeline (Pipeline | None, optional): An callback pipeline to execute on
                 incoming messages.
-            overwrite (bool, optional): If True, overwrite any existing topic buffers.
+            overwrite (bool, optional): If True, re-subscribe to the topic and overwrite any
+                existing topic buffers.
             buffer_size_bytes (int | None, optional): The maximum buffer size in bytes before
                 evicting old messages. If None, the buffer size is unbounded.
             extract_timestamp (Callable[[dict[str, Any]], float] | None, optional):
@@ -186,18 +194,24 @@ class TopicSink(abc.ABC):
         if topic not in self.available_topics:
             raise TopicNotFoundError(topic)
 
-        if topic not in self._buffers:
-            self._buffers[topic] = TopicBufferWriter(
-                self.directory,
-                topic,
-                self._type_name(topic),
-                self._definition(topic),
-                self._struct(topic),
-                buffer_size_bytes=buffer_size_bytes,
-                overwrite=overwrite,
-                pipeline=pipeline,
-                extract_timestamp=extract_timestamp,
-            )
+        if topic in self._buffers and not overwrite:
+            raise TopicAlreadySubscribedError(topic)
+
+        self._buffers[topic] = TopicBufferWriter(
+            self.directory,
+            topic,
+            self._type_name(topic),
+            self._definition(topic),
+            self._struct(topic),
+            buffer_size_bytes=buffer_size_bytes,
+            overwrite=overwrite,
+            pipeline=pipeline,
+            extract_timestamp=extract_timestamp,
+        )
+
+        if overwrite:
+            self._unsubscribe(self._buffers[topic])
+
         self._subscribe(self._buffers[topic])
 
     def pause(self, topics: list[str] | None = None) -> None:
@@ -222,7 +236,7 @@ class TopicSink(abc.ABC):
             self._unsubscribe(self._buffers[topic])
 
     def close(self) -> None:
-        """Disconnect and release all resources.
+        """Disconnect from the data stream, run any pending pipelines, and release all resources.
 
         Notes:
             After closing, the sink must not be reused.
@@ -233,6 +247,47 @@ class TopicSink(abc.ABC):
             self._disconnect()
         finally:
             del _global_sink_singletons[(self.host, self.port)]
+
+            while self._buffers:
+                topic, writer = self._buffers.popitem()
+                if writer.pipeline is not None and isinstance(writer.pipeline.cadence, AtTheEnd):
+                    if writer.last_timestamp_seconds is None:
+                        logging.info(
+                            "No messages received on topic %s, skipping pipeline execution", topic
+                        )
+                        continue
+                    elif writer.last_run_at == writer.last_timestamp_seconds:
+                        logging.info(
+                            "Pipeline '%s' already executed on topic '%s' at the end, skipping",
+                            writer.pipeline.name,
+                            topic,
+                        )
+                        continue
+                try:
+                    if writer.pipeline.run(writer.last_timestamp_seconds):
+                        logging.info(
+                            "Pipeline '%s' executed successfully when topic '%s' received message at %.4f seconds",  # noqa: E501
+                            writer.pipeline.name,
+                            topic,
+                            writer.last_timestamp_seconds,
+                        )
+                    else:
+                        logging.debug(
+                            "Pipeline '%s' didn't pass the gating criteria when topic '%s' received message at %.4f seconds",  # noqa: E501
+                            writer.pipeline.name,
+                            topic,
+                            writer.last_timestamp_seconds,
+                        )
+                except Exception as e:
+                    if not writer.pipeline.allow_failure:
+                        raise e
+                    logging.error(
+                        "Pipeline '%s' execution failed when topic '%s' received message at %.4f seconds: %s",  # noqa: E501
+                        writer.pipeline.name,
+                        topic,
+                        writer.last_timestamp_seconds,
+                        str(e),
+                    )
 
     def __enter__(self) -> "TopicSink":  # noqa: D105
         return self

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -1,7 +1,6 @@
 """File-backed topic buffer writer and reader."""
 
 import json
-import logging
 import pathlib
 import pickle
 import shutil
@@ -183,33 +182,8 @@ class TopicBufferWriter:
         if self.pipeline and self._should_run(
             self.pipeline.cadence, self.message_count, self.last_run_at, timestamp_seconds
         ):
-            try:
-                if self.pipeline.run(timestamp_seconds):
-                    logging.info(
-                        "Pipeline '%s' executed successfully when topic '%s' received message at %.4f seconds",  # noqa: E501
-                        self.pipeline.name,
-                        self.topic,
-                        timestamp_seconds,
-                    )
-                else:
-                    logging.debug(
-                        "Pipeline '%s' didn't pass the gating criteria when topic '%s' received message at %.4f seconds",  # noqa: E501
-                        self.pipeline.name,
-                        self.topic,
-                        timestamp_seconds,
-                    )
-            except Exception as e:
-                if not self.pipeline.allow_failure:
-                    raise e
-                logging.error(
-                    "Pipeline '%s' execution failed when topic '%s' received message at %.4f seconds: %s",  # noqa: E501
-                    self.pipeline.name,
-                    self.topic,
-                    timestamp_seconds,
-                    str(e),
-                )
-            finally:
-                self._last_run_at = timestamp_seconds
+            self.pipeline.run_at(timestamp_seconds)
+            self._last_run_at = timestamp_seconds
 
         self._message_count += 1
         self._last_timestamp_seconds = timestamp_seconds
@@ -220,12 +194,12 @@ class TopicBufferWriter:
         if last_run_at is None:
             return True
 
-        if isinstance(cadence, Frequency):
-            match cadence.unit:
+        if isinstance(cadence.when, Frequency):
+            match cadence.when.unit:
                 case Unit.FRAME:
-                    return message_count % cadence.every == 0
+                    return message_count % cadence.when.every == 0
                 case _:
-                    return asof_seconds - last_run_at >= cadence.to_seconds()
+                    return asof_seconds - last_run_at >= cadence.when.to_seconds()
 
         return False
 

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -16,7 +16,7 @@ import pyarrow as pa
 import yaml
 
 from settings import settings
-from src.pipeline.base import Pipeline, Unit
+from src.pipeline.base import Cadence, Frequency, Pipeline, Unit
 
 
 def _topic_uuid(topic: str) -> str:
@@ -122,11 +122,40 @@ class TopicBufferWriter:
         self._pipeline = pipeline
         self._message_count = 0
         self._last_run_at = None
+        self._last_timestamp_seconds = None
 
     @property
     def topic(self) -> str:
         """Topic name for the messages held by this buffer."""
         return self._topic
+
+    @property
+    def pipeline(self) -> Pipeline | None:
+        """The callback pipeline associated with this buffer, if any."""
+        return self._pipeline
+
+    @property
+    def last_run_at(self) -> float | None:
+        """The last time the pipeline was run, in seconds.
+
+        If None, the pipeline has never been run.
+
+        """
+        return self._last_run_at
+
+    @property
+    def message_count(self) -> int:
+        """The total number of messages observed by this buffer."""
+        return self._message_count
+
+    @property
+    def last_timestamp_seconds(self) -> float | None:
+        """The timestamp in seconds extracted from the last message.
+
+        If None, no messages have been received yet.
+
+        """
+        return self._last_timestamp_seconds
 
     def append(self, msg: dict[str, Any]) -> None:
         """Append a message to the buffer."""
@@ -151,42 +180,52 @@ class TopicBufferWriter:
             with open(self._current_data_file, "a", encoding="utf-8") as f:
                 f.write(line)
 
-        if self._pipeline and self._should_run(
-            self._pipeline, self._last_run_at, self._message_count, timestamp_seconds
+        if self.pipeline and self._should_run(
+            self.pipeline.cadence, self.message_count, self.last_run_at, timestamp_seconds
         ):
             try:
-                if self._pipeline.run(timestamp_seconds):
+                if self.pipeline.run(timestamp_seconds):
                     logging.info(
-                        "Pipeline executed at %.4f seconds (%d messages processed in total)",
+                        "Pipeline '%s' executed successfully when topic '%s' received message at %.4f seconds",  # noqa: E501
+                        self.pipeline.name,
+                        self.topic,
                         timestamp_seconds,
-                        self._message_count,
                     )
                 else:
-                    logging.info(
-                        "Pipeline skipped at %.4f seconds (%d messages processed in total)",
+                    logging.debug(
+                        "Pipeline '%s' didn't pass the gating criteria when topic '%s' received message at %.4f seconds",  # noqa: E501
+                        self.pipeline.name,
+                        self.topic,
                         timestamp_seconds,
-                        self._message_count,
                     )
             except Exception as e:
-                if not self._pipeline.allow_failure:
+                if not self.pipeline.allow_failure:
                     raise e
-                logging.error(f"Pipeline execution failed: {e}")
+                logging.error(
+                    "Pipeline '%s' execution failed when topic '%s' received message at %.4f seconds: %s",  # noqa: E501
+                    self.pipeline.name,
+                    self.topic,
+                    timestamp_seconds,
+                    str(e),
+                )
             finally:
                 self._last_run_at = timestamp_seconds
 
         self._message_count += 1
+        self._last_timestamp_seconds = timestamp_seconds
 
     def _should_run(
-        self, pipeline: Pipeline, last_run_at: float | None, message_count: int, asof_seconds: float
+        self, cadence: Cadence, message_count: int, last_run_at: float | None, asof_seconds: float
     ) -> bool:
         if last_run_at is None:
             return True
 
-        match pipeline.frequency.unit:
-            case Unit.FRAME:
-                return message_count % pipeline.frequency.every == 0
-            case _:
-                return asof_seconds - last_run_at >= pipeline.frequency.to_seconds()
+        if isinstance(cadence, Frequency):
+            match cadence.unit:
+                case Unit.FRAME:
+                    return message_count % cadence.every == 0
+                case _:
+                    return asof_seconds - last_run_at >= cadence.to_seconds()
 
         return False
 

--- a/src/sink/ros1/bridge.py
+++ b/src/sink/ros1/bridge.py
@@ -1,11 +1,14 @@
 """Provide a topic sink that connects to ROS1 through a rosbridge server."""
 
+from typing import Any
+
 import pyarrow as pa
 import roslibpy
 from roslibpy import ros
 
 from settings import settings
 from src.di import module
+from src.di.types.base_module import BaseModule
 from src.sink import base, buffer
 from src.topic.ros1 import parse, schema
 
@@ -68,6 +71,14 @@ class TopicSink(base.TopicSink):
         }
         self._subscribers: dict[str, roslibpy.Topic] = {}
 
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Metadata about the topic sink."""
+        return {
+            **super().metadata,
+            "image_dataset_module": f"{BaseModule.IMAGE_DATASET.value}.ros1.sink",
+        }
+
     def _connect(self) -> None:
         self._client.run()
 
@@ -99,7 +110,9 @@ class TopicSink(base.TopicSink):
         self._subscribers[writer.topic].subscribe(callback=writer.append)
 
     def _unsubscribe(self, writer: buffer.TopicBufferWriter) -> None:
-        self._subscribers[writer.topic].unsubscribe()
+        if writer.topic in self._subscribers:
+            self._subscribers[writer.topic].unsubscribe()
+            del self._subscribers[writer.topic]
 
 
 def register() -> None:

--- a/src/sink/ros2/bridge.py
+++ b/src/sink/ros2/bridge.py
@@ -1,11 +1,14 @@
 """Provide a topic sink that connects to ROS2 through a rosbridge server."""
 
+from typing import Any
+
 import pyarrow as pa
 import roslibpy
 from roslibpy import ros
 
 from settings import settings
 from src.di import module
+from src.di.types.base_module import BaseModule
 from src.sink import base, buffer
 from src.topic.ros2.ros2msg import parse, schema
 
@@ -68,6 +71,14 @@ class TopicSink(base.TopicSink):
         }
         self._subscribers: dict[str, roslibpy.Topic] = {}
 
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Metadata about the topic sink."""
+        return {
+            **super().metadata,
+            "image_dataset_module": f"{BaseModule.IMAGE_DATASET.value}.ros2.sink",
+        }
+
     def _connect(self) -> None:
         self._client.run()
 
@@ -99,7 +110,9 @@ class TopicSink(base.TopicSink):
         self._subscribers[writer.topic].subscribe(callback=writer.append)
 
     def _unsubscribe(self, writer: buffer.TopicBufferWriter) -> None:
-        self._subscribers[writer.topic].unsubscribe()
+        if writer.topic in self._subscribers:
+            self._subscribers[writer.topic].unsubscribe()
+            del self._subscribers[writer.topic]
 
 
 def register() -> None:


### PR DESCRIPTION
We supported running pipeline on live rosbridge data streams. This PR added support for a bounded log like ROS1 bags.

- Added support for `Pipeline` class to run on file-based data source
- Refined YAML definition schema for pipelines. No need to specify factory, registry and dataset modules.
- Supported `OnceAtEnd` cadence type in addition to running pipeline at the fixed interval
- Only allowed one pipeline subscription per topic in the `TopicSink`