### PR TITLE
Verify ROS2 write paths end-to-end with in-container integration tests

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -171,7 +171,28 @@ You can also preview a reduction on the same CSV sample
 (`message['accel_x'] < -10` → 2 events, ~33.6% kept), exercising the full detect/merge
 path without ROS.
 
+## Verify the ROS write paths (integration tests)
+
+The db3/MCAP reduce and snippet writers are covered by integration tests that synthesize
+a bag with real IMU telemetry (two decelerations below -10) and assert on the written
+output. They skip automatically outside ROS; run them in a container:
+
+```bash
+docker compose run --rm -v "$PWD:/home/ubuntu/work" ros2-jazzy bash -c '
+  cd /home/ubuntu/work
+  uv pip install --python /home/ubuntu/runtime/.venv/bin/python -q pytest
+  source /opt/ros/jazzy/setup.bash
+  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+    /home/ubuntu/runtime/.venv/bin/python -m pytest test/pipeline/integration -v'
+```
+
+To generate a standalone synthetic telemetry bag (db3 or mcap) for manual experiments:
+
+```bash
+uv run python -m test.pipeline.integration.synth --directory ./data/synthetic --storage mcap
+```
+
 > [!NOTE]
 > The bundled ROS2 sample (`data/sample/ros2/db3`) contains only `std_msgs/String`
-> topics over a sub-microsecond span, so it is not a meaningful reduction target — point
-> the reduce pipeline at a bag with real numeric telemetry.
+> topics over a sub-microsecond span, so it is not a meaningful reduction target — use
+> the synthesizer above or a bag with real numeric telemetry.

