### PR TITLE
Add S3 data uploader task and artifact mix-in

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -117,8 +117,29 @@ which calls `run_pipeline_batch(config, ["./logs/*"])` and returns a summary:
 { "sources": 42, "completed": 40, "failed": 2, "artifacts": 40, "results": [ ... ] }
 ```
 
-The base config's `path` is ignored — it is overridden per source. Pair this with a data
-uploader to push the reduced bags to cloud storage.
+The base config's `path` is ignored — it is overridden per source. Pair this with the
+upload task below to push the reduced bags to cloud storage.
+
+## Upload the reduced data to S3
+
+Add an upload task to the pipeline (or run one afterwards) to push artifacts to S3 or
+any S3-compatible store (MinIO, Cloudflare R2, ...) via `endpoint_url`. Files whose
+SHA-256 already matches the remote object are skipped, so re-runs are cheap:
+
+```yaml
+tasks:
+  - module: src.pipeline.tasks.reduce.ros2.mcap
+    args: { event_topic: /imu, predicate: "...", pre_seconds: 10, post_seconds: 10 }
+  - module: src.pipeline.tasks.upload.s3
+    args:
+      bucket: drone-fleet-reduced
+      source: ~/.bagel/artifacts        # file, directory, or glob
+      prefix: "2026/week-27"
+      filter_modified_at: true          # only files modified within the lookback window
+    lookback: { last: 1, unit: hour }
+```
+
+Credentials use the standard AWS resolution chain (env vars, `~/.aws`, instance role).
 
 ## Verify the mechanism without ROS
 

--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -320,6 +320,43 @@ class Task(Operator):
         """
 
 
+class ArtifactMixin:
+    """Mixin for tasks that create artifacts, providing the canonical artifact path.
+
+    Guarantees a consistent naming convention across tasks: every artifact lands under
+    ``pipeline=<name>/task=<name>/datestr=<date>/site=<site>/asset=<asset>/log_id=<id>/``
+    in the artifact directory. Expects to be mixed into an `Operator` subclass (it uses
+    the operator's `pipeline`, `name`, `site`, `asset`, and `log_id` attributes).
+    """
+
+    def artifact_path(self, asof_seconds: float, extension: str | None = None) -> pathlib.Path:
+        """Return the canonical artifact path for this task at the given timestamp.
+
+        The parent directory is created if it does not exist, so the caller can write
+        to the returned path directly.
+
+        Args:
+            asof_seconds (float): The timestamp (in seconds) the artifact corresponds to.
+            extension (str | None, optional): The file extension (e.g. ".csv"). If None,
+                the path has no extension -- used for directory artifacts such as bags.
+
+        Returns:
+            pathlib.Path: The artifact path, with its parent directory created.
+
+        """
+        path = artifacts.pipeline_task_artifact_path(
+            self.pipeline,
+            self.name,
+            self.site,
+            self.asset,
+            self.log_id,
+            asof_seconds,
+            extension,
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+
 class Pipeline:
     """A data processing pipeline consisting of gates and tasks.
 

--- a/src/pipeline/tasks/generate_gif.py
+++ b/src/pipeline/tasks/generate_gif.py
@@ -5,12 +5,11 @@ import pathlib
 
 from PIL import Image, ImageDraw, ImageFont
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, images
 
 
-class GenerateGif(images.TopicImageMixin, base.Task):
+class GenerateGif(base.ArtifactMixin, images.TopicImageMixin, base.Task):
     """Generate a GIF file from images in a topic."""
 
     def __init__(self, topic: str) -> None:
@@ -72,16 +71,7 @@ class GenerateGif(images.TopicImageMixin, base.Task):
             first_image = first_image or annotated
 
         if frames and first_image:
-            gif_file = artifacts.pipeline_task_artifact_path(
-                self.pipeline,
-                self.name,
-                self.site,
-                self.asset,
-                self.log_id,
-                asof_seconds,
-                ".gif",
-            )
-            gif_file.parent.mkdir(parents=True, exist_ok=True)
+            gif_file = self.artifact_path(asof_seconds, ".gif")
             first_image.save(
                 gif_file,
                 save_all=True,

--- a/src/pipeline/tasks/reduce/ros2/db3.py
+++ b/src/pipeline/tasks/reduce/ros2/db3.py
@@ -6,7 +6,6 @@ import pathlib
 import rosbag2_py
 from rclpy.serialization import serialize_message
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 from src.pipeline.tasks.reduce.base import ReduceMixin
@@ -17,7 +16,7 @@ MILLISECOND = 1_000 * MICROSECOND
 SECOND = 1_000 * MILLISECOND
 
 
-class ReduceRosbag(ReduceMixin, messages.TopicMessageMixin, base.Task):
+class ReduceRosbag(base.ArtifactMixin, ReduceMixin, messages.TopicMessageMixin, base.Task):
     """Reduce a ROS2 DB3 bag to only the windows around events matching a predicate.
 
     Unlike the ``snippet`` task -- which fires once per event and writes one clip per
@@ -91,16 +90,7 @@ class ReduceRosbag(ReduceMixin, messages.TopicMessageMixin, base.Task):
             self._event_topic,
         )
 
-        bag_directory = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            None,
-        )
-        bag_directory.parent.mkdir(parents=True, exist_ok=True)
+        bag_directory = self.artifact_path(asof_seconds)
 
         storage_options = rosbag2_py.StorageOptions(
             uri=str(bag_directory), storage_id=self._output_storage_id

--- a/src/pipeline/tasks/reduce/ros2/mcap.py
+++ b/src/pipeline/tasks/reduce/ros2/mcap.py
@@ -12,7 +12,6 @@ import pathlib
 from mcap.reader import make_reader
 from mcap.writer import Writer
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 from src.pipeline.tasks.reduce.base import ReduceMixin
@@ -28,7 +27,7 @@ def _in_intervals(log_time_ns: int, intervals_ns: list[tuple[int, int]]) -> bool
     return any(start <= log_time_ns <= end for start, end in intervals_ns)
 
 
-class ReduceMcap(ReduceMixin, messages.TopicMessageMixin, base.Task):
+class ReduceMcap(base.ArtifactMixin, ReduceMixin, messages.TopicMessageMixin, base.Task):
     """Reduce a ROS2 MCAP bag to only the windows around events matching a predicate.
 
     Like the db3 reduce task, but writes a single reduced ``.mcap`` file by copying raw
@@ -91,16 +90,7 @@ class ReduceMcap(ReduceMixin, messages.TopicMessageMixin, base.Task):
         data_source = self.factory.build()
         keep_topics = set(self._topics) if self._topics else None
 
-        output_file = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            ".mcap",
-        )
-        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file = self.artifact_path(asof_seconds, ".mcap")
 
         with open(output_file, "wb") as output_stream:
             writer = Writer(output_stream)

--- a/src/pipeline/tasks/snippet/ros1/bag.py
+++ b/src/pipeline/tasks/snippet/ros1/bag.py
@@ -6,12 +6,11 @@ import pathlib
 import shlex
 import subprocess
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 
 
-class SnipRosbag(messages.TopicMessageMixin, base.Task):
+class SnipRosbag(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
     """Create a new ROS1 bag snippet using the `rosbag filter` CLI tool."""
 
     def __init__(
@@ -75,16 +74,7 @@ class SnipRosbag(messages.TopicMessageMixin, base.Task):
                 end_seconds = asof_seconds + self._post_seconds
                 conditions.append(f"t.to_sec() <= {end_seconds}")
 
-        output_file = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            ".bag",
-        )
-        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file = self.artifact_path(asof_seconds, ".bag")
 
         command = [
             "rosbag",

--- a/src/pipeline/tasks/snippet/ros2/db3.py
+++ b/src/pipeline/tasks/snippet/ros2/db3.py
@@ -7,7 +7,6 @@ from collections import deque
 import rosbag2_py
 from rclpy.serialization import serialize_message
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 
@@ -17,7 +16,7 @@ MILLISECOND = 1_000 * MICROSECOND
 SECOND = 1_000 * MILLISECOND
 
 
-class SnipRosbag(messages.TopicMessageMixin, base.Task):
+class SnipRosbag(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
     """Create a new ROS2 DB3 bag snippet."""
 
     def __init__(
@@ -72,16 +71,7 @@ class SnipRosbag(messages.TopicMessageMixin, base.Task):
             case _:
                 messages = self.dataset._messages(data_source, topics, None, end_seconds)
 
-        bag_directory = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            None,
-        )
-        bag_directory.parent.mkdir(parents=True, exist_ok=True)
+        bag_directory = self.artifact_path(asof_seconds)
 
         storage_options = rosbag2_py.StorageOptions(
             uri=str(bag_directory), storage_id=self._output_storage_id

--- a/src/pipeline/tasks/topic_sql.py
+++ b/src/pipeline/tasks/topic_sql.py
@@ -6,7 +6,6 @@ from enum import Enum
 
 import duckdb
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 
@@ -18,7 +17,7 @@ class OutputFormat(Enum):
     PARQUET = "parquet"
 
 
-class TopicSqlQuery(messages.TopicMessageMixin, base.Task):
+class TopicSqlQuery(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
     """Run a SQL query on messages from a topic and write the result to a file."""
 
     def __init__(
@@ -48,16 +47,7 @@ class TopicSqlQuery(messages.TopicMessageMixin, base.Task):
         duckdb.register(self._topic, relation)
         result = duckdb.sql(self._statement)
 
-        output_file = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            f".{self._output_format.value}",
-        )
-        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file = self.artifact_path(asof_seconds, f".{self._output_format.value}")
 
         match self._output_format:
             case OutputFormat.CSV:

--- a/src/pipeline/tasks/upload/s3.py
+++ b/src/pipeline/tasks/upload/s3.py
@@ -1,0 +1,184 @@
+"""Upload local files to an S3 (or S3-compatible) bucket."""
+
+import glob
+import logging
+import pathlib
+
+import boto3
+import botocore
+
+from src import artifacts
+from src.di import module
+from src.pipeline import base
+
+_GLOB_CHARS = "*?["
+
+
+def _glob_root(pattern: str) -> pathlib.Path:
+    """Return the leading non-wildcard directory of a glob pattern.
+
+    Used as the base against which matched files are relativized, so a pattern like
+    ``logs/2026/*/imu.mcap`` produces keys relative to ``logs/2026``.
+    """
+    root_parts = []
+    for part in pathlib.PurePath(pattern).parts:
+        if any(char in part for char in _GLOB_CHARS):
+            break
+        root_parts.append(part)
+    return pathlib.Path(*root_parts) if root_parts else pathlib.Path(".")
+
+
+class UploadFilesToS3(base.Task):
+    """Upload local files to an S3 (or S3-compatible) bucket.
+
+    The `source` may be a single file, a directory (uploaded recursively), or a glob
+    pattern. Object keys preserve the file structure relative to the source root, under
+    an optional key `prefix`. Files whose SHA-256 checksum already matches the remote
+    object are skipped, so re-running a pipeline does not re-upload unchanged artifacts.
+
+    Works with any S3-compatible store (MinIO, Cloudflare R2, GCS interop, ...) via
+    `endpoint_url`.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        bucket: str,
+        source: str,
+        prefix: str = "",
+        region: str | None = None,
+        endpoint_url: str | None = None,
+        filter_modified_at: bool = False,
+        skip_existing: bool = True,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            bucket (str): The destination bucket name.
+            source (str): A file path, directory (uploaded recursively), or glob pattern
+                selecting the local files to upload.
+            prefix (str, optional): Key prefix under which objects are stored.
+                Defaults to "" (bucket root).
+            region (str | None, optional): The bucket region. If None, the default
+                region resolution applies. Defaults to None.
+            endpoint_url (str | None, optional): Endpoint for S3-compatible stores
+                (e.g. MinIO). If None, AWS S3 is used. Defaults to None.
+            filter_modified_at (bool, optional): If True, only upload files whose
+                modified time falls within `[asof_seconds - lookback, asof_seconds]`
+                when the task executes -- so a pipeline cadence uploads only new files.
+                Defaults to False.
+            skip_existing (bool, optional): If True, skip files whose SHA-256 checksum
+                matches the existing remote object. Defaults to True.
+
+        Raises:
+            ValueError: If 'bucket' or 'source' is empty.
+
+        """
+        if not bucket:
+            raise ValueError("'bucket' must not be empty.")
+        if not source:
+            raise ValueError("'source' must not be empty.")
+        self._bucket = bucket
+        self._source = source
+        self._prefix = prefix.strip("/")
+        self._region = region
+        self._endpoint_url = endpoint_url
+        self._filter_modified_at = filter_modified_at
+        self._skip_existing = skip_existing
+
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        """Nothing to set up in this task."""
+
+    def _source_files(self) -> list[tuple[pathlib.Path, str]]:
+        """Resolve the source into (local file, object key) pairs."""
+        source = pathlib.Path(self._source)
+
+        if source.is_file():
+            pairs = [(source, source.name)]
+        elif source.is_dir():
+            pairs = [
+                (file, file.relative_to(source).as_posix())
+                for file in sorted(source.rglob("*"))
+                if file.is_file()
+            ]
+        else:
+            root = _glob_root(self._source)
+            pairs = [
+                (match, match.relative_to(root).as_posix())
+                for match in sorted(
+                    pathlib.Path(p) for p in glob.glob(self._source, recursive=True)
+                )
+                if match.is_file()
+            ]
+
+        if self._prefix:
+            pairs = [(file, f"{self._prefix}/{key}") for file, key in pairs]
+        return pairs
+
+    def _remote_matches(self, s3_client: object, key: str, local_sha256: str) -> bool:
+        """Return True if the remote object exists with the same SHA-256 checksum."""
+        try:
+            response = s3_client.get_object_attributes(
+                Bucket=self._bucket, Key=key, ObjectAttributes=["Checksum"]
+            )
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NotFound"):
+                return False
+            raise
+        return response.get("Checksum", {}).get("ChecksumSHA256") == local_sha256
+
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
+        """Execute the task at the given time."""
+        start_seconds = None
+        if self._filter_modified_at:
+            match lookback:
+                case base.Lookback(unit=base.Unit.FRAME):
+                    raise ValueError(f"Does not support lookback with FRAME unit: {lookback}")
+                case base.Lookback():
+                    start_seconds = asof_seconds - lookback.to_seconds()
+                case None:
+                    start_seconds = None
+        else:
+            logging.debug(
+                "'asof_seconds' and 'lookback' are ignored since 'filter_modified_at' is False"
+            )
+
+        s3_client = boto3.client(
+            "s3", region_name=self._region, endpoint_url=self._endpoint_url
+        )
+
+        uploaded, skipped = 0, 0
+        for local_file, key in self._source_files():
+            if self._filter_modified_at:
+                modified_at = local_file.stat().st_mtime
+                if start_seconds is not None and modified_at < start_seconds:
+                    continue
+                if modified_at > asof_seconds:
+                    continue
+
+            local_sha256 = artifacts.checksum_sha256(local_file)
+            if self._skip_existing and self._remote_matches(s3_client, key, local_sha256):
+                logging.info("'%s' already exists with matching SHA-256, skipping", key)
+                skipped += 1
+                continue
+
+            s3_client.upload_file(
+                Filename=str(local_file),
+                Bucket=self._bucket,
+                Key=key,
+                ExtraArgs={"ChecksumAlgorithm": "SHA256"},
+            )
+            logging.info("Uploaded s3://%s/%s", self._bucket, key)
+            uploaded += 1
+
+        logging.info(
+            "Upload complete: %d uploaded, %d skipped to s3://%s/%s",
+            uploaded,
+            skipped,
+            self._bucket,
+            self._prefix,
+        )
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = UploadFilesToS3

--- a/src/pipeline/tasks/write_topics_to_file.py
+++ b/src/pipeline/tasks/write_topics_to_file.py
@@ -4,7 +4,6 @@ import logging
 import pathlib
 from enum import Enum
 
-from src import artifacts
 from src.di import module
 from src.pipeline import base, messages
 
@@ -16,7 +15,7 @@ class OutputFormat(Enum):
     PARQUET = "parquet"
 
 
-class WriteTopicsToFile(messages.TopicMessageMixin, base.Task):
+class WriteTopicsToFile(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
     """Write messages from specified topics to a file in various formats."""
 
     def __init__(
@@ -50,16 +49,7 @@ class WriteTopicsToFile(messages.TopicMessageMixin, base.Task):
             topics=topics, asof_seconds=asof_seconds, lookback=lookback, ffill=self._ffill
         )
 
-        output_file = artifacts.pipeline_task_artifact_path(
-            self.pipeline,
-            self.name,
-            self.site,
-            self.asset,
-            self.log_id,
-            asof_seconds,
-            f".{self._output_format.value}",
-        )
-        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file = self.artifact_path(asof_seconds, f".{self._output_format.value}")
 
         match self._output_format:
             case OutputFormat.CSV:

--- a/test/pipeline/test_artifact_mixin.py
+++ b/test/pipeline/test_artifact_mixin.py
@@ -1,0 +1,63 @@
+"""Tests for the ArtifactMixin canonical artifact path."""
+
+import pathlib
+
+import pytest
+
+from settings import settings
+from src import artifacts
+from src.pipeline import base
+
+
+class _DummyTask(base.ArtifactMixin, base.Task):
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        pass
+
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
+        pass
+
+
+def _task() -> _DummyTask:
+    task = _DummyTask()
+    task._pipeline = "my_pipeline"
+    task._name = "my_task"
+    task._site = "warehouse"
+    task._asset = "forklift"
+    task._log_id = "log-123"
+    return task
+
+
+def test_artifact_path_matches_canonical_convention(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path))
+    task = _task()
+    path = task.artifact_path(42.5, ".csv")
+    expected = artifacts.pipeline_task_artifact_path(
+        "my_pipeline", "my_task", "warehouse", "forklift", "log-123", 42.5, ".csv"
+    )
+    assert path == expected
+    assert "pipeline=my_pipeline" in str(path)
+    assert "task=my_task" in str(path)
+    assert path.suffix == ".csv"
+
+
+def test_artifact_path_creates_parent_directory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path))
+    path = _task().artifact_path(1.0, ".gif")
+    assert path.parent.is_dir()
+    assert not path.exists()  # only the parent is created; the task writes the file
+
+
+def test_artifact_path_without_extension_for_directory_artifacts(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path))
+    path = _task().artifact_path(1.0)
+    expected = artifacts.pipeline_task_artifact_path(
+        "my_pipeline", "my_task", "warehouse", "forklift", "log-123", 1.0, None
+    )
+    assert path == expected
+    assert path.name == "1.0"  # bare timestamp, no appended extension

--- a/test/pipeline/test_upload_s3.py
+++ b/test/pipeline/test_upload_s3.py
@@ -1,0 +1,156 @@
+"""Tests for the S3 upload task, using a mocked boto3 client."""
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import botocore.exceptions
+import pytest
+
+from src.pipeline import base
+from src.pipeline.tasks.upload.s3 import UploadFilesToS3, _glob_root
+
+NO_SUCH_KEY = botocore.exceptions.ClientError(
+    {"Error": {"Code": "NoSuchKey"}}, "GetObjectAttributes"
+)
+
+
+def _client(remote_checksum: str | None = None) -> MagicMock:
+    """A fake S3 client: object missing by default, or present with a checksum."""
+    client = MagicMock()
+    if remote_checksum is None:
+        client.get_object_attributes.side_effect = NO_SUCH_KEY
+    else:
+        client.get_object_attributes.return_value = {
+            "Checksum": {"ChecksumSHA256": remote_checksum}
+        }
+    return client
+
+
+def _uploaded_keys(client: MagicMock) -> list[str]:
+    return [call.kwargs["Key"] for call in client.upload_file.call_args_list]
+
+
+def _run(task: UploadFilesToS3, client: MagicMock, asof: float = 1e12) -> None:
+    with patch("src.pipeline.tasks.upload.s3.boto3.client", return_value=client):
+        task.execute(asof_seconds=asof, lookback=None)
+
+
+def test_glob_root_stops_at_first_wildcard() -> None:
+    assert _glob_root("logs/2026/*/imu.mcap") == pathlib.Path("logs/2026")
+    assert _glob_root("*.csv") == pathlib.Path(".")
+
+
+def test_directory_source_preserves_structure_under_prefix(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.csv").write_text("a")
+    (tmp_path / "sub" / "b.csv").write_text("b")
+
+    client = _client()
+    _run(UploadFilesToS3(bucket="bkt", source=str(tmp_path), prefix="fleet/run1"), client)
+
+    assert _uploaded_keys(client) == ["fleet/run1/a.csv", "fleet/run1/sub/b.csv"]
+    assert all(call.kwargs["Bucket"] == "bkt" for call in client.upload_file.call_args_list)
+
+
+def test_single_file_source_uses_basename(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "reduced.mcap"
+    source.write_text("x")
+
+    client = _client()
+    _run(UploadFilesToS3(bucket="bkt", source=str(source)), client)
+
+    assert _uploaded_keys(client) == ["reduced.mcap"]
+
+
+def test_glob_source_relativizes_to_pattern_root(tmp_path: pathlib.Path) -> None:
+    for run in ("run1", "run2"):
+        (tmp_path / run).mkdir()
+        (tmp_path / run / "out.csv").write_text(run)
+    (tmp_path / "run1" / "ignored.txt").write_text("no")
+
+    client = _client()
+    _run(UploadFilesToS3(bucket="bkt", source=str(tmp_path / "*" / "*.csv")), client)
+
+    assert _uploaded_keys(client) == ["run1/out.csv", "run2/out.csv"]
+
+
+def test_skip_existing_with_matching_checksum(tmp_path: pathlib.Path) -> None:
+    from src.artifacts import checksum_sha256
+
+    source = tmp_path / "same.bin"
+    source.write_bytes(b"identical")
+
+    client = _client(remote_checksum=checksum_sha256(source))
+    _run(UploadFilesToS3(bucket="bkt", source=str(source)), client)
+
+    client.upload_file.assert_not_called()
+
+
+def test_uploads_when_remote_checksum_differs(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "changed.bin"
+    source.write_bytes(b"new content")
+
+    client = _client(remote_checksum="c29tZXRoaW5nIGVsc2U=")
+    _run(UploadFilesToS3(bucket="bkt", source=str(source)), client)
+
+    assert _uploaded_keys(client) == ["changed.bin"]
+
+
+def test_skip_existing_disabled_never_checks_remote(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "always.bin"
+    source.write_bytes(b"x")
+
+    client = _client()
+    _run(UploadFilesToS3(bucket="bkt", source=str(source), skip_existing=False), client)
+
+    client.get_object_attributes.assert_not_called()
+    assert _uploaded_keys(client) == ["always.bin"]
+
+
+def test_filter_modified_at_uploads_only_files_in_window(tmp_path: pathlib.Path) -> None:
+    import os
+
+    fresh = tmp_path / "fresh.csv"
+    stale = tmp_path / "stale.csv"
+    fresh.write_text("f")
+    stale.write_text("s")
+    os.utime(fresh, (1000.0, 1000.0))
+    os.utime(stale, (100.0, 100.0))
+
+    task = UploadFilesToS3(bucket="bkt", source=str(tmp_path), filter_modified_at=True)
+    client = _client()
+    with patch("src.pipeline.tasks.upload.s3.boto3.client", return_value=client):
+        task.execute(
+            asof_seconds=1000.0, lookback=base.Lookback(last=60, unit=base.Unit.SECOND)
+        )
+
+    assert _uploaded_keys(client) == ["fresh.csv"]
+
+
+def test_frame_lookback_rejected_with_filter(tmp_path: pathlib.Path) -> None:
+    task = UploadFilesToS3(bucket="bkt", source=str(tmp_path), filter_modified_at=True)
+    with (
+        patch("src.pipeline.tasks.upload.s3.boto3.client", return_value=_client()),
+        pytest.raises(ValueError, match="FRAME"),
+    ):
+        task.execute(asof_seconds=1.0, lookback=base.Lookback(last=5, unit=base.Unit.FRAME))
+
+
+def test_empty_bucket_or_source_rejected() -> None:
+    with pytest.raises(ValueError, match="bucket"):
+        UploadFilesToS3(bucket="", source="x")
+    with pytest.raises(ValueError, match="source"):
+        UploadFilesToS3(bucket="b", source="")
+
+
+def test_registry_discovers_upload_task() -> None:
+    from src.pipeline import capabilities
+
+    entries = capabilities.list_capabilities()
+    upload = next(
+        (e for e in entries if e["module"] == "src.pipeline.tasks.upload.s3"), None
+    )
+    assert upload is not None
+    assert upload["kind"] == "task"
+    param_names = {p["name"] for p in upload["parameters"]}
+    assert {"bucket", "source", "prefix", "endpoint_url", "filter_modified_at"} <= param_names


### PR DESCRIPTION
## Summary

Implements issue #87: a pipeline task that uploads local data to cloud storage, plus a mix-in giving artifact-producing tasks a single, consistent path convention.

Stacked on #99 — this PR's base is `claude/session-context-niux5t` and will retarget to `stage` when #99 merges. Together they complete the fleet loop: **batch-reduce a folder of logs → upload the reduced bags**.

## What's new

**`UploadFilesToS3`** (`src/pipeline/tasks/upload/s3.py`)
- `source` may be a file, a directory (recursive), or a glob; object keys preserve structure relative to the source root under an optional `prefix`.
- Works with any S3-compatible store (MinIO, Cloudflare R2, GCS interop) via `endpoint_url`.
- **Checksum skip**: files whose SHA-256 matches the remote object are skipped (same contract as the existing pipeline artifact upload), so re-runs are cheap.
- **`filter_modified_at`**: only uploads files modified within `[asof - lookback, asof]`, so a scheduled pipeline uploads just the new artifacts each tick (mirrors `rsync_files` semantics).
- Credentials via the standard AWS resolution chain.

**`ArtifactMixin`** (`src/pipeline/base.py`)
- One `artifact_path(asof_seconds, extension)` helper encoding the canonical layout (`pipeline=/task=/datestr=/site=/asset=/log_id=`) and creating the parent directory.
- All seven artifact-producing tasks (`topic_sql`, `write_topics_to_file`, `generate_gif`, snippet ros1/ros2, reduce db3/mcap) refactored onto it — the issue's "consistent naming convention" ask, minus ~70 lines of boilerplate.

**Runbook** — new section pairing batch reduction with cloud upload.

## Testing

14 new tests with a mocked boto3 client (no real cloud needed): key layout for dir/file/glob sources, checksum skip/upload decisions, modified-time filtering, frame-lookback rejection, empty-arg validation, and capability-registry discovery. Full pipeline suite: 71 passed, ruff clean. ROS-coupled refactored tasks are py_compile-checked (they still need a ROS env to run — tracked as the next PR).

## Follow-ups

- GCS / Azure native clients (boto3 is currently the only cloud SDK dep; the S3-compatible `endpoint_url` path covers MinIO/R2/GCS-interop meanwhile).
- Wire `report_progress` into the upload task for large-file progress bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
