### PR TITLE
Add MQTT topic sink: chat with live IoT data, no ROS required

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Can’t wait to try it out? 👉 Check out the [Quickstart](#️-quickstart).
 | ------------ | ------------------------------ |
 | **Robotics** | ROS1, ROS2, MCAP (any profile) |
 | **Drones**   | PX4, ArduPilot, Betaflight     |
-| **IoT**      | Coming soon...                 |
+| **IoT**      | MQTT (live)                    |
 
 ## 💬 What Can I Prompt?
 
@@ -136,6 +136,7 @@ Pick the service that matches your environment:
 | `px4`             | PX4 flight logs         |
 | `ardupilot`       | ArduPilot flight logs   |
 | `betaflight`      | Betaflight flight logs  |
+| `iot`             | IoT / MQTT (live)       |
 
 > [!TIP]
 > To give Bagel access to your local files, edit `compose.yaml` before starting Docker:

--- a/compose.yaml
+++ b/compose.yaml
@@ -202,3 +202,24 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     # volumes:
     #   - <path-to-local-data>:/home/ubuntu/data
+
+  iot:
+    image: ghcr.io/extelligence-ai/bagel/iot:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.iot
+      args:
+        UV_VERSION: 0.8.0
+        DEV_MODE: false
+        MCP_SERVER_PORT: ${MCP_SERVER_PORT}
+        JUPYTER_HOST: ${JUPYTER_HOST}
+        JUPYTER_PORT: ${JUPYTER_PORT}
+    environment:
+      CONTAINER_MODE: true
+    ports:
+      - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
+      - "${JUPYTER_PORT}:${JUPYTER_PORT}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    # volumes:
+    #   - <path-to-local-data>:/home/ubuntu/data

--- a/doc/runbooks/iot_mqtt.md
+++ b/doc/runbooks/iot_mqtt.md
@@ -1,0 +1,83 @@
+# Chat with your IoT data over MQTT
+
+Bagel subscribes to any MQTT 3.1.1/5.0 broker (Mosquitto, EMQX, HiveMQ, AWS IoT Core, ...)
+and buffers topic messages locally, where every Bagel tool works on them: describe, SQL
+queries, previews, and live event-driven pipelines. Pure Python -- no ROS required.
+
+## Start Bagel
+
+```bash
+docker compose run --service-ports iot
+```
+
+Then connect your MCP client as usual (see the README quickstart).
+
+## Discover and subscribe
+
+MQTT brokers have no topic-listing API, so Bagel listens on the `#` wildcard for a short
+window (`discovery_seconds`, default 2s) and reports the topics it sees -- retained
+messages show up immediately. From your MCP client:
+
+> List the available live topics on the MQTT broker at `broker.local`.
+
+> Subscribe to `freezer/1/status` and `freezer/2/status` from the MQTT broker.
+
+Subscribed messages are buffered to a local sink directory; ask questions about them at
+any time:
+
+> What's the average temperature on `freezer/1/status` over the buffered data?
+
+## Payloads and schemas
+
+Payloads are parsed as JSON (the ecosystem norm): JSON objects become queryable structs
+(schema inferred from sampled messages), bare scalars become `{"value": ...}`, and
+non-JSON text becomes `{"payload": "<text>"}`. A sample payload doubles as the topic's
+"definition" when you ask Bagel to describe it. Sparkplug B / protobuf payloads are a
+planned extension.
+
+Authentication: pass `username`/`password` via the `args` of `subscribe_live_topics`
+(they are forwarded to the sink constructor). Timestamps use message arrival time.
+
+## Live edge-recording
+
+Attach an event-driven pipeline so only the moments that matter are acted on -- for
+example, alert on a cold-chain excursion:
+
+```yaml
+name: freezer_excursion
+site: warehouse
+asset: freezer_1
+path: <sink directory>            # printed by subscribe_live_topics
+allow_failure: true
+cadence:
+  topic: freezer/1/status
+  when:
+    on_event:
+      predicate: "\"freezer/1/status\"['temp'] > -15"
+      debounce: {last: 120, unit: second}
+      forward: {last: 30, unit: second}   # capture 30s after the excursion begins
+tasks:
+  - module: src.pipeline.tasks.write_topics_to_file
+    lookback: {last: 30, unit: second}
+    args: {topics: ["freezer/1/status"], output_format: csv}
+```
+
+The `on_event` cadence fires once per excursion (debounced), the `forward` window delays
+firing until the post-event data has been buffered, and the task snapshots the window --
+swap in `send_email` or the S3 upload task as needed.
+
+## Local test broker
+
+```bash
+docker run -d --name mosquitto -p 1883:1883 eclipse-mosquitto:2 \
+  mosquitto -c /mosquitto-no-auth.conf
+# publish something
+docker exec mosquitto mosquitto_pub -t 'freezer/1/status' \
+  -m '{"temp": -18.5, "door": "closed"}' -r
+```
+
+## Notes and limits (v1)
+
+- Subscribe to exact topic names; wildcards are used internally for discovery only.
+- Schema is inferred from early samples; fields that appear later read as NULL.
+- Messages carry no standard timestamp, so arrival time is used.

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -1,0 +1,103 @@
+# Ubuntu 22.04 LTS (Jammy Jellyfish)
+# Python 3.10.6
+FROM ubuntu:22.04
+
+# Install common tools
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    rsync \
+    vim && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up runtime environment
+ARG USERNAME=ubuntu
+RUN id -u 1000 >/dev/null 2>&1 || useradd -m -u 1000 ${USERNAME}
+USER ${USERNAME}
+ENV PATH="/home/${USERNAME}/.local/bin:$PATH"
+RUN mkdir -p /home/${USERNAME}/runtime
+WORKDIR /home/${USERNAME}/runtime
+
+# Install uv
+ARG UV_VERSION
+RUN /bin/bash -c "curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && uv --version"
+
+# Set up virtual environment and install PyPI dependencies
+COPY --chown=${USERNAME}:${USERNAME} pyproject.toml ./
+COPY --chown=${USERNAME}:${USERNAME} uv.lock ./
+ARG DEV_MODE
+RUN if [ "_${DEV_MODE}" = "_true" ]; then \
+    uv sync --group iot; \
+    else \
+    uv sync --no-dev --group iot; \
+    fi
+
+# Expose MCP server port
+ARG MCP_SERVER_PORT
+EXPOSE ${MCP_SERVER_PORT}
+
+# Configure Jupyter Lab host and port
+ARG JUPYTER_HOST
+ARG JUPYTER_PORT
+RUN if [ "_${DEV_MODE}" = "_true" ]; then \
+    uv run jupyter lab --generate-config && \
+    CONFIG_FILE="/home/${USERNAME}/.jupyter/jupyter_lab_config.py" && \
+    echo "c.ServerApp.ip = '${JUPYTER_HOST}'" >> "${CONFIG_FILE}" && \
+    echo "c.ServerApp.port = ${JUPYTER_PORT}" >> "${CONFIG_FILE}"; \
+    fi
+
+# Expose Jupyter Lab port
+EXPOSE ${JUPYTER_PORT}
+
+# Copy common source code
+COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
+COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
+COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
+COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
+COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
+COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
+COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
+COPY --chown=${USERNAME}:${USERNAME} src/sink/mqtt.py ./src/sink/mqtt.py
+COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
+COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
+COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
+COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
+COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
+COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
+COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
+COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+# MCAP as a first-class format (no ROS required)
+COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
+COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
+COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
+COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
+COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
+COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
+COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
+COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
+COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
+COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
+COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
+COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
+
+# Copy common test code
+COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
+COPY --chown=${USERNAME}:${USERNAME} test/di ./test/di
+COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/source/test_source_base.py
+
+# Copy configuration file
+COPY --chown=${USERNAME}:${USERNAME} .env ./.env
+
+# Copy sample data
+COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
+
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+
+# By default, the Bagel MCP server will be launched
+CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ px4 = ["pyulog >=1.2.0,<2.0.0", "GitPython >=3.1.0,<4.0.0"]
 ardupilot = ["pymavlink >=2.4.0,<3.0.0"]
 betaflight = ["orangebox >=0.4.0,<1.0.0"]
 cloudini = ["wasmtime >=26.0.0", "numpy >=1.24.0,<3.0.0"]
+iot = [
+    "paho-mqtt>=2.1.0,<3.0.0",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/src/di/types/topic_sink.py
+++ b/src/di/types/topic_sink.py
@@ -10,6 +10,7 @@ class TopicSink(Enum):
 
     ROS1_BRIDGE = "ros1.bridge"
     ROS2_BRIDGE = "ros2.bridge"
+    MQTT = "mqtt"
 
 
 def guess_host(type_: TopicSink) -> str:
@@ -17,9 +18,9 @@ def guess_host(type_: TopicSink) -> str:
     match type_:
         case TopicSink.ROS1_BRIDGE:
             return "0.0.0.0"  # noqa: S104
-        case TopicSink.ROS2_BRIDGE if settings.CONTAINER_MODE:
+        case (TopicSink.ROS2_BRIDGE | TopicSink.MQTT) if settings.CONTAINER_MODE:
             return "host.docker.internal"
-        case TopicSink.ROS2_BRIDGE:
+        case TopicSink.ROS2_BRIDGE | TopicSink.MQTT:
             return "localhost"
         case _:
             raise ValueError(
@@ -33,6 +34,8 @@ def guess_port(type_: TopicSink) -> int:
     match type_:
         case TopicSink.ROS2_BRIDGE:
             return 9090
+        case TopicSink.MQTT:
+            return 1883
         case _:
             raise ValueError(
                 f"Cannot guess port for TopicSink type: {type_}. "

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -246,7 +246,8 @@ class TopicSink(abc.ABC):
             self.pause()
             self._disconnect()
         finally:
-            del _global_sink_singletons[(self.host, self.port)]
+            # pop, not del: close() may run again via the weakref finalizer at GC time.
+            _global_sink_singletons.pop((self.host, self.port), None)
 
             while self._buffers:
                 topic, writer = self._buffers.popitem()

--- a/src/sink/mqtt.py
+++ b/src/sink/mqtt.py
@@ -1,0 +1,200 @@
+"""Provide a topic sink that subscribes to an MQTT broker.
+
+Pure Python (paho-mqtt); no robotics middleware required. MQTT specifics handled here:
+
+- **Topic discovery**: MQTT brokers expose no topic-listing API, so the sink subscribes
+  to the ``#`` wildcard for a short window (``discovery_seconds``) and collects the
+  topics it sees -- retained messages arrive immediately, live ones during the window.
+  Topics not seen during discovery can still be subscribed to explicitly.
+- **Schemas**: payloads are JSON in the vast majority of deployments, so structure is
+  inferred from sampled payloads. Bare JSON scalars/arrays are wrapped as
+  ``{"value": ...}`` and non-JSON payloads as ``{"payload": "<text>"}``, so every topic
+  gets a queryable struct. (Sparkplug B / protobuf payloads are a future extension.)
+- **Timestamps**: MQTT messages carry no standard timestamp; arrival time is used
+  (the `TopicBufferWriter` default).
+"""
+
+import json
+import logging
+import threading
+import time
+from typing import Any
+
+import pyarrow as pa
+from paho.mqtt import client as paho
+
+from src.di import module
+from src.sink import base, buffer
+
+DISCOVERY_WILDCARD = "#"
+
+
+def normalize_payload(payload: bytes) -> dict[str, Any]:
+    """Normalize a raw MQTT payload into a JSON-serializable dictionary.
+
+    JSON objects pass through; bare JSON scalars and arrays are wrapped as
+    ``{"value": ...}``; anything that is not valid JSON becomes ``{"payload": "<text>"}``.
+    """
+    try:
+        decoded = json.loads(payload)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {"payload": payload.decode("utf-8", errors="replace")}
+    if isinstance(decoded, dict):
+        return decoded
+    return {"value": decoded}
+
+
+def infer_struct(samples: list[dict[str, Any]]) -> pa.StructType:
+    """Infer a PyArrow StructType from sampled payload dictionaries.
+
+    Fields are unified across all samples (PyArrow's from_pylist only looks at the
+    first row, so missing keys are padded with None to make them nullable fields).
+    """
+    if not samples:
+        raise ValueError("Cannot infer a schema from zero samples.")
+    keys: dict[str, None] = {}  # ordered union of keys across samples
+    for sample in samples:
+        keys.update(dict.fromkeys(sample))
+    padded = [{key: sample.get(key) for key in keys} for sample in samples]
+    table = pa.Table.from_pylist(padded)
+    return pa.struct(table.schema)
+
+
+class TopicSink(base.TopicSink):
+    """A topic sink that subscribes to an MQTT broker.
+
+    Works with any MQTT 3.1.1/5.0 broker (Mosquitto, EMQX, HiveMQ, AWS IoT Core, ...).
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        host: str,
+        port: int,
+        username: str | None = None,
+        password: str | None = None,
+        discovery_seconds: float = 2.0,
+        sample_size: int = 5,
+        schema_timeout_seconds: float = 5.0,
+        client_id: str | None = None,
+    ) -> None:
+        """Initialize the MQTT topic sink.
+
+        Args:
+            host (str): The hostname of the MQTT broker.
+            port (int): The port number of the MQTT broker (typically 1883).
+            username (str | None, optional): Username for broker authentication.
+            password (str | None, optional): Password for broker authentication.
+            discovery_seconds (float, optional): How long to listen on the ``#`` wildcard
+                to discover topics and sample payloads. Retained messages arrive
+                immediately; larger values catch more low-rate topics. Defaults to 2.0.
+            sample_size (int, optional): Maximum payload samples kept per topic for
+                schema inference. Defaults to 5.
+            schema_timeout_seconds (float, optional): When subscribing to a topic that was
+                not seen during discovery, how long to wait for a first message to infer
+                its schema before falling back to a raw-payload schema. Defaults to 5.0.
+            client_id (str | None, optional): MQTT client identifier. If None, a random
+                one is generated.
+
+        """
+        self._paho = paho.Client(
+            callback_api_version=paho.CallbackAPIVersion.VERSION2, client_id=client_id
+        )
+        if username is not None:
+            self._paho.username_pw_set(username, password)
+        self._paho.on_message = self._on_discovery_message
+
+        self._discovery_seconds = discovery_seconds
+        self._sample_size = sample_size
+        self._schema_timeout_seconds = schema_timeout_seconds
+
+        self._samples: dict[str, list[dict[str, Any]]] = {}
+        self._samples_lock = threading.Lock()
+        self._callbacks: dict[str, Any] = {}  # topic -> paho callback (for unsubscribe)
+
+        # The base __init__ calls _connect() before assigning self._host/_port,
+        # so keep our own copy of the broker address (same pattern as the ros bridges).
+        self._broker = (host, int(port))
+
+        super().__init__(host, port)  # establishes the connection, runs discovery
+
+    # -- paho wiring ---------------------------------------------------------------
+
+    def _connect(self) -> None:
+        if self._paho.is_connected():
+            return
+        self._paho.connect(self._broker[0], self._broker[1], keepalive=60)
+        self._paho.loop_start()  # background network thread
+
+    def _disconnect(self) -> None:
+        self._paho.loop_stop()
+        self._paho.disconnect()
+
+    def _on_discovery_message(self, client: object, userdata: object, message: object) -> None:
+        """Collect topic names and payload samples from the discovery wildcard."""
+        with self._samples_lock:
+            samples = self._samples.setdefault(message.topic, [])
+            if len(samples) < self._sample_size:
+                samples.append(normalize_payload(message.payload))
+
+    def _available_topics(self) -> list[str]:
+        """Discover topics by listening on the wildcard for the discovery window."""
+        self._paho.subscribe(DISCOVERY_WILDCARD)
+        time.sleep(self._discovery_seconds)
+        self._paho.unsubscribe(DISCOVERY_WILDCARD)
+        with self._samples_lock:
+            return sorted(self._samples)
+
+    def _sample(self, topic: str) -> list[dict[str, Any]]:
+        """Return payload samples for a topic, waiting briefly for one if unseen."""
+        with self._samples_lock:
+            if self._samples.get(topic):
+                return list(self._samples[topic])
+
+        # Topic unseen during discovery: listen for a first message to infer its schema.
+        self._paho.subscribe(topic)
+        deadline = time.monotonic() + self._schema_timeout_seconds
+        while time.monotonic() < deadline:
+            with self._samples_lock:
+                if self._samples.get(topic):
+                    return list(self._samples[topic])
+            time.sleep(0.05)
+        logging.warning(
+            "No message received on '%s' within %.1fs; using raw-payload schema",
+            topic,
+            self._schema_timeout_seconds,
+        )
+        return [{"payload": ""}]
+
+    def _type_name(self, topic: str) -> str:
+        return "mqtt/json"
+
+    def _definition(self, topic: str) -> str:
+        """Return a sample payload as the topic's human-readable definition."""
+        samples = self._sample(topic)
+        return json.dumps(samples[0], indent=2, default=str)
+
+    def _struct(self, topic: str) -> pa.StructType:
+        return infer_struct(self._sample(topic))
+
+    def _subscribe(self, writer: buffer.TopicBufferWriter) -> None:
+        def _on_message(client: object, userdata: object, message: object) -> None:
+            try:
+                writer.append(normalize_payload(message.payload))
+            except Exception:
+                # A malformed payload must not kill the subscription's network thread.
+                logging.exception("Failed to buffer message on topic '%s'", message.topic)
+
+        self._callbacks[writer.topic] = _on_message
+        self._paho.message_callback_add(writer.topic, _on_message)
+        self._paho.subscribe(writer.topic)
+
+    def _unsubscribe(self, writer: buffer.TopicBufferWriter) -> None:
+        if writer.topic in self._callbacks:
+            self._paho.message_callback_remove(writer.topic)
+            self._paho.unsubscribe(writer.topic)
+            del self._callbacks[writer.topic]
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = TopicSink

--- a/test/sink/test_mqtt.py
+++ b/test/sink/test_mqtt.py
@@ -1,0 +1,225 @@
+"""Tests for the MQTT topic sink, using a fake paho client (no broker needed)."""
+
+import json
+import pathlib
+from collections.abc import Callable, Iterator
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("paho")
+
+from settings import settings
+from src.pipeline.base import Cadence, OnEvent
+from src.sink import base as sink_base
+from src.sink import mqtt
+
+
+class FakePahoClient:
+    """A stand-in for paho.Client that delivers configured retained messages."""
+
+    def __init__(self, callback_api_version: object = None, client_id: str | None = None) -> None:
+        self.on_message = None
+        self.retained: dict[str, list[bytes]] = {}
+        self.subscriptions: list[str] = []
+        self.topic_callbacks: dict[str, object] = {}
+        self._connected = False
+
+    # -- connection ------------------------------------------------------------
+    def username_pw_set(self, username: str, password: str | None = None) -> None:
+        pass
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def connect(self, host: str, port: int, keepalive: int = 60) -> None:
+        self._connected = True
+
+    def loop_start(self) -> None:
+        pass
+
+    def loop_stop(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    # -- pub/sub ----------------------------------------------------------------
+    def subscribe(self, topic: str) -> None:
+        self.subscriptions.append(topic)
+        # Deliver retained messages synchronously, like a broker on subscribe.
+        for retained_topic, payloads in self.retained.items():
+            if topic in (mqtt.DISCOVERY_WILDCARD, retained_topic):
+                for payload in payloads:
+                    self.deliver(retained_topic, payload)
+
+    def unsubscribe(self, topic: str) -> None:
+        self.subscriptions = [s for s in self.subscriptions if s != topic]
+
+    def message_callback_add(self, topic: str, callback: object) -> None:
+        self.topic_callbacks[topic] = callback
+
+    def message_callback_remove(self, topic: str) -> None:
+        self.topic_callbacks.pop(topic, None)
+
+    def deliver(self, topic: str, payload: bytes) -> None:
+        """Simulate a message arriving from the broker."""
+        message = SimpleNamespace(topic=topic, payload=payload)
+        if topic in self.topic_callbacks:
+            self.topic_callbacks[topic](self, None, message)
+        elif self.on_message is not None:
+            self.on_message(self, None, message)
+
+
+_PORT_COUNTER = iter(range(20000, 30000))
+
+MakeSink = Callable[..., "mqtt.TopicSink"]
+
+
+@pytest.fixture
+def make_sink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[MakeSink]:
+    """Build an MQTT sink wired to a FakePahoClient, isolated per test."""
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
+    sink_base._global_sink_singletons.clear()
+
+    def _make(retained: dict[str, list[bytes]] | None = None, **kwargs: object) -> mqtt.TopicSink:
+        fake = FakePahoClient()
+        fake.retained = retained or {}
+        monkeypatch.setattr(mqtt.paho, "Client", lambda **_: fake)
+        sink = mqtt.TopicSink(
+            host="broker.test", port=next(_PORT_COUNTER), discovery_seconds=0.0, **kwargs
+        )
+        sink._fake = fake  # expose for assertions/injection
+        return sink
+
+    yield _make
+    sink_base._global_sink_singletons.clear()
+
+
+# -- pure helpers ------------------------------------------------------------------
+
+
+def test_normalize_payload_json_object() -> None:
+    assert mqtt.normalize_payload(b'{"temp": -18.5, "door": "closed"}') == {
+        "temp": -18.5,
+        "door": "closed",
+    }
+
+
+def test_normalize_payload_bare_scalar_and_array() -> None:
+    assert mqtt.normalize_payload(b"23.5") == {"value": 23.5}
+    assert mqtt.normalize_payload(b"[1, 2]") == {"value": [1, 2]}
+
+
+def test_normalize_payload_non_json_text() -> None:
+    assert mqtt.normalize_payload(b"ON") == {"payload": "ON"}
+
+
+def test_normalize_payload_invalid_utf8() -> None:
+    result = mqtt.normalize_payload(b"\xff\xfe")
+    assert "payload" in result
+
+
+def test_infer_struct_unifies_samples() -> None:
+    struct = mqtt.infer_struct([{"temp": -18.5}, {"temp": -17.0, "door": "open"}])
+    assert struct.field("temp").type == pa.float64()
+    assert struct.field("door").type == pa.string()
+
+
+def test_infer_struct_nested() -> None:
+    struct = mqtt.infer_struct([{"gps": {"lat": 1.0, "lon": 2.0}}])
+    assert pa.types.is_struct(struct.field("gps").type)
+
+
+def test_infer_struct_empty_raises() -> None:
+    with pytest.raises(ValueError, match="zero samples"):
+        mqtt.infer_struct([])
+
+
+# -- sink behavior ------------------------------------------------------------------
+
+
+def test_discovery_finds_retained_topics(make_sink: MakeSink) -> None:
+    sink = make_sink(
+        retained={
+            "freezer/1/status": [b'{"temp": -18.5}'],
+            "freezer/2/status": [b'{"temp": -17.9}'],
+        }
+    )
+    assert sink.available_topics == ["freezer/1/status", "freezer/2/status"]
+    # Discovery wildcard is released after the window.
+    assert mqtt.DISCOVERY_WILDCARD not in sink._fake.subscriptions
+
+
+def test_struct_and_definition_from_samples(make_sink: MakeSink) -> None:
+    sink = make_sink(retained={"freezer/1/status": [b'{"temp": -18.5, "door": "closed"}']})
+    struct = sink._struct("freezer/1/status")
+    assert struct.field("temp").type == pa.float64()
+    definition = sink._definition("freezer/1/status")
+    assert json.loads(definition) == {"temp": -18.5, "door": "closed"}
+
+
+def test_unseen_topic_falls_back_after_timeout(make_sink: MakeSink) -> None:
+    sink = make_sink(retained={}, schema_timeout_seconds=0.1)
+    struct = sink._struct("never/seen")
+    assert struct.field("payload").type == pa.string()
+
+
+def test_subscribe_buffers_messages(make_sink: MakeSink) -> None:
+    sink = make_sink(retained={"plant/pump": [b'{"pressure": 4.2}']})
+    sink.subscribe("plant/pump")
+
+    sink._fake.deliver("plant/pump", b'{"pressure": 3.9}')
+    sink._fake.deliver("plant/pump", b'{"pressure": 1.1}')
+
+    buffers = list(pathlib.Path(settings.CACHE_DIRECTORY).rglob("current.jsonl"))
+    assert len(buffers) == 1
+    lines = [json.loads(line) for line in buffers[0].read_text().splitlines()]
+    # The retained sample is delivered again on topic subscribe, then the two live ones.
+    assert [record["plant/pump"]["pressure"] for record in lines] == [4.2, 3.9, 1.1]
+    assert all(settings.TIMESTAMP_SECONDS_COLUMN_NAME in record for record in lines)
+
+
+def test_on_event_pipeline_fires_on_live_messages(make_sink: MakeSink) -> None:
+    # Retained message includes "t" since brokers re-deliver retained on subscribe.
+    sink = make_sink(retained={"freezer/1/status": [b'{"temp": -18.5, "t": 0.0}']})
+
+    pipeline = MagicMock()
+    pipeline.cadence = Cadence(
+        topic="freezer/1/status",
+        when=OnEvent(predicate="\"freezer/1/status\"['temp'] > -15"),
+    )
+    sink.subscribe(
+        "freezer/1/status",
+        pipeline=pipeline,
+        extract_timestamp=lambda message: message["t"],
+    )
+
+    for t, temp in ((1.0, -18.0), (2.0, -12.0), (3.0, -11.5), (4.0, -18.0)):
+        sink._fake.deliver(
+            "freezer/1/status", json.dumps({"temp": temp, "t": t}).encode()
+        )
+
+    # One rising edge at t=2.0 (sustained warm reading counts once).
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [2.0]
+
+
+def test_close_unsubscribes_and_disconnects(make_sink: MakeSink) -> None:
+    sink = make_sink(retained={"a/b": [b'{"x": 1}']})
+    sink.subscribe("a/b")
+    fake = sink._fake
+    sink.close()
+    assert "a/b" not in fake.topic_callbacks
+    assert not fake.is_connected()
+
+
+def test_guess_defaults() -> None:
+    from src.di.types import topic_sink
+
+    assert topic_sink.guess_port(topic_sink.TopicSink.MQTT) == 1883
+    assert topic_sink.guess_host(topic_sink.TopicSink.MQTT) in (
+        "localhost",
+        "host.docker.internal",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,9 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+iot = [
+    { name = "paho-mqtt" },
+]
 px4 = [
     { name = "gitpython" },
     { name = "pyulog" },
@@ -265,6 +268,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0,<9.0.0" },
     { name = "ruff", specifier = "==0.12.4" },
 ]
+iot = [{ name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" }]
 px4 = [
     { name = "gitpython", specifier = ">=3.1.0,<4.0.0" },
     { name = "pyulog", specifier = ">=1.2.0,<2.0.0" },
@@ -2050,6 +2054,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First slice of the **IoT lane**: Bagel can now subscribe to any MQTT 3.1.1/5.0 broker (Mosquitto, EMQX, HiveMQ, AWS IoT Core, …) and buffer topic messages locally, where every existing tool works on them — describe, DuckDB SQL, previews, and **live event-driven pipelines**. Pure Python, no ROS. The README's IoT row flips from "Coming soon…" to "MQTT (live)".

Stacked on #103. Merge order: #99 → #100 → #101 → #102 → #103 → #104.

## What's new

**`src/sink/mqtt.py`** (paho-mqtt, new `iot` dependency group)
- **Discovery**: MQTT has no topic-listing API, so the sink listens on the `#` wildcard for a short window (`discovery_seconds`) and collects topic names plus payload samples — retained messages arrive immediately. `list_live_topics` / `subscribe_live_topics` work unchanged.
- **Schemas**: payloads are JSON-first (the ecosystem norm): objects pass through, bare scalars become `{"value": …}`, non-JSON text becomes `{"payload": …}`. Structs are inferred from samples and unified across messages; a sample payload doubles as the topic's human-readable "definition". Topics unseen during discovery are sampled on demand with a timeout, falling back to a raw-payload schema.
- **Robustness**: a malformed payload logs instead of killing the subscription's network thread; `base.TopicSink.close()` is now idempotent (the weakref finalizer could re-run it after an explicit close).
- `TopicSink.MQTT` enum with `localhost:1883` defaults (`host.docker.internal` in containers).

**Packaging** — `Dockerfile.iot` + `iot` compose service, following the px4/betaflight pattern (dep group + dockerfile + service). Image built and smoke-tested.

**Docs** — `doc/runbooks/iot_mqtt.md`: discovery, schema/auth notes, a cold-chain edge-recording pipeline example (`on_event` + `forward` window + snapshot task), and a local mosquitto test-broker recipe.

## Verification

- **14 unit tests** against a fake paho client: payload normalization (object/scalar/array/text/invalid-UTF8), schema inference (field unification across samples — found and fixed that `pa.Table.from_pylist` only infers from the first row), discovery, buffering through `TopicBufferWriter`, live `OnEvent` wiring, unseen-topic fallback, close semantics.
- **Real broker end-to-end** (mosquitto in Docker): wildcard discovery found retained fleet topics; struct inferred as `{temp: double, door: string}`; a live `OnEvent` pipeline **fired exactly once** on a real temperature excursion (sustained warm reading correctly debounced); DuckDB queried the live-buffered data through the standard `bagel.sink` source.

Full suite: 118 passed + 1 skipped, ruff clean.

## Follow-ups

- Sparkplug B / protobuf payloads (industrial standard; we have protobuf muscle from the MCAP work)
- TLS / websocket transport options; wildcard subscriptions; timestamp-field extraction option
- Phase 2 of the IoT lane: TimescaleDB/Postgres source via DuckDB's postgres extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)
