### PR TITLE
Add MCAP snippet task via shared raw-record passthrough

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -82,6 +82,22 @@ tasks:
 
 (`src.pipeline.tasks.reduce.ros2.mcap` remains as a back-compat alias.)
 
+For per-event clips instead of one reduced file, pair the snippet variant with an
+`on_event` cadence — same raw passthrough, one `.mcap` per event:
+
+```yaml
+cadence:
+  topic: /imu
+  when:
+    on_event:
+      predicate: "\"/imu\"['linear_acceleration']['x'] < -10"
+      debounce: {last: 2, unit: second}
+tasks:
+  - module: src.pipeline.tasks.snippet.mcap
+    lookback: {last: 10, unit: second}
+    args: {post_seconds: 10}
+```
+
 ## Live edge-recording
 
 Attach the reduction to a live stream so only event windows are ever written. Use an

--- a/src/pipeline/mcap_raw.py
+++ b/src/pipeline/mcap_raw.py
@@ -1,0 +1,80 @@
+"""Raw MCAP record passthrough utilities.
+
+Shared by the MCAP reduce and snippet tasks: iterate raw (schema, channel, message)
+records out of MCAP files and copy a selection of them verbatim into a new MCAP file.
+Messages are never decoded or re-encoded, so no middleware typesupport is needed and
+any profile (ros1, ros2, protobuf, ...) passes through unchanged.
+"""
+
+import pathlib
+from collections.abc import Iterable, Iterator
+
+from mcap.reader import make_reader
+from mcap.records import Channel, Message, Schema
+from mcap.writer import Writer
+
+RawRecord = tuple[Schema | None, Channel, Message]
+
+
+def in_intervals(log_time_ns: int, intervals_ns: list[tuple[int, int]]) -> bool:
+    """Return True if a nanosecond log time falls within any interval."""
+    return any(start <= log_time_ns <= end for start, end in intervals_ns)
+
+
+def iter_raw_messages(
+    mcap_files: Iterable[pathlib.Path], topics: list[str] | None = None
+) -> Iterator[RawRecord]:
+    """Yield raw (schema, channel, message) records from MCAP files in log-time order.
+
+    Args:
+        mcap_files: The .mcap files to read, in order.
+        topics: Topics to include. If None, all topics are included.
+
+    """
+    keep_topics = set(topics) if topics else None
+    for mcap_file in mcap_files:
+        with open(mcap_file, "rb") as stream:
+            reader = make_reader(stream)
+            for schema, channel, message in reader.iter_messages(
+                topics=topics, log_time_order=True
+            ):
+                if keep_topics is not None and channel.topic not in keep_topics:
+                    continue
+                yield schema, channel, message
+
+
+def write_raw_messages(output_file: pathlib.Path, records: Iterable[RawRecord]) -> int:
+    """Copy raw records verbatim into a new MCAP file, returning the message count.
+
+    Schema and channel definitions are registered once on first sight and copied
+    unchanged; message payload bytes pass through untouched.
+    """
+    count = 0
+    with open(output_file, "wb") as output_stream:
+        writer = Writer(output_stream)
+        writer.start()
+        schema_ids: dict[int, int] = {}  # source schema id -> output schema id
+        channel_ids: dict[int, int] = {}  # source channel id -> output channel id
+
+        for schema, channel, message in records:
+            if schema is not None and schema.id not in schema_ids:
+                schema_ids[schema.id] = writer.register_schema(
+                    name=schema.name, encoding=schema.encoding, data=schema.data
+                )
+            if channel.id not in channel_ids:
+                channel_ids[channel.id] = writer.register_channel(
+                    topic=channel.topic,
+                    message_encoding=channel.message_encoding,
+                    schema_id=schema_ids.get(schema.id, 0) if schema else 0,
+                    metadata=dict(channel.metadata),
+                )
+            writer.add_message(
+                channel_id=channel_ids[channel.id],
+                log_time=message.log_time,
+                data=message.data,
+                publish_time=message.publish_time,
+                sequence=message.sequence,
+            )
+            count += 1
+        writer.finish()
+    return count

