### PR TITLE
Add InfluxDB 3 data source: every measurement is a topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Can’t wait to try it out? 👉 Check out the [Quickstart](#️-quickstart).
 | ------------ | ------------------------------ |
 | **Robotics** | ROS1, ROS2, MCAP (any profile) |
 | **Drones**   | PX4, ArduPilot, Betaflight     |
-| **IoT**      | MQTT (live), PostgreSQL / TimescaleDB |
+| **IoT**      | MQTT (live), PostgreSQL / TimescaleDB, InfluxDB 3 |
 
 ## 💬 What Can I Prompt?
 

--- a/doc/runbooks/iot_influxdb.md
+++ b/doc/runbooks/iot_influxdb.md
@@ -1,0 +1,55 @@
+# Chat with your InfluxDB 3 data
+
+Point Bagel at an InfluxDB 3 database (Core, Enterprise, or Cloud Dedicated) and every
+measurement becomes a queryable topic. Queries go over Arrow Flight SQL and return
+Arrow tables natively -- a direct fit for Bagel's DuckDB core, with no serialization
+in between.
+
+> InfluxDB 1.x/2.x are in maintenance upstream and are not supported; the Docker
+> `influxdb:latest` tag points to InfluxDB 3 Core from September 2026.
+
+## Connect
+
+The data source path is a URL:
+
+```
+influxdb://<token>@<host>:<port>/<database>
+```
+
+The port defaults to 8181 (InfluxDB 3 Core). The token can instead be passed via
+`args` (`{"token": "..."}`), which takes precedence over the URL.
+
+> Describe the data source `influxdb://my-token@influx.local:8181/telemetry`.
+
+- Each measurement (table) is a topic; InfluxDB's mandatory `time` column provides
+  timestamps.
+- Schemas come from the Arrow results directly, so types are always exact.
+
+## Ask questions
+
+> What's the max temperature in `readings` today?
+
+> Which devices reported humidity above 80% in the last 6 hours?
+
+Queries hit the database on every call -- results are always fresh.
+
+## Find events and extract windows
+
+> Preview keeping 60s before and after every reading above 30°C in `readings`.
+
+Then run a pipeline (`write_topics_to_file`, the S3 upload task, ...) to extract the
+windows -- event-windowed reduction over your time series.
+
+## Local test database
+
+```bash
+docker run -d --name influx -p 8181:8181 influxdb:3-core \
+  influxdb3 serve --node-id node0 --object-store memory --without-auth
+```
+
+## Notes and limits (v1)
+
+- InfluxDB 3 **Core** limits query time ranges to roughly the last 72 hours; use
+  Enterprise (free for home use) for longer historical windows, and prefer
+  time-bounded queries either way.
+- Read-only; writes are out of scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ardupilot = ["pymavlink >=2.4.0,<3.0.0"]
 betaflight = ["orangebox >=0.4.0,<1.0.0"]
 cloudini = ["wasmtime >=26.0.0", "numpy >=1.24.0,<3.0.0"]
 iot = [
+    "influxdb3-python>=0.10.0",
     "paho-mqtt>=2.1.0,<3.0.0",
 ]
 

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -24,12 +24,14 @@ class DataSource(Enum):
     PYARROW_JSON = "pyarrow.json"
     PYARROW_CSV = "pyarrow.csv"
     POSTGRES = "postgres"
+    INFLUXDB = "influxdb"
 
 
 # URL schemes mapped to their data source types.
 URL_SCHEMES = {
     "postgres": DataSource.POSTGRES,
     "postgresql": DataSource.POSTGRES,  # TimescaleDB uses standard postgres URLs
+    "influxdb": DataSource.INFLUXDB,  # InfluxDB 3 (SQL / Arrow Flight)
 }
 
 

--- a/src/message/influxdb.py
+++ b/src/message/influxdb.py
@@ -1,0 +1,122 @@
+"""A message dataset for InfluxDB 3 databases.
+
+Overrides `to_duckdb`: InfluxDB returns Arrow tables over Flight SQL, which register
+directly into DuckDB -- no serialization step and no Arrow-file caching (the database
+is the source of truth, so every query sees fresh data). The relation matches the
+standard contract: a `timestamp_seconds` column plus one struct column per topic.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import duckdb
+import pyarrow as pa
+
+from settings import settings
+from src.di import module
+from src.message import base
+from src.source.base import SourceFactory
+from src.source.influxdb import InfluxDatabase
+from src.source.postgres import quote_identifier
+from src.topic.base import TopicRegistry
+
+
+class MessageDataset(base.MessageDataset):
+    """A message dataset for InfluxDB 3 databases."""
+
+    def __init__(self) -> None:
+        """Initialize the dataset (no Arrow-file caching; the DB is authoritative)."""
+        super().__init__(use_cache=False)
+
+    def _topic_arrow(
+        self,
+        data_source: InfluxDatabase,
+        topic: str,
+        start_seconds: float | None,
+        end_seconds: float | None,
+    ) -> pa.Table:
+        """Fetch one measurement as an Arrow table, filtered to the time range."""
+        conditions = ["TRUE"]
+        if start_seconds is not None:
+            conditions.append(f"time >= to_timestamp({start_seconds})")
+        if end_seconds is not None:
+            conditions.append(f"time <= to_timestamp({end_seconds})")
+        return data_source.client.query(
+            f'SELECT * FROM "{topic}" WHERE {" AND ".join(conditions)} ORDER BY time'  # noqa: S608
+        )
+
+    def _topic_relation(
+        self,
+        data_source: InfluxDatabase,
+        topic: str,
+        start_seconds: float | None,
+        end_seconds: float | None,
+        empty: bool = False,
+    ) -> duckdb.DuckDBPyRelation:
+        """Build the `timestamp_seconds + <topic> struct` relation for one measurement."""
+        if empty:
+            arrow_table = data_source.client.query(f'SELECT * FROM "{topic}" LIMIT 0')  # noqa: S608
+        else:
+            arrow_table = self._topic_arrow(data_source, topic, start_seconds, end_seconds)
+
+        packed = ", ".join(
+            f"{quote_identifier(name)} := {quote_identifier(name)}"
+            for name in arrow_table.schema.names
+        )
+        relation = duckdb.from_arrow(arrow_table)
+        return relation.project(
+            f'epoch("time")::DOUBLE AS "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}", '
+            f"struct_pack({packed}) AS {quote_identifier(topic)}"
+        )
+
+    def to_duckdb(  # noqa: PLR0913
+        self,
+        factory: SourceFactory,
+        registry: TopicRegistry,
+        topics: list[str] | None = None,
+        start_seconds: float | None = None,
+        end_seconds: float | None = None,
+        ffill: bool = False,
+        empty: bool = False,
+    ) -> duckdb.DuckDBPyRelation:
+        """Return a DuckDB relation over the measurements' Arrow data."""
+        data_source = factory.build()
+        topics = topics or registry.available_topics(data_source)
+
+        combined = None
+        for topic in topics:
+            relation = self._topic_relation(data_source, topic, start_seconds, end_seconds, empty)
+            # union() on projections with differing struct columns lines up by position,
+            # so register each relation and combine with UNION ALL BY NAME in SQL.
+            alias = f"influx_{abs(hash((data_source.database, topic))) % 10**8}"
+            duckdb.register(alias, relation.arrow())
+            select = f'SELECT * FROM "{alias}"'  # noqa: S608
+            combined = select if combined is None else f"{combined} UNION ALL BY NAME {select}"
+
+        return duckdb.sql(
+            f'{combined} ORDER BY "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}"'
+        )
+
+    def _messages(
+        self,
+        data_source: InfluxDatabase,
+        topics: list[str],
+        start_seconds_inclusive: float | None,
+        end_seconds_inclusive: float | None,
+    ) -> Iterator[tuple[str, float, object]]:
+        """Yield (topic, timestamp seconds, row dict) tuples from the database."""
+        for topic in topics:
+            relation = self._topic_relation(
+                data_source, topic, start_seconds_inclusive, end_seconds_inclusive
+            )
+            for timestamp_seconds, row in relation.fetchall():
+                yield topic, float(timestamp_seconds), row
+
+    def _to_json(self, message: object, struct: pa.StructType) -> dict[str, Any]:
+        """Rows come back from DuckDB as dictionaries already."""
+        return dict(message)
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = MessageDataset

--- a/src/source/influxdb.py
+++ b/src/source/influxdb.py
@@ -1,0 +1,147 @@
+"""A data source factory for InfluxDB 3 databases.
+
+Connects via `influxdb3-python` (Arrow Flight SQL), which returns PyArrow tables --
+a direct fit for Bagel's Arrow/DuckDB core. Each measurement (table) is a Bagel
+"topic"; InfluxDB 3's mandatory `time` column provides timestamps.
+
+The data source `path` is a URL of the form::
+
+    influxdb://<token>@<host>:<port>/<database>
+
+The token may instead be passed via `args` (``{"token": "..."}``), which takes
+precedence over the URL. The default port is 8181 (InfluxDB 3 Core). Targets
+InfluxDB 3 (Core/Enterprise/Cloud Dedicated); v1/v2 are in maintenance upstream.
+"""
+
+import functools
+import uuid
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from influxdb_client_3 import InfluxDBClient3
+from pydantic import BaseModel
+
+from src.di import module
+
+DEFAULT_PORT = 8181  # InfluxDB 3 Core
+
+
+def parse_url(url: str) -> dict[str, str]:
+    """Parse an ``influxdb://token@host:port/database`` URL.
+
+    Returns:
+        A dict with ``host`` (scheme://host:port for the client), ``database``,
+        and ``token`` (possibly empty).
+
+    Raises:
+        ValueError: If the URL has no host or no database path segment.
+
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "influxdb":
+        raise ValueError(f"Expected an influxdb:// URL, got: {url}")
+    if not parsed.hostname:
+        raise ValueError(f"Missing host in InfluxDB URL: {url}")
+    database = parsed.path.lstrip("/")
+    if not database:
+        raise ValueError(
+            f"Missing database in InfluxDB URL: {url} "
+            "(expected influxdb://token@host:port/database)"
+        )
+    port = parsed.port or DEFAULT_PORT
+    return {
+        "host": f"http://{parsed.hostname}:{port}",
+        "database": database,
+        "token": unquote(parsed.username) if parsed.username else "",
+    }
+
+
+@functools.lru_cache
+def client(host: str, database: str, token: str) -> InfluxDBClient3:
+    """Return a cached InfluxDB client for the given connection parameters."""
+    return InfluxDBClient3(host=host, database=database, token=token)
+
+
+class InfluxDatabase(BaseModel):
+    """Represent an InfluxDB 3 data source."""
+
+    host: str
+    database: str
+    token: str = ""
+
+    @property
+    def client(self) -> InfluxDBClient3:
+        """The (cached) InfluxDB client."""
+        return client(self.host, self.database, self.token)
+
+    def tables(self) -> list[str]:
+        """Return the measurement (table) names in the database."""
+        result = self.client.query(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'iox' ORDER BY table_name"
+        )
+        return result["table_name"].to_pylist()
+
+    def __hash__(self) -> int:
+        """Needed for functools caching."""
+        return hash((self.host, self.database, self.token))
+
+
+class SourceFactory:
+    """A data source factory for InfluxDB 3 databases."""
+
+    def __init__(self, path: str, token: str | None = None) -> None:
+        """Initialize the InfluxDB data source factory.
+
+        Args:
+            path (str): The connection URL, ``influxdb://<token>@<host>:<port>/<database>``.
+            token (str | None, optional): Authentication token; overrides any token in
+                the URL. Defaults to None.
+
+        Raises:
+            ValueError: If the URL is malformed.
+            ConnectionError: If the database cannot be reached.
+
+        """
+        parts = parse_url(path)
+        self._url = path
+        self._database = InfluxDatabase(
+            host=parts["host"],
+            database=parts["database"],
+            token=token or parts["token"],
+        )
+        try:
+            self._database.tables()
+        except Exception as error:
+            raise ConnectionError(f"Cannot connect to '{parts['host']}': {error}") from error
+
+    @property
+    def path(self) -> str:
+        """The connection URL."""
+        return self._url
+
+    @property
+    def uuid(self) -> str:
+        """A unique identifier for the data source."""
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, self._url))
+
+    def build(self) -> InfluxDatabase:
+        """Return an InfluxDatabase object."""
+        return self._database
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return metadata about the database: measurements and their row counts."""
+        database = self.build()
+        tables = []
+        for table in database.tables():
+            count_result = database.client.query(
+                f'SELECT COUNT(*) AS n FROM "{table}"'  # noqa: S608
+            )
+            tables.append({"topic": table, "row_count": count_result["n"][0].as_py()})
+        return {"host": database.host, "database": database.database, "tables": tables}
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = SourceFactory

--- a/src/topic/influxdb.py
+++ b/src/topic/influxdb.py
@@ -1,0 +1,52 @@
+"""A topic registry for InfluxDB 3 databases.
+
+Each measurement (table) is a topic. Schemas come from a LIMIT-0 SQL query's Arrow
+result, so types are exact -- InfluxDB 3 returns Arrow natively over Flight SQL.
+"""
+
+import pyarrow as pa
+
+from src.di import module
+from src.source.influxdb import InfluxDatabase
+from src.topic import base
+
+
+class TopicRegistry(base.TopicRegistry):
+    """A topic registry for InfluxDB 3 databases."""
+
+    def available_topics(self, data_source: InfluxDatabase) -> list[str]:
+        """Return a list of available topic (measurement) names."""
+        return data_source.tables()
+
+    def _require_topic(self, topic: str, data_source: InfluxDatabase) -> None:
+        if topic not in data_source.tables():
+            raise base.TopicNotFoundError(topic)
+
+    def native_type_name(self, topic: str, data_source: InfluxDatabase) -> str:
+        """Return the native type name for the given topic."""
+        self._require_topic(topic, data_source)
+        return "influxdb/measurement"
+
+    def message_count(self, topic: str, data_source: InfluxDatabase) -> int:
+        """Return the number of rows for the given topic."""
+        self._require_topic(topic, data_source)
+        result = data_source.client.query(f'SELECT COUNT(*) AS n FROM "{topic}"')  # noqa: S608
+        return result["n"][0].as_py()
+
+    def struct(self, topic: str, data_source: InfluxDatabase) -> pa.StructType:
+        """Return the PyArrow StructType for the given topic (all columns)."""
+        self._require_topic(topic, data_source)
+        empty = data_source.client.query(f'SELECT * FROM "{topic}" LIMIT 0')  # noqa: S608
+        return pa.struct(empty.schema)
+
+    def describe(self, topic: str, data_source: InfluxDatabase) -> str:
+        """Return a human-readable description: the measurement's columns and types."""
+        struct = self.struct(topic, data_source)
+        lines = [f"measurement {topic} (timestamp column: time)"]
+        lines += [f"  {field.name}: {field.type}" for field in struct]
+        return "\n".join(lines)
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = TopicRegistry

--- a/test/source/test_influxdb.py
+++ b/test/source/test_influxdb.py
@@ -1,0 +1,108 @@
+"""Tests for the InfluxDB 3 data source.
+
+Pure tests run everywhere. The end-to-end tests require a live InfluxDB 3 and are
+gated on `BAGEL_INFLUXDB_TEST_URL`, e.g.:
+
+    docker run -d --name bagel-influx -p 8181:8181 influxdb:3-core \
+        influxdb3 serve --node-id node0 --object-store memory --without-auth
+    BAGEL_INFLUXDB_TEST_URL=influxdb://localhost:8181/telemetry \
+        uv run pytest test/source/test_influxdb.py
+"""
+
+import os
+
+import pytest
+
+pytest.importorskip("influxdb_client_3")
+
+from src.di.types import data_source
+from src.source import influxdb
+
+INFLUX_URL = os.environ.get("BAGEL_INFLUXDB_TEST_URL")
+
+requires_db = pytest.mark.skipif(
+    not INFLUX_URL, reason="set BAGEL_INFLUXDB_TEST_URL to run against a live InfluxDB 3"
+)
+
+
+# -- pure ---------------------------------------------------------------------------
+
+
+def test_influxdb_urls_resolve() -> None:
+    assert (
+        data_source.resolve("influxdb://tok@h:8181/telemetry")
+        == data_source.DataSource.INFLUXDB
+    )
+
+
+def test_parse_url_with_token_and_port() -> None:
+    parts = influxdb.parse_url("influxdb://s3cr3t@influx.local:8282/fleet")
+    assert parts == {"host": "http://influx.local:8282", "database": "fleet", "token": "s3cr3t"}
+
+
+def test_parse_url_defaults_port_and_allows_no_token() -> None:
+    parts = influxdb.parse_url("influxdb://influx.local/fleet")
+    assert parts["host"] == "http://influx.local:8181"
+    assert parts["token"] == ""
+
+
+def test_parse_url_unquotes_token() -> None:
+    parts = influxdb.parse_url("influxdb://a%2Fb@h/db")
+    assert parts["token"] == "a/b"  # noqa: S105 -- not a real credential
+
+
+def test_parse_url_requires_database() -> None:
+    with pytest.raises(ValueError, match="database"):
+        influxdb.parse_url("influxdb://h:8181")
+
+
+def test_parse_url_requires_influxdb_scheme() -> None:
+    with pytest.raises(ValueError, match="influxdb://"):
+        influxdb.parse_url("postgres://h/db")
+
+
+# -- live database ------------------------------------------------------------------
+
+
+@requires_db
+def test_end_to_end_over_live_influxdb() -> None:
+    import server
+    from src.di import module
+
+    factory = module.provide("src.source.influxdb", {"path": INFLUX_URL})
+    registry = module.provide("src.topic.influxdb", {})
+    database = factory.build()
+
+    topics = registry.available_topics(database)
+    assert "readings" in topics
+    assert registry.message_count("readings", database) > 0
+    struct = registry.struct("readings", database)
+    assert "temp" in struct.names
+    assert "time" in struct.names
+    assert "readings" in registry.describe("readings", database)
+
+    rows = server.query_messages(
+        path=INFLUX_URL,
+        sql_statement=(
+            'SELECT COUNT(*) AS n, MAX("readings"[\'temp\']) AS max_temp FROM "readings"'
+        ),
+        topic="readings",
+    )
+    assert rows[0]["n"] > 0
+    assert rows[0]["max_temp"] is not None
+
+
+@requires_db
+def test_preview_pipeline_detects_events_in_influxdb() -> None:
+    import server
+
+    result = server.preview_pipeline(
+        path=INFLUX_URL,
+        event_topic="readings",
+        predicate="\"readings\"['temp'] > 30",
+        pre_seconds=60.0,
+        post_seconds=60.0,
+        debounce_seconds=120.0,
+    )
+    assert result["event_count"] == 2  # seeded by the harness
+    assert 0 < result["kept_fraction"] < 1

--- a/uv.lock
+++ b/uv.lock
@@ -207,6 +207,7 @@ dev = [
     { name = "ruff" },
 ]
 iot = [
+    { name = "influxdb3-python" },
     { name = "paho-mqtt" },
 ]
 px4 = [
@@ -268,7 +269,10 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0,<9.0.0" },
     { name = "ruff", specifier = "==0.12.4" },
 ]
-iot = [{ name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" }]
+iot = [
+    { name = "influxdb3-python", specifier = ">=0.10.0" },
+    { name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" },
+]
 px4 = [
     { name = "gitpython", specifier = ">=3.1.0,<4.0.0" },
     { name = "pyulog", specifier = ">=1.2.0,<2.0.0" },
@@ -1052,6 +1056,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/87/156b374ff6578062965afe30cc57627d35234369b3336cf244b240c8d8e6/incremental-24.7.2.tar.gz", hash = "sha256:fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9", size = 28157, upload-time = "2024-07-29T20:03:55.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/38/221e5b2ae676a3938c2c1919131410c342b6efc2baffeda395dd66eeca8f/incremental-24.7.2-py3-none-any.whl", hash = "sha256:8cb2c3431530bec48ad70513931a760f446ad6c25e8333ca5d95e24b0ed7b8fe", size = 20516, upload-time = "2024-07-29T20:03:53.677Z" },
+]
+
+[[package]]
+name = "influxdb3-python"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "pyarrow" },
+    { name = "python-dateutil" },
+    { name = "reactivex" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f0/3fb234e83316e439a91d4d7ee5a2f569b9b81e5a709618c4168dca3a087b/influxdb3_python-0.20.0.tar.gz", hash = "sha256:f1e28c2f4f244d48006beeb82be7aea82ebdd3b3e1807250d124b6f1d53c5943", size = 102084, upload-time = "2026-06-11T06:49:53.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/2f/06961cdb1d38d0cdb3c6876970db227e69824a293896af6d1eb983fa1534/influxdb3_python-0.20.0-py3-none-any.whl", hash = "sha256:0914f05c2ed9b96f2962fb3d410068dda9c411b562dab22fae1d6c6599a37927", size = 86330, upload-time = "2026-06-11T06:49:52.016Z" },
 ]
 
 [[package]]
@@ -2761,6 +2781,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/ba/64af397e0f421453dc68e31d5e0784d554bf39013a2de0872056e96e58af/pyzmq-27.0.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14fe7aaac86e4e93ea779a821967360c781d7ac5115b3f1a171ced77065a0174", size = 567400, upload-time = "2025-06-13T14:08:46.855Z" },
     { url = "https://files.pythonhosted.org/packages/63/87/ec956cbe98809270b59a22891d5758edae147a258e658bf3024a8254c855/pyzmq-27.0.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ad0562d4e6abb785be3e4dd68599c41be821b521da38c402bc9ab2a8e7ebc7e", size = 747031, upload-time = "2025-06-13T14:08:48.419Z" },
     { url = "https://files.pythonhosted.org/packages/be/8a/4a3764a68abc02e2fbb0668d225b6fda5cd39586dd099cee8b2ed6ab0452/pyzmq-27.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:9df43a2459cd3a3563404c1456b2c4c69564daa7dbaf15724c09821a3329ce46", size = 544726, upload-time = "2025-06-13T14:08:49.903Z" },
+]
+
+[[package]]
+name = "reactivex"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/af/38a4b62468e4c5bd50acf511d86fe62e65a466aa6abb55b1d59a4a9e57f3/reactivex-4.1.0.tar.gz", hash = "sha256:c7499e3c802bccaa20839b3e17355a7d939573fded3f38ba3d4796278a169a3d", size = 113482, upload-time = "2025-11-05T21:44:24.557Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/9e/3c2f5d3abb6c5d82f7696e1e3c69b7279049e928596ce82ed25ca97a08f3/reactivex-4.1.0-py3-none-any.whl", hash = "sha256:485750ec8d9b34bcc8ff4318971d234dc4f595058a1b4435a74aefef4b2bc9bd", size = 218588, upload-time = "2025-11-05T21:44:23.015Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

IoT lane, **phase 3**: point Bagel at `influxdb://<token>@<host>:<port>/<database>` and chat with an InfluxDB 3 database — describe, DuckDB SQL, event previews, and event-windowed extraction, with every measurement exposed as a topic.

Stacked on #105. Merge order: #99 → … → #105 → #106.

## Why InfluxDB 3 only (researched decision)

- InfluxDB **v1/v2 are in maintenance** upstream and Flux is deprecated; the Docker `influxdb:latest` tag [flips to 3 Core in September 2026](https://docs.influxdata.com/influxdb3/which-influxdb-3/).
- The v3 client (`influxdb3-python`, new `iot`-group dep) returns **PyArrow tables natively over Arrow Flight SQL** — results register straight into DuckDB with zero serialization, the cleanest possible fit for Bagel's Arrow core ([query docs](https://docs.influxdata.com/influxdb3/core/get-started/query/)).
- Caveat documented in the runbook: [3 Core limits query ranges to ~72 hours](https://www.influxdata.com/blog/influxdb3-open-source-public-alpha-jan-27/) (Enterprise lifts it and is free for home use); time-bounded queries are Bagel's idiom anyway.
- v2 support: demand-driven follow-up only.

## What's new

- `resolve()` maps the `influxdb://` scheme to `DataSource.INFLUXDB`; the URL carries host/database/token (token overridable via `args`), default port 8181.
- `src/source/influxdb.py` — measurements (iox tables) as topics, cached client, metadata with row counts, actionable `ConnectionError` on bad targets.
- `src/topic/influxdb.py` — structs from a LIMIT-0 query's Arrow schema; the mandatory `time` column provides timestamps.
- `src/message/influxdb.py` — `to_duckdb` fetches Arrow per measurement, projects `epoch(time) AS timestamp_seconds` + `struct_pack(...) AS "<measurement>"`, combines topics with `UNION ALL BY NAME`. No Arrow-file caching — the database is authoritative.
- Runbook `doc/runbooks/iot_influxdb.md`; README IoT row now **"MQTT (live), PostgreSQL / TimescaleDB, InfluxDB 3"**; `iot` image rebuilt with the client.

## Verification

Against a **live `influxdb:3-core` container** (tests gated on `BAGEL_INFLUXDB_TEST_URL`): topics / struct / describe / `query_messages` end to end, and `preview_pipeline` detected **exactly the two seeded heat events** over Flight SQL. Pure URL-parsing/resolution tests run everywhere: **133 passed locally, ruff clean**.

```bash
docker run -d --name bagel-influx -p 8181:8181 influxdb:3-core \
  influxdb3 serve --node-id node0 --object-store memory --without-auth
BAGEL_INFLUXDB_TEST_URL=influxdb://localhost:8181/telemetry \
  uv run pytest test/source/test_influxdb.py
```

## Follow-ups

- Sparkplug B payloads for the MQTT sink (industrial standard)
- InfluxDB v2 support if users ask
- Prometheus source (IoT phase 4, likely deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
