### PR TITLE
Add MQTT transport, TLS, and payload-timestamp options

### DIFF
--- a/doc/runbooks/iot_mqtt.md
+++ b/doc/runbooks/iot_mqtt.md
@@ -35,8 +35,11 @@ non-JSON text becomes `{"payload": "<text>"}`. A sample payload doubles as the t
 "definition" when you ask Bagel to describe it. Sparkplug B / protobuf payloads are a
 planned extension.
 
-Authentication: pass `username`/`password` via the `args` of `subscribe_live_topics`
-(they are forwarded to the sink constructor). Timestamps use message arrival time.
+Authentication and transport: pass `username`/`password`, `tls: true` (with optional
+`tls_ca_certs`), and `transport: "websockets"` via the `args` of `subscribe_live_topics`
+(they are forwarded to the sink constructor). Timestamps default to message arrival
+time; if your payloads carry one, set `timestamp_field` (and `timestamp_unit`:
+second/millisecond/microsecond/nanosecond) to use it instead.
 
 ## Live edge-recording
 

--- a/src/sink/mqtt.py
+++ b/src/sink/mqtt.py
@@ -18,15 +18,25 @@ import json
 import logging
 import threading
 import time
+from collections.abc import Callable
 from typing import Any
 
 import pyarrow as pa
 from paho.mqtt import client as paho
 
+from settings import settings
 from src.di import module
+from src.pipeline.base import Pipeline
 from src.sink import base, buffer
 
 DISCOVERY_WILDCARD = "#"
+
+TIMESTAMP_DIVISORS = {
+    "second": 1.0,
+    "millisecond": 1e3,
+    "microsecond": 1e6,
+    "nanosecond": 1e9,
+}
 
 
 def normalize_payload(payload: bytes) -> dict[str, Any]:
@@ -76,12 +86,19 @@ class TopicSink(base.TopicSink):
         sample_size: int = 5,
         schema_timeout_seconds: float = 5.0,
         client_id: str | None = None,
+        transport: str = "tcp",
+        tls: bool = False,
+        tls_ca_certs: str | None = None,
+        tls_insecure: bool = False,
+        timestamp_field: str | None = None,
+        timestamp_unit: str = "second",
     ) -> None:
         """Initialize the MQTT topic sink.
 
         Args:
             host (str): The hostname of the MQTT broker.
-            port (int): The port number of the MQTT broker (typically 1883).
+            port (int): The port number of the MQTT broker (typically 1883; 8883 for TLS;
+                often 443/8083 for websockets).
             username (str | None, optional): Username for broker authentication.
             password (str | None, optional): Password for broker authentication.
             discovery_seconds (float, optional): How long to listen on the ``#`` wildcard
@@ -94,18 +111,50 @@ class TopicSink(base.TopicSink):
                 its schema before falling back to a raw-payload schema. Defaults to 5.0.
             client_id (str | None, optional): MQTT client identifier. If None, a random
                 one is generated.
+            transport (str, optional): "tcp" or "websockets" (for brokers like AWS IoT
+                Core behind websockets). Defaults to "tcp".
+            tls (bool, optional): If True, connect over TLS. Defaults to False.
+            tls_ca_certs (str | None, optional): Path to a CA bundle for TLS. If None,
+                the system defaults are used. Defaults to None.
+            tls_insecure (bool, optional): If True, skip server certificate verification
+                (testing only). Defaults to False.
+            timestamp_field (str | None, optional): A payload field carrying the message
+                timestamp (e.g. "ts"). If set, buffered messages use it instead of
+                arrival time; messages missing the field fall back to arrival time.
+                Defaults to None (arrival time).
+            timestamp_unit (str, optional): The unit of `timestamp_field`: "second",
+                "millisecond", "microsecond", or "nanosecond". Defaults to "second".
+
+        Raises:
+            ValueError: If 'transport' or 'timestamp_unit' is invalid.
 
         """
+        if transport not in ("tcp", "websockets"):
+            raise ValueError(f"'transport' must be 'tcp' or 'websockets', got {transport!r}.")
+        if timestamp_unit not in TIMESTAMP_DIVISORS:
+            raise ValueError(
+                f"'timestamp_unit' must be one of {sorted(TIMESTAMP_DIVISORS)}, "
+                f"got {timestamp_unit!r}."
+            )
+
         self._paho = paho.Client(
-            callback_api_version=paho.CallbackAPIVersion.VERSION2, client_id=client_id
+            callback_api_version=paho.CallbackAPIVersion.VERSION2,
+            client_id=client_id,
+            transport=transport,
         )
         if username is not None:
             self._paho.username_pw_set(username, password)
+        if tls:
+            self._paho.tls_set(ca_certs=tls_ca_certs)
+            if tls_insecure:
+                self._paho.tls_insecure_set(True)
         self._paho.on_message = self._on_discovery_message
 
         self._discovery_seconds = discovery_seconds
         self._sample_size = sample_size
         self._schema_timeout_seconds = schema_timeout_seconds
+        self._timestamp_field = timestamp_field
+        self._timestamp_divisor = TIMESTAMP_DIVISORS[timestamp_unit]
 
         self._samples: dict[str, list[dict[str, Any]]] = {}
         self._samples_lock = threading.Lock()
