### PR TITLE
Decompress zstd MCAP without rosbag2; retire the ros2.mcap resolution path

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -66,7 +66,8 @@ and `save_pipeline` (persist a config as YAML for reuse).
 ## Reduce an MCAP bag
 
 MCAP is a first-class format: any `.mcap` file or directory of them (ros1, ros2,
-protobuf, or json profiles) works in **every** Bagel image -- no ROS required. The reduce module
+protobuf, or json profiles; zstd-compressed included) works in **every** Bagel image --
+no ROS required. The reduce module
 copies raw message records within the kept windows -- no decode/re-encode -- so it needs
 no rosidl typesupport:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pydantic >=2.11.0,<3.0.0",
     "pydantic-settings >=2.9.0,<3.0.0",
     "PyYAML >=6.0.0,<7.0.0",
+    "zstandard>=0.23.0,<1.0.0",
 ]
 
 [dependency-groups]

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -15,7 +15,7 @@ class DataSource(Enum):
     ROS1_BAG = "ros1.bag"
     ROS2_DB3 = "ros2.db3"
     MCAP = "mcap"
-    ROS2_MCAP = "ros2.mcap"  # zstd-compressed MCAP bags; decompression requires rosbag2
+    ROS2_MCAP = "ros2.mcap"  # back-compat only; resolve() no longer returns this
     PX4_ULOG = "px4.ulg"
     ARDUPILOT_BIN = "ardupilot.bin"
     BETAFLIGHT_BBL = "betaflight.bbl"
@@ -60,14 +60,11 @@ def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # n
         return DataSource.ROS1_BAG
     elif is_ros2_db3_file(path) or is_ros2_db3_zstd_file(path) or is_ros2_db3_directory(path):
         return DataSource.ROS2_DB3
-    elif is_mcap_file(path) or is_mcap_directory(path):
-        # MCAP is a first-class, middleware-independent format: any bare .mcap file or
-        # directory of .mcap files (including rosbag2-produced MCAP bags).
+    elif is_mcap_file(path) or is_mcap_zstd_file(path) or is_mcap_directory(path):
+        # MCAP is a first-class, middleware-independent format: any bare .mcap file,
+        # zstd-compressed .mcap.zstd, or directory of them (including rosbag2-produced
+        # MCAP bags). Decompression is handled by the generic mcap source.
         return DataSource.MCAP
-    elif is_ros2_mcap_zstd_file(path) or is_ros2_mcap_directory(path):
-        # Zstandard-compressed MCAP bags still go through the ROS2 path, which has
-        # the rosbag2-based decompression machinery.
-        return DataSource.ROS2_MCAP
     elif is_px4_ulog_file(path):
         return DataSource.PX4_ULOG
     elif is_ardupilot_bin_file(path):
@@ -143,13 +140,21 @@ def is_mcap_file(path: pathlib.Path) -> bool:
     return has_magic_bytes(path, b"\x89MCAP0\r\n")
 
 
+def is_mcap_zstd_file(path: pathlib.Path) -> bool:
+    """Check if the given path is a Zstandard-compressed MCAP file."""
+    return is_zstd_file(path) and path.name.endswith(".mcap.zstd")
+
+
 def is_mcap_directory(path: pathlib.Path) -> bool:
     """Check if the given path is a directory containing at least one MCAP file."""
     if not path.is_dir():
         return False
 
-    files = list(path.glob("*.mcap"))
-    return bool(files) and all(is_mcap_file(file) for file in files)
+    files = [
+        *((file, is_mcap_file) for file in path.glob("*.mcap")),
+        *((file, is_mcap_zstd_file) for file in path.glob("*.mcap.zstd")),
+    ]
+    return bool(files) and all(check(file) for file, check in files)
 
 
 def is_ros2_mcap_file(path: pathlib.Path) -> bool:

--- a/src/source/mcap.py
+++ b/src/source/mcap.py
@@ -3,17 +3,22 @@
 Reads everything from the MCAP container itself (header, summary, statistics) --
 no rosbag2 metadata.yaml or ROS installation required. Handles a single ``.mcap``
 file or a directory of ``.mcap`` files (including rosbag2-produced MCAP bags,
-whose ``metadata.yaml`` is simply ignored).
+whose ``metadata.yaml`` is simply ignored). Zstandard-compressed files
+(``.mcap.zstd``) are decompressed transparently into the cache directory,
+leaving the source untouched.
 """
 
 import functools
 import pathlib
+import uuid
 from typing import Any
 
+import zstandard
 from mcap.reader import make_reader
 from mcap.summary import Summary
 from pydantic import BaseModel
 
+from settings import settings
 from src.di import module
 from src.source import base
 
@@ -21,6 +26,29 @@ NANOSECOND = 1
 SECOND = 1_000_000_000 * NANOSECOND
 
 MCAP_MAGIC = b"\x89MCAP0\r\n"
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+def decompress(file: pathlib.Path) -> pathlib.Path:
+    """Decompress a ``.mcap.zstd`` file into the cache and return the decompressed path.
+
+    The cache key includes the source path, size, and mtime, so a changed source is
+    re-decompressed while repeat reads are free. The source file is never modified.
+    """
+    stat = file.stat()
+    key = str(
+        uuid.uuid5(uuid.NAMESPACE_OID, f"{file.resolve()}_{stat.st_size}_{stat.st_mtime_ns}")
+    )
+    output = pathlib.Path(settings.CACHE_DIRECTORY) / "decompressed" / key / file.stem
+    if output.exists():
+        return output
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    partial = output.with_suffix(".partial")
+    with open(file, "rb") as f_in, open(partial, "wb") as f_out:
+        zstandard.ZstdDecompressor().copy_stream(f_in, f_out)
+    partial.rename(output)  # atomic-ish: readers only ever see complete files
+    return output
 
 
 class McapBag(BaseModel):
@@ -30,10 +58,15 @@ class McapBag(BaseModel):
 
     @property
     def mcap_files(self) -> list[pathlib.Path]:
-        """Return all .mcap files in the data source."""
+        """Return all .mcap files in the data source, decompressing .mcap.zstd as needed."""
         if self.path.is_file():
-            return [self.path]
-        return sorted(self.path.glob("*.mcap"))
+            candidates = [self.path]
+        else:
+            candidates = sorted([*self.path.glob("*.mcap"), *self.path.glob("*.mcap.zstd")])
+        return [
+            decompress(file) if file.name.endswith(".mcap.zstd") else file
+            for file in candidates
+        ]
 
     def __hash__(self) -> int:
         """Needed for functools caching."""

--- a/test/di/types/test_data_source.py
+++ b/test/di/types/test_data_source.py
@@ -88,7 +88,7 @@ def test_should_resolve_mcap_file_as_first_class_mcap() -> None:
     assert result == data_source.DataSource.MCAP
 
 
-def test_should_resolve_ros2_mcap_zstd_file() -> None:
+def test_should_resolve_mcap_zstd_file_as_first_class_mcap() -> None:
     # GIVEN
     path = "./data/sample/ros2/mcap_zstd/part_0.mcap.zstd"
 
@@ -96,7 +96,18 @@ def test_should_resolve_ros2_mcap_zstd_file() -> None:
     result = data_source.resolve(path)
 
     # THEN
-    assert result == data_source.DataSource.ROS2_MCAP
+    assert result == data_source.DataSource.MCAP
+
+
+def test_should_resolve_mcap_zstd_directory_as_first_class_mcap() -> None:
+    # GIVEN
+    path = "./data/sample/ros2/mcap_zstd"
+
+    # WHEN
+    result = data_source.resolve(path)
+
+    # THEN
+    assert result == data_source.DataSource.MCAP
 
 
 def test_should_resolve_px4_ulog() -> None:

--- a/test/pipeline/test_mcap_zstd.py
+++ b/test/pipeline/test_mcap_zstd.py
@@ -1,0 +1,65 @@
+"""End-to-end tests for zstd-compressed MCAP through the generic (ROS-free) path.
+
+Uses the bundled `data/sample/ros2/mcap_zstd` bag: a rosbag2-produced directory whose
+single part is `part_0.mcap.zstd`. Decompression goes to the cache directory, keyed by
+source path/size/mtime, and never touches the source.
+"""
+
+import pathlib
+
+import pytest
+
+import server
+from settings import settings
+from src.di import module
+from src.source import mcap as mcap_source
+
+SAMPLE_DIR = "./data/sample/ros2/mcap_zstd"
+SAMPLE_FILE = "./data/sample/ros2/mcap_zstd/part_0.mcap.zstd"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
+
+
+def test_zstd_bag_reads_through_generic_path() -> None:
+    factory = module.provide("src.source.mcap", {"path": SAMPLE_DIR})
+    registry = module.provide("src.topic.mcap", {})
+    bag = factory.build()
+
+    topics = registry.available_topics(bag)
+    assert "/rosout" in topics
+    # ros2msg schema parsed from the decompressed file, no ROS involved.
+    struct = registry.struct("/rosout", bag)
+    assert "msg" in struct.names
+
+    rows = server.query_messages(
+        path=SAMPLE_DIR,
+        sql_statement='SELECT COUNT(*) AS n FROM "/rosout"',
+        topic="/rosout",
+    )
+    assert rows[0]["n"] > 0
+
+
+def test_bare_zstd_file_reads_too() -> None:
+    factory = module.provide("src.source.mcap", {"path": SAMPLE_FILE})
+    registry = module.provide("src.topic.mcap", {})
+    assert "/rosout" in registry.available_topics(factory.build())
+
+
+def test_decompression_is_cached_and_source_untouched() -> None:
+    source = pathlib.Path(SAMPLE_FILE)
+    before = source.stat().st_mtime_ns
+
+    first = mcap_source.decompress(source)
+    assert first.exists()
+    assert first.name == "part_0.mcap"
+    first_mtime = first.stat().st_mtime_ns
+
+    second = mcap_source.decompress(source)
+    assert second == first
+    assert second.stat().st_mtime_ns == first_mtime, "second call must reuse the cache"
+    assert source.stat().st_mtime_ns == before, "source file must not be modified"
+    # Nothing new was written next to the source (the old ROS path used to do this).
+    assert not (source.parent / "part_0.mcap").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -178,6 +178,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -245,6 +246,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.9.0,<3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
+    { name = "zstandard", specifier = ">=0.23.0,<1.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Removes the last `ros2.mcap` remnant from resolution, stacked on #110.

- **`.mcap.zstd` files and directories now resolve to first-class `mcap`** and decompress transparently via the `zstandard` package (promoted to a main dependency — it was already in the lockfile transitively). `resolve()` never returns `ros2.mcap` anymore; the enum and modules remain as inert back-compat.
- **Better behavior than the old path**: the rosbag2-based decompressor wrote the decompressed file *next to the source*; the generic one goes to the cache directory keyed by source path/size/mtime — repeat reads are free, changed sources re-decompress, read-only source dirs stay pristine, and a `.partial`→rename keeps readers from seeing incomplete files.

**Verified** against the bundled `data/sample/ros2/mcap_zstd` bag on a plain host (no ROS): resolve → topics → ros2msg struct → SQL over `/rosout`, both bare-file and directory forms, plus cache-reuse and source-untouched assertions. 151 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)