--- a/src/pipeline/tasks/reduce/mcap.py
+++ b/src/pipeline/tasks/reduce/mcap.py
@@ -10,22 +10,14 @@ still uses the decoded path (``to_duckdb``); only the write is a raw byte passth
 import logging
 import pathlib
 
-from mcap.reader import make_reader
-from mcap.writer import Writer
-
 from src.di import module
-from src.pipeline import base, messages
+from src.pipeline import base, mcap_raw, messages
 from src.pipeline.tasks.reduce.base import ReduceMixin
 
 NANOSECOND = 1
 MICROSECOND = 1_000 * NANOSECOND
 MILLISECOND = 1_000 * MICROSECOND
 SECOND = 1_000 * MILLISECOND
-
-
-def _in_intervals(log_time_ns: int, intervals_ns: list[tuple[int, int]]) -> bool:
-    """Return True if a nanosecond log time falls within any kept interval."""
-    return any(start <= log_time_ns <= end for start, end in intervals_ns)
 
 
 class ReduceMcap(base.ArtifactMixin, ReduceMixin, messages.TopicMessageMixin, base.Task):
@@ -89,46 +81,14 @@ class ReduceMcap(base.ArtifactMixin, ReduceMixin, messages.TopicMessageMixin, ba
         intervals_ns = [(int(start * SECOND), int(end * SECOND)) for start, end in intervals]
 
         data_source = self.factory.build()
-        keep_topics = set(self._topics) if self._topics else None
-
         output_file = self.artifact_path(asof_seconds, ".mcap")
 
-        with open(output_file, "wb") as output_stream:
-            writer = Writer(output_stream)
-            writer.start()
-            schema_ids: dict[int, int] = {}  # source schema id -> output schema id
-            channel_ids: dict[int, int] = {}  # source channel id -> output channel id
-
-            for mcap_file in data_source.mcap_files:
-                with open(mcap_file, "rb") as input_stream:
-                    reader = make_reader(input_stream)
-                    for schema, channel, message in reader.iter_messages(
-                        topics=self._topics, log_time_order=True
-                    ):
-                        if keep_topics is not None and channel.topic not in keep_topics:
-                            continue
-                        if not _in_intervals(message.log_time, intervals_ns):
-                            continue
-
-                        if schema is not None and schema.id not in schema_ids:
-                            schema_ids[schema.id] = writer.register_schema(
-                                name=schema.name, encoding=schema.encoding, data=schema.data
-                            )
-                        if channel.id not in channel_ids:
-                            channel_ids[channel.id] = writer.register_channel(
-                                topic=channel.topic,
-                                message_encoding=channel.message_encoding,
-                                schema_id=schema_ids.get(schema.id, 0) if schema else 0,
-                                metadata=dict(channel.metadata),
-                            )
-                        writer.add_message(
-                            channel_id=channel_ids[channel.id],
-                            log_time=message.log_time,
-                            data=message.data,
-                            publish_time=message.publish_time,
-                            sequence=message.sequence,
-                        )
-            writer.finish()
+        records = (
+            record
+            for record in mcap_raw.iter_raw_messages(data_source.mcap_files, self._topics)
+            if mcap_raw.in_intervals(record[2].log_time, intervals_ns)
+        )
+        mcap_raw.write_raw_messages(output_file, records)
 
         logging.info("Wrote %s", output_file)
 

--- a/src/pipeline/tasks/snippet/mcap.py
+++ b/src/pipeline/tasks/snippet/mcap.py
@@ -1,0 +1,91 @@
+"""Create an MCAP snippet: one clip around the current pipeline timestamp.
+
+Format-agnostic and ROS-free: works on any MCAP source (ros1, ros2, protobuf, ...
+profiles) by copying raw message records verbatim -- no decode/re-encode, no rosidl
+typesupport. Pair it with an `on_event` cadence to write one clip per detected event,
+or with a `frequency` cadence for periodic clips.
+"""
+
+import logging
+import pathlib
+from collections import deque
+
+from src.di import module
+from src.pipeline import base, mcap_raw, messages
+
+NANOSECOND = 1
+SECOND = 1_000_000_000 * NANOSECOND
+
+
+class SnipMcap(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
+    """Create a new MCAP snippet around the current pipeline timestamp.
+
+    The clip spans ``[asof - lookback, asof + post_seconds]`` for a time-based
+    lookback, the last N messages for a frame-based lookback, or everything up to
+    ``asof + post_seconds`` when no lookback is given.
+    """
+
+    def __init__(
+        self,
+        topics: list[str] | None = None,
+        post_seconds: float = 0.0,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            topics (list[str] | None, optional): A list of topics to include. If None, all
+                available topics are written to the snippet.
+            post_seconds (float, optional): How many seconds *after* `asof_seconds` to also
+                include in the snippet. Combined with a time-based `lookback` (the
+                pre-window) this produces a symmetric window around an event, e.g.
+                lookback=10s + post_seconds=10 keeps [asof - 10s, asof + 10s].
+                Defaults to 0.0 (pre-window only). Ignored for frame-based lookbacks.
+                Must be non-negative.
+
+        Raises:
+            ValueError: If 'topics' is specified but is an empty list.
+            ValueError: If 'post_seconds' is negative.
+
+        """
+        if topics is not None and len(topics) == 0:
+            raise ValueError("If 'topics' is specified, it must contain at least one topic name.")
+        if post_seconds < 0:
+            raise ValueError(f"'post_seconds' must be non-negative, got {post_seconds}.")
+        self._topics = topics
+        self._post_seconds = post_seconds
+
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> list[pathlib.Path]:
+        """Execute the task at the given time."""
+        data_source = self.factory.build()
+        raw_messages = mcap_raw.iter_raw_messages(data_source.mcap_files, self._topics)
+
+        end_ns = int((asof_seconds + self._post_seconds) * SECOND)
+
+        match lookback:
+            case base.Lookback(last=int(last), unit=base.Unit.FRAME):
+                asof_ns = int(asof_seconds * SECOND)
+                records = deque(
+                    (record for record in raw_messages if record[2].log_time <= asof_ns),
+                    maxlen=last,
+                )
+            case base.Lookback(last=_, unit=_):
+                start_ns = int((asof_seconds - lookback.to_seconds()) * SECOND)
+                records = (
+                    record
+                    for record in raw_messages
+                    if start_ns <= record[2].log_time <= end_ns
+                )
+            case _:
+                records = (record for record in raw_messages if record[2].log_time <= end_ns)
+
+        output_file = self.artifact_path(asof_seconds, ".mcap")
+        count = mcap_raw.write_raw_messages(output_file, records)
+
+        logging.info("Wrote %s (%d messages)", output_file, count)
+
+        return [output_file]
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = SnipMcap

--- a/test/pipeline/integration/test_ros2_write_paths.py
+++ b/test/pipeline/integration/test_ros2_write_paths.py
@@ -165,6 +165,48 @@ def test_reduce_mcap_raw_passthrough(tmp_path: pathlib.Path) -> None:
     assert schemas == {"sensor_msgs/msg/Imu", "std_msgs/msg/String"}, "schemas copied verbatim"
 
 
+def test_snippet_mcap_writes_one_clip_per_event(tmp_path: pathlib.Path) -> None:
+    from mcap.reader import make_reader
+
+    bag = synth.write_imu_bag(tmp_path / "source_bag", "mcap")
+
+    config = {
+        "name": "verify_snippet_mcap",
+        "site": "test_site",
+        "asset": "test_asset",
+        "path": str(bag),
+        "allow_failure": False,
+        "cadence": {
+            "topic": "/imu",
+            "when": {
+                "on_event": {
+                    "predicate": PREDICATE,
+                    "debounce": {"last": 2, "unit": "second"},
+                }
+            },
+        },
+        "tasks": [
+            {
+                "module": "src.pipeline.tasks.snippet.mcap",
+                "lookback": {"last": 1, "unit": "second"},
+                "args": {"post_seconds": POST_SECONDS},
+            }
+        ],
+    }
+    produced = base.Pipeline.build(config).run_all()
+
+    assert len(produced) == len(EXPECTED_EVENTS), "one clip per detected event"
+    for clip_path, event_ts in zip(sorted(produced), EXPECTED_EVENTS, strict=True):
+        with open(clip_path, "rb") as stream:
+            timestamps = [
+                message.log_time / SECOND_NS
+                for _, _, message in make_reader(stream).iter_messages()
+            ]
+        assert timestamps, "clip must not be empty"
+        for ts in timestamps:
+            assert event_ts - PRE_SECONDS <= ts <= event_ts + POST_SECONDS + 1e-6
+
+
 def test_preview_reports_ground_truth_events(tmp_path: pathlib.Path) -> None:
     import server
 

--- a/test/pipeline/test_mcap_snippet.py
+++ b/test/pipeline/test_mcap_snippet.py
@@ -1,0 +1,117 @@
+"""End-to-end tests for the MCAP snippet task -- ROS-free, via a protobuf MCAP."""
+
+import pathlib
+
+import pytest
+from google.protobuf.wrappers_pb2 import DoubleValue
+from mcap.reader import make_reader
+from mcap_protobuf.writer import Writer as ProtobufWriter
+
+from settings import settings
+from src.pipeline import base
+from src.pipeline.tasks.snippet.mcap import SnipMcap
+
+EPOCH = 1_700_000_000.0
+SECOND_NS = 1_000_000_000
+
+RATE_HZ = 4
+DURATION_SECONDS = 12.0
+EVENTS = ((4.0, 5.0, -13.0), (8.0, 8.75, -11.5))
+PRE_SECONDS, POST_SECONDS = 1.0, 1.0
+PREDICATE = "\"/accel\"['value'] < -10"
+
+
+def _accel_at(offset: float) -> float:
+    for start, end, value in EVENTS:
+        if start <= offset <= end:
+            return value
+    return -0.5
+
+
+@pytest.fixture
+def protobuf_mcap(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / "flight.mcap"
+    with open(path, "wb") as stream, ProtobufWriter(stream) as writer:
+        for i in range(int(DURATION_SECONDS * RATE_HZ)):
+            offset = i / RATE_HZ
+            timestamp_ns = int((EPOCH + offset) * SECOND_NS)
+            writer.write_message(
+                topic="/accel",
+                message=DoubleValue(value=_accel_at(offset)),
+                log_time=timestamp_ns,
+                publish_time=timestamp_ns,
+            )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def _read_clip(path: pathlib.Path) -> list[tuple[str, str, float]]:
+    """Return (topic, schema name, offset seconds) triples from a clip."""
+    with open(path, "rb") as stream:
+        return [
+            (channel.topic, schema.name, message.log_time / SECOND_NS - EPOCH)
+            for schema, channel, message in make_reader(stream).iter_messages()
+        ]
+
+
+def test_on_event_cadence_writes_one_clip_per_event(protobuf_mcap: pathlib.Path) -> None:
+    config = {
+        "name": "snippet_mcap",
+        "site": "test_site",
+        "asset": "test_asset",
+        "path": str(protobuf_mcap),
+        "allow_failure": False,
+        "cadence": {
+            "topic": "/accel",
+            "when": {
+                "on_event": {
+                    "predicate": PREDICATE,
+                    "debounce": {"last": 2, "unit": "second"},
+                }
+            },
+        },
+        "tasks": [
+            {
+                "module": "src.pipeline.tasks.snippet.mcap",
+                "lookback": {"last": 1, "unit": "second"},
+                "args": {"post_seconds": POST_SECONDS},
+            }
+        ],
+    }
+    produced = base.Pipeline.build(config).run_all()
+
+    assert len(produced) == len(EVENTS), "one clip per detected event"
+    for clip_path, (event_offset, _, _) in zip(sorted(produced), EVENTS, strict=True):
+        clip = _read_clip(clip_path)
+        assert clip, "clip must not be empty"
+        for topic, schema_name, offset in clip:
+            assert topic == "/accel"
+            assert schema_name == "google.protobuf.DoubleValue", "schema copied verbatim"
+            assert event_offset - PRE_SECONDS <= offset <= event_offset + POST_SECONDS + 1e-6
+
+
+def test_frame_lookback_keeps_last_n_messages(protobuf_mcap: pathlib.Path) -> None:
+    task = SnipMcap()
+    task.setup(path=str(protobuf_mcap))
+    task._pipeline, task._name = "snippet_mcap", "snip_mcap"
+    task._site, task._asset, task._log_id = "test_site", "test_asset", "log-1"
+
+    asof = EPOCH + 6.0
+    (clip_path,) = task.execute(asof, base.Lookback(last=5, unit=base.Unit.FRAME))
+
+    clip = _read_clip(clip_path)
+    assert len(clip) == 5
+    assert all(offset <= 6.0 for _, _, offset in clip)
+    # The last 5 messages at 4 Hz before t=6 are t = 5.0 .. 6.0.
+    assert [offset for _, _, offset in clip] == pytest.approx([5.0, 5.25, 5.5, 5.75, 6.0])
+
+
+def test_validation_errors() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        SnipMcap(topics=[])
+    with pytest.raises(ValueError, match="non-negative"):
+        SnipMcap(post_seconds=-1.0)


### PR DESCRIPTION
## Summary

Adds the MCAP **snippet** task (one clip per event), completing issue #86: with the reduce task (single reduced file) already in the stack, both MCAP creation modes now exist — and both are ROS-free.

Closes #86.

Stacked on #102. Merge order: #99 → #100 → #101 → #102 → #103.

## What's new

**`src/pipeline/mcap_raw.py`** — shared raw MCAP passthrough
- `iter_raw_messages` yields `(schema, channel, message)` records in log-time order; `write_raw_messages` copies a selection verbatim into a new file.
- No decode/re-encode → no middleware typesupport needed; any profile (ros1, ros2, protobuf, …) passes through unchanged. This is the mechanism that sidesteps the original `serialize_message` blocker from #86.
- `ReduceMcap` refactored onto it (same behavior, ~40 fewer lines).

**`SnipMcap`** (`src/pipeline/tasks/snippet/mcap.py`)
- One clip around the pipeline timestamp: `[asof − lookback, asof + post_seconds]` for time lookbacks, last N raw records for frame lookbacks.
- Paired with the `on_event` cadence it writes **one `.mcap` per detected event**:

```yaml
cadence:
  topic: /imu
  when:
    on_event:
      predicate: "\"/imu\"['linear_acceleration']['x'] < -10"
      debounce: {last: 2, unit: second}
tasks:
  - module: src.pipeline.tasks.snippet.mcap
    lookback: {last: 10, unit: second}
    args: {post_seconds: 10}
```

## Testing

- **Plain host, no ROS** (`test_mcap_snippet.py`): an `on_event` pipeline over a protobuf-profile MCAP writes exactly one clip per deceleration event, each clip's messages within its `[pre, post]` window and the schema copied verbatim; frame-lookback returns exactly the last N messages; validation cases.
- **`ros2-jazzy` container**: the integration suite gains the same scenario over a ros2-profile MCAP bag — 8 passing in-container, 104 on host, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