@@ -175,6 +224,32 @@ class TopicSink(base.TopicSink):
 
     def _struct(self, topic: str) -> pa.StructType:
         return infer_struct(self._sample(topic))
+
+    def _extract_payload_timestamp(self, message: dict[str, Any]) -> float:
+        """Read the configured timestamp field, falling back to arrival time."""
+        value = message.get(self._timestamp_field)
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            return float(value) / self._timestamp_divisor
+        return time.time()
+
+    def subscribe(
+        self,
+        topic: str,
+        pipeline: Pipeline | None = None,
+        overwrite: bool = False,
+        buffer_size_bytes: int | None = settings.JSONL_BUFFER_SIZE_PER_TOPIC_BYTES,
+        extract_timestamp: Callable[[dict[str, Any]], float] | None = None,
+    ) -> None:
+        """Subscribe to a topic, defaulting timestamps to the configured payload field."""
+        if extract_timestamp is None and self._timestamp_field is not None:
+            extract_timestamp = self._extract_payload_timestamp
+        super().subscribe(
+            topic,
+            pipeline=pipeline,
+            overwrite=overwrite,
+            buffer_size_bytes=buffer_size_bytes,
+            extract_timestamp=extract_timestamp,
+        )
 
     def _subscribe(self, writer: buffer.TopicBufferWriter) -> None:
         def _on_message(client: object, userdata: object, message: object) -> None:

--- a/test/sink/test_mqtt.py
+++ b/test/sink/test_mqtt.py
@@ -223,3 +223,67 @@ def test_guess_defaults() -> None:
         "localhost",
         "host.docker.internal",
     )
+
+
+# -- extras: TLS / transport / timestamp field ---------------------------------------
+
+
+def test_websockets_transport_and_tls_configure_paho(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
+    captured: dict[str, object] = {}
+
+    class RecordingFake(FakePahoClient):
+        def __init__(self, callback_api_version: object = None, client_id: str | None = None,
+                     transport: str = "tcp") -> None:
+            super().__init__(callback_api_version, client_id)
+            captured["transport"] = transport
+            self.tls_args: dict[str, object] | None = None
+
+        def tls_set(self, ca_certs: str | None = None) -> None:
+            captured["ca_certs"] = ca_certs
+
+        def tls_insecure_set(self, value: bool) -> None:
+            captured["tls_insecure"] = value
+
+    monkeypatch.setattr(mqtt.paho, "Client", RecordingFake)
+    mqtt.TopicSink(
+        host="broker.test",
+        port=next(_PORT_COUNTER),
+        discovery_seconds=0.0,
+        transport="websockets",
+        tls=True,
+        tls_ca_certs="/etc/ssl/ca.pem",
+        tls_insecure=True,
+    )
+    assert captured == {
+        "transport": "websockets",
+        "ca_certs": "/etc/ssl/ca.pem",
+        "tls_insecure": True,
+    }
+
+
+def test_invalid_transport_and_unit_rejected() -> None:
+    with pytest.raises(ValueError, match="transport"):
+        mqtt.TopicSink(host="h", port=next(_PORT_COUNTER), transport="carrier-pigeon")
+    with pytest.raises(ValueError, match="timestamp_unit"):
+        mqtt.TopicSink(host="h", port=next(_PORT_COUNTER), timestamp_unit="fortnight")
+
+
+def test_timestamp_field_used_for_buffered_messages(make_sink: MakeSink) -> None:
+    sink = make_sink(
+        retained={"plant/pump": [b'{"pressure": 4.2, "ts": 1700000000500}']},
+        timestamp_field="ts",
+        timestamp_unit="millisecond",
+    )
+    sink.subscribe("plant/pump")
+    sink._fake.deliver("plant/pump", b'{"pressure": 3.9, "ts": 1700000001000}')
+    sink._fake.deliver("plant/pump", b'{"pressure": 3.7}')  # missing field -> arrival time
+
+    buffers = list(pathlib.Path(settings.CACHE_DIRECTORY).rglob("current.jsonl"))
+    lines = [json.loads(line) for line in buffers[0].read_text().splitlines()]
+    stamps = [record[settings.TIMESTAMP_SECONDS_COLUMN_NAME] for record in lines]
+    assert stamps[0] == pytest.approx(1700000000.5)  # retained, redelivered on subscribe
+    assert stamps[1] == pytest.approx(1700000001.0)
+    assert stamps[2] > 1750000000  # fell back to (much later) arrival time


### PR DESCRIPTION
Polish on #104's MQTT sink, stacked on #106.

- **`transport: "websockets"`** — brokers behind websockets (AWS IoT Core et al.)
- **TLS** — `tls` / `tls_ca_certs` / `tls_insecure` (testing only); invalid options raise clear errors
- **`timestamp_field` + `timestamp_unit`** — use a timestamp carried in the payload (second/milli/micro/nano) instead of arrival time, with per-message fallback to arrival time when the field is missing or non-numeric. Wired as the default `extract_timestamp` via a `subscribe()` override, so explicit extractors still win.

Deliberately **not** included: wildcard subscriptions (needs per-matched-topic buffer routing — tracked as a follow-up).

Tests: paho configuration capture through a recording fake, option validation, and buffered-timestamp behavior including the fallback path. 136 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)