### PR TITLE
Make jsonschema-encoded MCAP topics queryable

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -65,8 +65,8 @@ and `save_pipeline` (persist a config as YAML for reuse).
 
 ## Reduce an MCAP bag
 
-MCAP is a first-class format: any `.mcap` file or directory of them (ros1, ros2, or
-protobuf profiles) works in **every** Bagel image -- no ROS required. The reduce module
+MCAP is a first-class format: any `.mcap` file or directory of them (ros1, ros2,
+protobuf, or json profiles) works in **every** Bagel image -- no ROS required. The reduce module
 copies raw message records within the kept windows -- no decode/re-encode -- so it needs
 no rosidl typesupport:
 

--- a/src/message/mcap.py
+++ b/src/message/mcap.py
@@ -1,14 +1,17 @@
 """A message dataset for MCAP files, independent of any robotics middleware.
 
-Messages are decoded by the registered decoder factories (ros1, ros2, protobuf),
-which parse the schema embedded in the MCAP file -- no ROS installation needed.
+Messages are decoded per channel encoding: ros1/ros2/protobuf via the registered
+decoder factories (which parse the schema embedded in the file), and json-encoded
+channels via plain ``json.loads`` -- no ROS installation needed for any of them.
 """
 
-from collections.abc import Iterator
+import json
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import pyarrow as pa
 from mcap.reader import make_reader
+from mcap.records import Channel, Schema
 from mcap_protobuf.decoder import DecoderFactory as ProtobufDecoderFactory
 from mcap_ros1.decoder import DecoderFactory as Ros1DecoderFactory
 from mcap_ros2.decoder import DecoderFactory as Ros2DecoderFactory
@@ -17,6 +20,7 @@ from src.di import module
 from src.message import base
 from src.message.ros2 import convert
 from src.source.mcap import McapBag
+from src.topic.base import UnsupportedEncodingError
 
 NANOSECOND = 1
 SECOND = 1_000_000_000 * NANOSECOND
@@ -26,6 +30,25 @@ DECODER_FACTORIES = [
     Ros2DecoderFactory(),
     ProtobufDecoderFactory(),
 ]
+
+
+def decoder_for(schema: Schema | None, channel: Channel) -> Callable[[bytes], object]:
+    """Return a decode function for a channel, by its message encoding.
+
+    Raises:
+        UnsupportedEncodingError: If no decoder handles the channel's encoding.
+
+    """
+    if channel.message_encoding == "json":
+        return json.loads
+    for factory in DECODER_FACTORIES:
+        decoder = factory.decoder_for(channel.message_encoding, schema)
+        if decoder is not None:
+            return decoder
+    raise UnsupportedEncodingError(
+        f"No decoder for message encoding '{channel.message_encoding}' "
+        f"on topic '{channel.topic}'"
+    )
 
 
 class MessageDataset(base.MessageDataset):
@@ -41,22 +64,27 @@ class MessageDataset(base.MessageDataset):
         """Return an iterator of topic name, timestamp in seconds, and decoded message."""
         for mcap_file in data_source.mcap_files:
             with open(mcap_file, "rb") as stream:
-                reader = make_reader(stream, decoder_factories=DECODER_FACTORIES)
+                reader = make_reader(stream)
                 start_time = start_seconds_inclusive * SECOND if start_seconds_inclusive else None