--- a/test/pipeline/integration/synth.py
+++ b/test/pipeline/integration/synth.py
@@ -1,0 +1,104 @@
+"""Synthesize a small ROS2 bag with numeric IMU telemetry and deceleration events.
+
+The bundled sample bags contain only string topics, so they cannot exercise the
+event-driven reduction paths. This helper writes a bag (sqlite3 or mcap storage)
+with a sensor_msgs/Imu topic whose linear_acceleration.x dips below -10 in two
+distinct events -- the ground truth the integration tests assert against.
+
+Requires a ROS2 environment (rclpy / rosbag2_py); run inside a bagel ros2-* container.
+
+Usage as a script:
+    uv run python -m test.pipeline.integration.synth --directory ./data/synthetic --storage mcap
+"""
+
+import argparse
+import math
+import pathlib
+
+EPOCH = 1_700_000_000.0  # realistic, epoch-scale timestamps
+SECOND_NS = 1_000_000_000
+
+RATE_HZ = 20
+DURATION_SECONDS = 12.0
+CRUISE_ACCEL = -0.5
+# (start offset, end offset, accel value): two hard decelerations below -10.
+EVENTS = ((4.0, 5.0, -13.0), (8.0, 8.75, -11.5))
+
+
+def accel_at(offset_seconds: float) -> float:
+    """The synthetic linear_acceleration.x profile at an offset into the bag."""
+    for start, end, value in EVENTS:
+        if start <= offset_seconds <= end:
+            return value
+    return CRUISE_ACCEL + 0.1 * math.sin(offset_seconds)
+
+
+def event_onsets() -> list[float]:
+    """Absolute timestamps of the rising edges (ground truth for assertions)."""
+    return [EPOCH + start for start, _, _ in EVENTS]
+
+
+def write_imu_bag(directory: pathlib.Path, storage_id: str) -> pathlib.Path:
+    """Write the synthetic bag and return its path.
+
+    Args:
+        directory: Directory to create the bag in (must not exist).
+        storage_id: rosbag2 storage plugin -- "sqlite3" (db3) or "mcap".
+
+    """
+    import rosbag2_py
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu
+    from std_msgs.msg import String
+
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(directory), storage_id=storage_id),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(
+            id=0, name="/imu", type="sensor_msgs/msg/Imu", serialization_format="cdr"
+        )
+    )
+    writer.create_topic(
+        rosbag2_py.TopicMetadata(
+            id=1, name="/status", type="std_msgs/msg/String", serialization_format="cdr"
+        )
+    )
+
+    count = int(DURATION_SECONDS * RATE_HZ)
+    for i in range(count):
+        offset = i / RATE_HZ
+        timestamp_ns = int((EPOCH + offset) * SECOND_NS)
+
+        imu = Imu()
+        imu.header.stamp.sec = timestamp_ns // SECOND_NS
+        imu.header.stamp.nanosec = timestamp_ns % SECOND_NS
+        imu.header.frame_id = "base_link"
+        imu.linear_acceleration.x = accel_at(offset)
+        imu.linear_acceleration.z = 9.81
+        writer.write("/imu", serialize_message(imu), timestamp_ns)
+
+        if i % RATE_HZ == 0:  # 1 Hz status topic to prove multi-topic copy
+            status = String()
+            status.data = f"tick {offset:.0f}"
+            writer.write("/status", serialize_message(status), timestamp_ns)
+
+    del writer  # close the bag (finalizes metadata.yaml)
+    return directory
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--directory", type=pathlib.Path, required=True)
+    parser.add_argument("--storage", choices=("sqlite3", "mcap"), default="sqlite3")
+    args = parser.parse_args()
+    write_imu_bag(args.directory, args.storage)
+    print(f"Wrote synthetic {args.storage} bag to {args.directory}")  # noqa: T201
+    print(f"Event onsets at: {event_onsets()}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/test/pipeline/integration/test_ros2_write_paths.py
+++ b/test/pipeline/integration/test_ros2_write_paths.py
@@ -1,0 +1,185 @@
+"""End-to-end verification of the ROS2 reduce/snippet write paths.
+
+These tests require a ROS2 environment (rclpy, rosbag2_py, the mcap python libs) and
+are skipped elsewhere -- run them inside a bagel ros2-* container:
+
+    docker compose run --rm -v "$PWD:/home/ubuntu/work" ros2-jazzy bash -c \
+      "cd /home/ubuntu/work && UV_PROJECT_ENVIRONMENT=/home/ubuntu/runtime/.venv \
+       uv run --no-sync pytest test/pipeline/integration -v"
+
+Each test synthesizes a small bag with real numeric IMU telemetry (two hard
+decelerations below -10), runs the actual pipeline (`Pipeline.build().run_all()`),
+and asserts on the *written output bag* -- proving the write layer end to end.
+"""
+
+import pathlib
+
+import pytest
+
+rosbag2_py = pytest.importorskip("rosbag2_py")
+
+from settings import settings  # noqa: E402
+from src.pipeline import base  # noqa: E402
+
+from . import synth  # noqa: E402
+
+SECOND_NS = 1_000_000_000
+
+PREDICATE = "\"/imu\"['linear_acceleration']['x'] < -10"
+PRE_SECONDS = 1.0
+POST_SECONDS = 1.0
+
+# Ground truth from synth: events at EPOCH+4 and EPOCH+8 -> kept windows [3,6] and [7,9.75].
+EXPECTED_EVENTS = synth.event_onsets()
+EXPECTED_WINDOWS = [
+    (start - PRE_SECONDS, end + POST_SECONDS) for start, end, _ in synth.EVENTS
+]
+
+
+def _read_messages(bag_dir: pathlib.Path, storage_id: str) -> list[tuple[str, float]]:
+    """Read (topic, timestamp_seconds) pairs from an output bag via rosbag2."""
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(bag_dir), storage_id=storage_id),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+    messages = []
+    while reader.has_next():
+        topic, _, nanoseconds = reader.read_next()
+        messages.append((topic, nanoseconds / SECOND_NS))
+    return messages
+
+
+def _in_expected_windows(timestamp: float) -> bool:
+    offset = timestamp - synth.EPOCH
+    return any(start <= offset <= end for start, end in EXPECTED_WINDOWS)
+
+
+def _reduce_config(bag_path: pathlib.Path, module: str) -> dict:
+    return {
+        "name": "verify_reduce",
+        "site": "test_site",
+        "asset": "test_asset",
+        "path": str(bag_path),
+        "allow_failure": False,
+        "cadence": {"topic": "/imu", "when": "once_at_end"},
+        "tasks": [
+            {
+                "module": module,
+                "args": {
+                    "event_topic": "/imu",
+                    "predicate": PREDICATE,
+                    "pre_seconds": PRE_SECONDS,
+                    "post_seconds": POST_SECONDS,
+                },
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def test_reduce_db3_keeps_only_event_windows(tmp_path: pathlib.Path) -> None:
+    bag = synth.write_imu_bag(tmp_path / "source_bag", "sqlite3")
+
+    pipeline = base.Pipeline.build(
+        _reduce_config(bag, "src.pipeline.tasks.reduce.ros2.db3")
+    )
+    produced = pipeline.run_all()
+
+    assert len(produced) == 1
+    source_count = len(_read_messages(bag, "sqlite3"))
+    kept = _read_messages(produced[0], "sqlite3")
+
+    assert kept, "reduced bag must not be empty"
+    assert len(kept) < source_count, "reduction must drop data"
+    assert all(_in_expected_windows(ts) for _, ts in kept), "no data outside event windows"
+    assert {topic for topic, _ in kept} == {"/imu", "/status"}, "all topics preserved"
+    # Both events' windows are represented.
+    for start, end in EXPECTED_WINDOWS:
+        assert any(start <= ts - synth.EPOCH <= end for _, ts in kept)
+
+
+def test_snippet_db3_writes_one_clip_per_event(tmp_path: pathlib.Path) -> None:
+    bag = synth.write_imu_bag(tmp_path / "source_bag", "sqlite3")
+
+    config = {
+        "name": "verify_snippet",
+        "site": "test_site",
+        "asset": "test_asset",
+        "path": str(bag),
+        "allow_failure": False,
+        "cadence": {
+            "topic": "/imu",
+            "when": {
+                "on_event": {
+                    "predicate": PREDICATE,
+                    "debounce": {"last": 2, "unit": "second"},
+                }
+            },
+        },
+        "tasks": [
+            {
+                "module": "src.pipeline.tasks.snippet.ros2.db3",
+                "lookback": {"last": 1, "unit": "second"},
+                "args": {"post_seconds": POST_SECONDS},
+            }
+        ],
+    }
+    produced = base.Pipeline.build(config).run_all()
+
+    assert len(produced) == len(EXPECTED_EVENTS), "one clip per detected event"
+    for clip_dir, event_ts in zip(sorted(produced), EXPECTED_EVENTS, strict=True):
+        clip = _read_messages(clip_dir, "sqlite3")
+        assert clip, "clip must not be empty"
+        for _, ts in clip:
+            assert event_ts - PRE_SECONDS <= ts <= event_ts + POST_SECONDS + 1e-6
+
+
+def test_reduce_mcap_raw_passthrough(tmp_path: pathlib.Path) -> None:
+    from mcap.reader import make_reader
+
+    bag = synth.write_imu_bag(tmp_path / "source_bag", "mcap")
+
+    pipeline = base.Pipeline.build(
+        _reduce_config(bag, "src.pipeline.tasks.reduce.ros2.mcap")
+    )
+    produced = pipeline.run_all()
+
+    assert len(produced) == 1
+    output_file = produced[0]
+    assert output_file.suffix == ".mcap"
+
+    kept, topics, schemas = [], set(), set()
+    with open(output_file, "rb") as stream:
+        reader = make_reader(stream)
+        for schema, channel, message in reader.iter_messages():
+            kept.append((channel.topic, message.log_time / SECOND_NS))
+            topics.add(channel.topic)
+            schemas.add(schema.name)
+
+    assert kept, "reduced mcap must not be empty"
+    assert all(_in_expected_windows(ts) for _, ts in kept), "no data outside event windows"
+    assert topics == {"/imu", "/status"}
+    assert schemas == {"sensor_msgs/msg/Imu", "std_msgs/msg/String"}, "schemas copied verbatim"
+
+
+def test_preview_reports_ground_truth_events(tmp_path: pathlib.Path) -> None:
+    import server
+
+    bag = synth.write_imu_bag(tmp_path / "source_bag", "sqlite3")
+    result = server.preview_pipeline(
+        path=str(bag),
+        event_topic="/imu",
+        predicate=PREDICATE,
+        pre_seconds=PRE_SECONDS,
+        post_seconds=POST_SECONDS,
+        debounce_seconds=2.0,
+    )
+    assert result["event_count"] == len(EXPECTED_EVENTS)
+    assert [round(e - synth.EPOCH, 3) for e in result["events"]] == [
+        start for start, _, _ in synth.EVENTS
+    ]

--- a/test/pipeline/test_live_buffer_wiring.py
+++ b/test/pipeline/test_live_buffer_wiring.py
@@ -1,0 +1,85 @@
+"""Wire-level tests: an OnEvent pipeline attached to the live sink buffer.
+
+Exercises the path `TopicBufferWriter.append -> evaluate_predicate -> LiveEventTrigger
+-> Pipeline.run_at` without a ROS bridge, proving the live edge-recorder wiring that
+`TopicSink.subscribe(topic, pipeline=...)` uses.
+"""
+
+import pathlib
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+from src.pipeline.base import Cadence, Frequency, Lookback, OnEvent, Unit
+from src.sink.buffer import TopicBufferWriter
+
+STRUCT = pa.struct([("ax", pa.float64()), ("t", pa.float64())])
+
+
+def _writer(tmp_path: pathlib.Path, when: object) -> tuple[TopicBufferWriter, MagicMock]:
+    pipeline = MagicMock()
+    pipeline.cadence = Cadence(topic="imu", when=when)
+    writer = TopicBufferWriter(
+        path=tmp_path,
+        topic="imu",
+        type_name="test/Imu",
+        definition="float64 ax",
+        struct=STRUCT,
+        buffer_size_bytes=None,
+        overwrite=True,
+        pipeline=pipeline,
+        extract_timestamp=lambda message: message["t"],
+    )
+    return writer, pipeline
+
+
+def _feed(writer: TopicBufferWriter, samples: list[tuple[float, float]]) -> None:
+    for t, ax in samples:
+        writer.append({"ax": ax, "t": t})
+
+
+def test_on_event_fires_once_per_rising_edge(tmp_path: pathlib.Path) -> None:
+    when = OnEvent(predicate="imu['ax'] < -10")
+    writer, pipeline = _writer(tmp_path, when)
+
+    _feed(writer, [(0.0, -0.5), (1.0, -12.0), (2.0, -12.0), (3.0, -0.5), (4.0, -15.0)])
+
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [1.0, 4.0]
+
+
+def test_forward_window_delays_firing_until_post_data_arrived(
+    tmp_path: pathlib.Path,
+) -> None:
+    when = OnEvent(
+        predicate="imu['ax'] < -10", forward=Lookback(last=2, unit=Unit.SECOND)
+    )
+    writer, pipeline = _writer(tmp_path, when)
+
+    _feed(writer, [(0.0, -0.5), (1.0, -12.0), (2.0, -0.5)])
+    pipeline.run_at.assert_not_called()  # post-window (until t=3) not yet buffered
+
+    _feed(writer, [(3.5, -0.5)])
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [1.0]
+
+
+def test_flush_fires_events_still_awaiting_forward_window(tmp_path: pathlib.Path) -> None:
+    when = OnEvent(
+        predicate="imu['ax'] < -10", forward=Lookback(last=10, unit=Unit.SECOND)
+    )
+    writer, pipeline = _writer(tmp_path, when)
+
+    _feed(writer, [(0.0, -0.5), (5.0, -13.0), (6.0, -0.5)])
+    pipeline.run_at.assert_not_called()
+
+    writer.flush_pending_events()  # what TopicSink.close() calls
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [5.0]
+
+
+def test_frequency_cadence_unaffected_by_event_wiring(tmp_path: pathlib.Path) -> None:
+    when = Frequency(every=2, unit=Unit.SECOND)
+    writer, pipeline = _writer(tmp_path, when)
+
+    _feed(writer, [(0.0, -0.5), (1.0, -0.5), (2.5, -0.5)])
+
+    # First message always runs; next only after >= 2s elapsed.
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [0.0, 2.5]


### PR DESCRIPTION
## Summary

Closes the verification gap from #99: the reduce/snippet **write layer** had shipped with its pure logic unit-tested but never executed in a ROS environment. This PR proves it end to end — all integration tests pass in the `ros2-jazzy` container against a synthesized bag with real numeric IMU telemetry.

Stacked on #100 (base auto-retargets as the stack merges). Merge order: #99 → #100 → #101.

## What was verified (all passing in `ros2-jazzy`)

| Path | Result |
|---|---|
| **reduce db3** | single output bag containing only the merged event windows; all topics preserved; both events represented |
| **snippet db3 via `OnEvent` cadence** | exactly one clip per detected event, each within its `[pre, post]` window — proves the cadence in the real engine |
| **reduce MCAP (raw passthrough)** | reduced `.mcap` with schemas copied verbatim, no data outside kept windows — confirms the `serialize_message` blocker (issue #86) is sidestepped |
| **preview on a real ROS bag** | `preview_pipeline` reports the ground-truth event onsets |
| **live edge-recorder wiring** (no bridge needed) | `TopicBufferWriter.append → evaluate_predicate → LiveEventTrigger → Pipeline.run_at`, incl. forward-window delay, flush-at-close, and Frequency cadences unaffected |

## What's new

- `test/pipeline/integration/synth.py` — synthesizes a small bag (sqlite3 **or** mcap storage) with a `sensor_msgs/Imu` topic containing two hard decelerations below −10 plus a 1 Hz status topic. Doubles as a CLI for manual experiments (the bundled db3 sample is `std_msgs/String`-only, so it can't exercise reduction).
- `test/pipeline/integration/test_ros2_write_paths.py` — the four write-path tests above; they `importorskip(rosbag2_py)` so CI outside ROS skips them cleanly.
- `test/pipeline/test_live_buffer_wiring.py` — four live-wiring tests that run anywhere (no ROS).
- Runbook — container recipe for running the integration suite (the image venv is built `--no-dev`, so install pytest into it and set `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` to avoid ROS's incompatible launch_testing plugins).

## How to run

```bash
docker compose run --rm -v "$PWD:/home/ubuntu/work" ros2-jazzy bash -c '
  cd /home/ubuntu/work
  uv pip install --python /home/ubuntu/runtime/.venv/bin/python -q pytest
  source /opt/ros/jazzy/setup.bash
  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
    /home/ubuntu/runtime/.venv/bin/python -m pytest test/pipeline/integration -v'
```

Local (no ROS): `uv run pytest test/pipeline -q` → 75 passed, 1 skipped, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