-                messages = reader.iter_decoded_messages(
+                decoders: dict[int, Callable[[bytes], object]] = {}
+                messages = reader.iter_messages(
                     topics, start_time=start_time, end_time=None, log_time_order=True
                 )
-                for _, channel, message, decoded_message in messages:
+                for schema, channel, message in messages:
                     timestamp_seconds = message.log_time / SECOND
                     if (
                         end_seconds_inclusive is not None
                         and timestamp_seconds > end_seconds_inclusive
                     ):
                         return
-                    yield channel.topic, timestamp_seconds, decoded_message
+                    if channel.id not in decoders:
+                        decoders[channel.id] = decoder_for(schema, channel)
+                    yield channel.topic, timestamp_seconds, decoders[channel.id](message.data)
 
     def _to_json(self, message: object, struct: pa.StructType) -> dict[str, Any]:
         """Cast a decoded message into a JSON-serializable dictionary."""
+        if isinstance(message, dict):
+            return message  # json-encoded channels decode to dictionaries already
         return convert.to_json(message, struct)
 
 

--- a/src/topic/mcap.py
+++ b/src/topic/mcap.py
@@ -3,8 +3,11 @@
 Topic names, type names, and message counts come from the MCAP summary (channels,
 schemas, statistics). Schemas are converted to PyArrow structs by their embedded
 encoding: ``ros2msg`` via the ros2msg grammar, ``protobuf`` via the embedded file
-descriptor set. Other encodings can be listed and described but not queried yet.
+descriptor set, and ``jsonschema`` via a JSON-Schema type mapper. Other encodings
+can be listed and described but not queried yet.
 """
+
+import json
 
 import pyarrow as pa
 from google.protobuf import descriptor_pb2
@@ -31,6 +34,49 @@ def _channels_with_schemas(data_source: McapBag) -> dict[str, base.MessageDefini
             else:
                 topics.setdefault(channel.topic, None)
     return topics
+
+
+def _jsonschema_type(schema: dict) -> pa.DataType:
+    """Map a JSON-Schema type definition to a PyArrow type (utf8 for unknowns)."""
+    json_type = schema.get("type")
+    if isinstance(json_type, list):  # e.g. ["number", "null"] -> nullable number
+        json_type = next((t for t in json_type if t != "null"), "string")
+
+    match json_type:
+        case "object":
+            properties = schema.get("properties", {})
+            if not properties:
+                return pa.string()  # schemaless object: keep as JSON text
+            return pa.struct(
+                [pa.field(name, _jsonschema_type(sub)) for name, sub in properties.items()]
+            )
+        case "number":
+            return pa.float64()
+        case "integer":
+            return pa.int64()
+        case "boolean":
+            return pa.bool_()
+        case "array":
+            return pa.list_(_jsonschema_type(schema.get("items", {})))
+        case _:
+            return pa.string()
+
+
+def jsonschema_to_struct(definition: bytes) -> pa.StructType:
+    """Convert a JSON-Schema document (top-level object) to a PyArrow StructType.
+
+    Raises:
+        UnsupportedEncodingError: If the document is not valid JSON or not an object schema.
+
+    """
+    try:
+        document = json.loads(definition)
+    except json.JSONDecodeError as error:
+        raise base.UnsupportedEncodingError(f"invalid jsonschema document: {error}") from error
+    struct = _jsonschema_type(document if isinstance(document, dict) else {})
+    if not isinstance(struct, pa.StructType):
+        raise base.UnsupportedEncodingError("jsonschema document is not an object schema")
+    return struct
 
 
 def _type_names(data_source: McapBag) -> dict[str, str]:
@@ -106,6 +152,9 @@ class TopicRegistry(base.TopicRegistry):
                 )
                 return protobuf_schema.to_pa_struct(descriptor)
 
+            case "jsonschema":
+                return jsonschema_to_struct(definition.definition)
+
             case _:
                 raise base.UnsupportedEncodingError(definition.encoding)
 
@@ -118,6 +167,9 @@ class TopicRegistry(base.TopicRegistry):
 
             case "protobuf":
                 return str(descriptor_pb2.FileDescriptorSet.FromString(definition.definition))
+
+            case "jsonschema":
+                return json.dumps(json.loads(definition.definition), indent=2)
 
             case _:
                 raise base.UnsupportedEncodingError(definition.encoding)

--- a/src/topic/mcap.py
+++ b/src/topic/mcap.py
@@ -36,7 +36,7 @@ def _channels_with_schemas(data_source: McapBag) -> dict[str, base.MessageDefini
     return topics
 
 
-def _jsonschema_type(schema: dict) -> pa.DataType:
+def _jsonschema_type(schema: dict) -> pa.DataType:  # noqa: PLR0911 -- one return per JSON type
     """Map a JSON-Schema type definition to a PyArrow type (utf8 for unknowns)."""
     json_type = schema.get("type")
     if isinstance(json_type, list):  # e.g. ["number", "null"] -> nullable number

--- a/test/pipeline/test_mcap_jsonschema.py
+++ b/test/pipeline/test_mcap_jsonschema.py
@@ -1,0 +1,153 @@
+"""End-to-end tests for jsonschema-encoded MCAP topics -- ROS-free.
+
+Writes an MCAP by hand (schema encoding "jsonschema", message encoding "json"),
+the shape produced by Foxglove-native and custom JSON loggers, then drives
+resolve -> topics -> struct -> SQL -> preview through the generic mcap modules.
+"""
+
+import json
+import pathlib
+
+import pyarrow as pa
+import pytest
+from mcap.writer import Writer
+
+import server
+from settings import settings
+from src.di.types import data_source
+from src.topic.mcap import jsonschema_to_struct
+
+EPOCH = 1_700_000_000.0
+SECOND_NS = 1_000_000_000
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "temp": {"type": "number"},
+        "cycles": {"type": "integer"},
+        "running": {"type": "boolean"},
+        "mode": {"type": "string"},
+        "gps": {
+            "type": "object",
+            "properties": {"lat": {"type": "number"}, "lon": {"type": "number"}},
+        },
+        "alarms": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+RATE_HZ = 2
+DURATION_SECONDS = 20.0
+EVENTS = ((6.0, 8.0), (14.0, 15.0))  # offsets where temp > 30
+
+
+def _temp_at(offset: float) -> float:
+    return 34.0 if any(start <= offset <= end for start, end in EVENTS) else 22.0
+
+
+@pytest.fixture
+def jsonschema_mcap(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / "iot.mcap"
+    with open(path, "wb") as stream:
+        writer = Writer(stream)
+        writer.start()
+        schema_id = writer.register_schema(
+            name="factory.Reading",
+            encoding="jsonschema",
+            data=json.dumps(SCHEMA).encode(),
+        )
+        channel_id = writer.register_channel(
+            topic="/readings", message_encoding="json", schema_id=schema_id
+        )
+        for i in range(int(DURATION_SECONDS * RATE_HZ)):
+            offset = i / RATE_HZ
+            timestamp_ns = int((EPOCH + offset) * SECOND_NS)
+            payload = {
+                "temp": _temp_at(offset),
+                "cycles": i,
+                "running": True,
+                "mode": "auto",
+                "gps": {"lat": 37.77, "lon": -122.42},
+                "alarms": [] if _temp_at(offset) < 30 else ["overtemp"],
+            }
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=timestamp_ns,
+                data=json.dumps(payload).encode(),
+                publish_time=timestamp_ns,
+            )
+        writer.finish()
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def test_jsonschema_mapper_types() -> None:
+    struct = jsonschema_to_struct(json.dumps(SCHEMA).encode())
+    assert struct.field("temp").type == pa.float64()
+    assert struct.field("cycles").type == pa.int64()
+    assert struct.field("running").type == pa.bool_()
+    assert struct.field("mode").type == pa.string()
+    assert pa.types.is_struct(struct.field("gps").type)
+    assert pa.types.is_list(struct.field("alarms").type)
+
+
+def test_jsonschema_mapper_edge_cases() -> None:
+    struct = jsonschema_to_struct(
+        json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "maybe": {"type": ["number", "null"]},
+                    "anything": {},
+                    "blob": {"type": "object"},
+                },
+            }
+        ).encode()
+    )
+    assert struct.field("maybe").type == pa.float64()
+    assert struct.field("anything").type == pa.string()
+    assert struct.field("blob").type == pa.string()
+
+
+def test_end_to_end_jsonschema_mcap(jsonschema_mcap: pathlib.Path) -> None:
+    assert data_source.resolve(str(jsonschema_mcap)) == data_source.DataSource.MCAP
+
+    from src.di import module
+
+    factory = module.provide("src.source.mcap", {"path": str(jsonschema_mcap)})
+    registry = module.provide("src.topic.mcap", {})
+    bag = factory.build()
+
+    assert registry.available_topics(bag) == ["/readings"]
+    assert registry.native_type_name("/readings", bag) == "factory.Reading"
+    struct = registry.struct("/readings", bag)
+    assert struct.field("temp").type == pa.float64()
+    assert "temp" in registry.describe("/readings", bag)
+
+    rows = server.query_messages(
+        path=str(jsonschema_mcap),
+        sql_statement=(
+            "SELECT COUNT(*) AS n, MAX(\"/readings\"['temp']) AS max_temp, "
+            "MAX(\"/readings\"['gps']['lat']) AS lat FROM \"/readings\""
+        ),
+        topic="/readings",
+    )
+    assert rows[0]["n"] == int(DURATION_SECONDS * RATE_HZ)
+    assert rows[0]["max_temp"] == 34.0
+    assert rows[0]["lat"] == pytest.approx(37.77)
+
+
+def test_preview_detects_events_in_jsonschema_mcap(jsonschema_mcap: pathlib.Path) -> None:
+    result = server.preview_pipeline(
+        path=str(jsonschema_mcap),
+        event_topic="/readings",
+        predicate="\"/readings\"['temp'] > 30",
+        pre_seconds=1.0,
+        post_seconds=1.0,
+        debounce_seconds=3.0,
+    )
+    assert result["event_count"] == len(EVENTS)
+    assert 0 < result["kept_fraction"] < 1


### PR DESCRIPTION
Closes the '#102 follow-up: jsonschema schemas list but don't query' gap, stacked on #109.

- **`jsonschema` schemas → Arrow structs**: object→struct, number→float64, integer→int64, boolean→bool, array→list; `["number", "null"]`-style unions collapse to the non-null type; unknown or schemaless members fall back to utf8. `describe()` pretty-prints the schema document.
- **`json` message decoding**: the message dataset now routes per channel encoding — `json` via `json.loads`, ros1/ros2/protobuf via the existing decoder factories (resolved lazily per channel) — with a clear `UnsupportedEncodingError` for anything else (flatbuffer remains future work).

This is the MCAP shape produced by Foxglove-native and custom JSON loggers, so a third profile family becomes fully chat-able.

**Tests** (no ROS): mapper types + edge cases, and a hand-written jsonschema MCAP driven through resolve → topics → struct (incl. nested fields) → SQL → `preview_pipeline` detecting the two seeded overtemp events. 149 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)