### PR TITLE
Add GCS and Azure Blob upload tasks via a shared upload base

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -161,6 +161,11 @@ tasks:
 
 Credentials use the standard AWS resolution chain (env vars, `~/.aws`, instance role).
 
+GCS (`src.pipeline.tasks.upload.gcs`, standard Google credential chain) and Azure Blob
+(`src.pipeline.tasks.upload.azure`, connection string or
+`AZURE_STORAGE_CONNECTION_STRING`) uploaders mirror the same source/prefix/window/skip
+semantics. Their SDKs live in the `upload` dependency group: `uv sync --group upload`.
+
 ## Verify the mechanism without ROS
 
 The event → window → merge → run machinery is format-agnostic; only the bag *writer* needs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ iot = [
     "influxdb3-python>=0.10.0",
     "paho-mqtt>=2.1.0,<3.0.0",
 ]
+upload = [
+    "azure-storage-blob>=12.24.0,<13.0.0",
+    "google-cloud-storage>=2.18.0,<4.0.0",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/src/pipeline/tasks/upload/azure.py
+++ b/src/pipeline/tasks/upload/azure.py
@@ -1,0 +1,106 @@
+"""Upload local files to an Azure Blob Storage container."""
+
+import hashlib
+import os
+import pathlib
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import ContainerClient, ContentSettings
+
+from src.di import module
+from src.pipeline.tasks.upload import base
+
+
+def md5_digest(local_file: pathlib.Path) -> bytes:
+    """Return the raw MD5 digest of a file (Azure's Content-MD5 format)."""
+    digest = hashlib.md5(usedforsecurity=False)
+    with open(local_file, "rb") as stream:
+        while chunk := stream.read(64 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.digest()
+
+
+class UploadFilesToAzure(base.UploadFilesTask):
+    """Upload local files to an Azure Blob Storage container.
+
+    See `UploadFilesTask` for the shared source/prefix/window/skip semantics; files
+    are skipped when their MD5 matches the remote blob's Content-MD5 (which this task
+    sets on upload). Authentication uses a connection string, passed explicitly or via
+    the AZURE_STORAGE_CONNECTION_STRING environment variable.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        container: str,
+        source: str,
+        prefix: str = "",
+        connection_string: str | None = None,
+        filter_modified_at: bool = False,
+        skip_existing: bool = True,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            container (str): The destination container name.
+            source (str): A file path, directory (uploaded recursively), or glob pattern
+                selecting the local files to upload.
+            prefix (str, optional): Blob-name prefix under which objects are stored.
+                Defaults to "" (container root).
+            connection_string (str | None, optional): Storage-account connection string.
+                If None, the AZURE_STORAGE_CONNECTION_STRING environment variable is
+                used. Defaults to None.
+            filter_modified_at (bool, optional): If True, only upload files whose
+                modified time falls within `[asof_seconds - lookback, asof_seconds]`.
+                Defaults to False.
+            skip_existing (bool, optional): If True, skip files whose MD5 matches the
+                existing remote blob's Content-MD5. Defaults to True.
+
+        Raises:
+            ValueError: If 'container' or 'source' is empty, or no connection string
+                is available.
+
+        """
+        if not container:
+            raise ValueError("'container' must not be empty.")
+        super().__init__(
+            source=source,
+            prefix=prefix,
+            filter_modified_at=filter_modified_at,
+            skip_existing=skip_existing,
+        )
+        self._container = container
+        self._connection_string = connection_string or os.environ.get(
+            "AZURE_STORAGE_CONNECTION_STRING"
+        )
+        if not self._connection_string:
+            raise ValueError(
+                "No connection string: pass 'connection_string' or set "
+                "AZURE_STORAGE_CONNECTION_STRING."
+            )
+
+    def _connect(self) -> object:
+        return ContainerClient.from_connection_string(self._connection_string, self._container)
+
+    def _destination(self) -> str:
+        return f"azure://{self._container}/{self._prefix}"
+
+    def _remote_matches(self, client: object, local_file: pathlib.Path, key: str) -> bool:
+        try:
+            properties = client.get_blob_client(key).get_blob_properties()
+        except ResourceNotFoundError:
+            return False
+        remote_md5 = properties.content_settings.content_md5
+        return remote_md5 is not None and bytes(remote_md5) == md5_digest(local_file)
+
+    def _upload_file(self, client: object, local_file: pathlib.Path, key: str) -> None:
+        with open(local_file, "rb") as stream:
+            client.get_blob_client(key).upload_blob(
+                stream,
+                overwrite=True,
+                content_settings=ContentSettings(content_md5=md5_digest(local_file)),
+            )
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = UploadFilesToAzure

--- a/src/pipeline/tasks/upload/base.py
+++ b/src/pipeline/tasks/upload/base.py
@@ -1,0 +1,169 @@
+"""Shared skeleton for cloud upload tasks.
+
+Providers (S3, GCS, Azure) share everything except the client, the checksum
+comparison, and the transfer call: source resolution (file / directory / glob),
+key layout under a prefix, the modified-time window, and skip-existing plumbing
+live here.
+"""
+
+import abc
+import glob
+import logging
+import pathlib
+
+from src.pipeline import base
+
+_GLOB_CHARS = "*?["
+
+
+def glob_root(pattern: str) -> pathlib.Path:
+    """Return the leading non-wildcard directory of a glob pattern.
+
+    Used as the base against which matched files are relativized, so a pattern like
+    ``logs/2026/*/imu.mcap`` produces keys relative to ``logs/2026``.
+    """
+    root_parts = []
+    for part in pathlib.PurePath(pattern).parts:
+        if any(char in part for char in _GLOB_CHARS):
+            break
+        root_parts.append(part)
+    return pathlib.Path(*root_parts) if root_parts else pathlib.Path(".")
+
+
+class UploadFilesTask(base.Task):
+    """Base class for tasks that upload local files to a cloud object store.
+
+    The `source` may be a single file, a directory (uploaded recursively), or a glob
+    pattern. Object keys preserve the file structure relative to the source root, under
+    an optional key `prefix`. Files whose checksum already matches the remote object
+    are skipped, so re-running a pipeline does not re-upload unchanged artifacts.
+    """
+
+    def __init__(
+        self,
+        source: str,
+        prefix: str = "",
+        filter_modified_at: bool = False,
+        skip_existing: bool = True,
+    ) -> None:
+        """Initialize the shared upload options.
+
+        Args:
+            source (str): A file path, directory (uploaded recursively), or glob pattern
+                selecting the local files to upload.
+            prefix (str, optional): Key prefix under which objects are stored.
+                Defaults to "" (bucket/container root).
+            filter_modified_at (bool, optional): If True, only upload files whose
+                modified time falls within `[asof_seconds - lookback, asof_seconds]`
+                when the task executes -- so a pipeline cadence uploads only new files.
+                Defaults to False.
+            skip_existing (bool, optional): If True, skip files whose checksum matches
+                the existing remote object. Defaults to True.
+
+        Raises:
+            ValueError: If 'source' is empty.
+
+        """
+        if not source:
+            raise ValueError("'source' must not be empty.")
+        self._source = source
+        self._prefix = prefix.strip("/")
+        self._filter_modified_at = filter_modified_at
+        self._skip_existing = skip_existing
+
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        """Nothing to set up in this task."""
+
+    # -- provider hooks --------------------------------------------------------------
+
+    @abc.abstractmethod
+    def _connect(self) -> object:
+        """Return the provider client."""
+
+    @abc.abstractmethod
+    def _destination(self) -> str:
+        """Return the destination for logging, e.g. ``s3://bucket/prefix``."""
+
+    @abc.abstractmethod
+    def _remote_matches(self, client: object, local_file: pathlib.Path, key: str) -> bool:
+        """Return True if the remote object exists with a matching checksum."""
+
+    @abc.abstractmethod
+    def _upload_file(self, client: object, local_file: pathlib.Path, key: str) -> None:
+        """Transfer one file to the destination key."""
+
+    # -- shared machinery ------------------------------------------------------------
+
+    def _source_files(self) -> list[tuple[pathlib.Path, str]]:
+        """Resolve the source into (local file, object key) pairs."""
+        source = pathlib.Path(self._source)
+
+        if source.is_file():
+            pairs = [(source, source.name)]
+        elif source.is_dir():
+            pairs = [
+                (file, file.relative_to(source).as_posix())
+                for file in sorted(source.rglob("*"))
+                if file.is_file()
+            ]
+        else:
+            root = glob_root(self._source)
+            pairs = [
+                (match, match.relative_to(root).as_posix())
+                for match in sorted(
+                    pathlib.Path(p) for p in glob.glob(self._source, recursive=True)
+                )
+                if match.is_file()
+            ]
+
+        if self._prefix:
+            pairs = [(file, f"{self._prefix}/{key}") for file, key in pairs]
+        return pairs
+
+    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
+        """Execute the task at the given time."""
+        start_seconds = None
+        if self._filter_modified_at:
+            match lookback:
+                case base.Lookback(unit=base.Unit.FRAME):
+                    raise ValueError(f"Does not support lookback with FRAME unit: {lookback}")
+                case base.Lookback():
+                    start_seconds = asof_seconds - lookback.to_seconds()
+                case None:
+                    start_seconds = None
+        else:
+            logging.debug(
+                "'asof_seconds' and 'lookback' are ignored since 'filter_modified_at' is False"
+            )
+
+        client = self._connect()
+
+        uploaded, skipped = 0, 0
+        for local_file, key in self._source_files():
+            if self._filter_modified_at:
+                modified_at = local_file.stat().st_mtime
+                if start_seconds is not None and modified_at < start_seconds:
+                    continue
+                if modified_at > asof_seconds:
+                    continue
+
+            if self._skip_existing and self._remote_matches(client, local_file, key):
+                logging.info("'%s' already exists with matching checksum, skipping", key)
+                skipped += 1
+                continue
+
+            self._upload_file(client, local_file, key)
+            logging.info(
+                "Uploaded %s/%s (%d bytes)",
+                self._destination().rstrip("/"),
+                key,
+                local_file.stat().st_size,
+            )
+            uploaded += 1
+
+        logging.info(
+            "Upload complete: %d uploaded, %d skipped to %s",
+            uploaded,
+            skipped,
+            self._destination(),
+        )

--- a/src/pipeline/tasks/upload/gcs.py
+++ b/src/pipeline/tasks/upload/gcs.py
@@ -1,0 +1,89 @@
+"""Upload local files to a Google Cloud Storage bucket."""
+
+import base64
+import hashlib
+import pathlib
+
+from google.cloud import storage
+
+from src.di import module
+from src.pipeline.tasks.upload import base
+
+
+def md5_base64(local_file: pathlib.Path) -> str:
+    """Return the base64-encoded MD5 of a file (GCS's object checksum format)."""
+    digest = hashlib.md5(usedforsecurity=False)
+    with open(local_file, "rb") as stream:
+        while chunk := stream.read(64 * 1024 * 1024):
+            digest.update(chunk)
+    return base64.b64encode(digest.digest()).decode("utf-8")
+
+
+class UploadFilesToGcs(base.UploadFilesTask):
+    """Upload local files to a Google Cloud Storage bucket.
+
+    See `UploadFilesTask` for the shared source/prefix/window/skip semantics; files
+    are skipped when their MD5 matches the remote object's. Credentials use the
+    standard Google resolution chain (GOOGLE_APPLICATION_CREDENTIALS, gcloud ADC,
+    workload identity).
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        bucket: str,
+        source: str,
+        prefix: str = "",
+        project: str | None = None,
+        filter_modified_at: bool = False,
+        skip_existing: bool = True,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            bucket (str): The destination bucket name.
+            source (str): A file path, directory (uploaded recursively), or glob pattern
+                selecting the local files to upload.
+            prefix (str, optional): Key prefix under which objects are stored.
+                Defaults to "" (bucket root).
+            project (str | None, optional): The GCP project. If None, the default
+                project resolution applies. Defaults to None.
+            filter_modified_at (bool, optional): If True, only upload files whose
+                modified time falls within `[asof_seconds - lookback, asof_seconds]`.
+                Defaults to False.
+            skip_existing (bool, optional): If True, skip files whose MD5 matches the
+                existing remote object. Defaults to True.
+
+        Raises:
+            ValueError: If 'bucket' or 'source' is empty.
+
+        """
+        if not bucket:
+            raise ValueError("'bucket' must not be empty.")
+        super().__init__(
+            source=source,
+            prefix=prefix,
+            filter_modified_at=filter_modified_at,
+            skip_existing=skip_existing,
+        )
+        self._bucket = bucket
+        self._project = project
+
+    def _connect(self) -> object:
+        return storage.Client(project=self._project)
+
+    def _destination(self) -> str:
+        return f"gs://{self._bucket}/{self._prefix}"
+
+    def _remote_matches(self, client: object, local_file: pathlib.Path, key: str) -> bool:
+        blob = client.bucket(self._bucket).get_blob(key)
+        if blob is None:
+            return False
+        return blob.md5_hash == md5_base64(local_file)
+
+    def _upload_file(self, client: object, local_file: pathlib.Path, key: str) -> None:
+        client.bucket(self._bucket).blob(key).upload_from_filename(str(local_file))
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = UploadFilesToGcs

--- a/src/pipeline/tasks/upload/s3.py
+++ b/src/pipeline/tasks/upload/s3.py
@@ -1,7 +1,5 @@
 """Upload local files to an S3 (or S3-compatible) bucket."""
 
-import glob
-import logging
 import pathlib
 
 import boto3
@@ -9,35 +7,15 @@ import botocore
 
 from src import artifacts
 from src.di import module
-from src.pipeline import base
-
-_GLOB_CHARS = "*?["
+from src.pipeline.tasks.upload import base
 
 
-def _glob_root(pattern: str) -> pathlib.Path:
-    """Return the leading non-wildcard directory of a glob pattern.
-
-    Used as the base against which matched files are relativized, so a pattern like
-    ``logs/2026/*/imu.mcap`` produces keys relative to ``logs/2026``.
-    """
-    root_parts = []
-    for part in pathlib.PurePath(pattern).parts:
-        if any(char in part for char in _GLOB_CHARS):
-            break
-        root_parts.append(part)
-    return pathlib.Path(*root_parts) if root_parts else pathlib.Path(".")
-
-
-class UploadFilesToS3(base.Task):
+class UploadFilesToS3(base.UploadFilesTask):
     """Upload local files to an S3 (or S3-compatible) bucket.
 
-    The `source` may be a single file, a directory (uploaded recursively), or a glob
-    pattern. Object keys preserve the file structure relative to the source root, under
-    an optional key `prefix`. Files whose SHA-256 checksum already matches the remote
-    object are skipped, so re-running a pipeline does not re-upload unchanged artifacts.
-
-    Works with any S3-compatible store (MinIO, Cloudflare R2, GCS interop, ...) via
-    `endpoint_url`.
+    See `UploadFilesTask` for the shared source/prefix/window/skip semantics; files
+    are skipped when their SHA-256 matches the remote object's checksum. Works with
+    any S3-compatible store (MinIO, Cloudflare R2, GCS interop, ...) via `endpoint_url`.
     """
 
     def __init__(  # noqa: PLR0913
@@ -63,8 +41,7 @@ class UploadFilesToS3(base.Task):
             endpoint_url (str | None, optional): Endpoint for S3-compatible stores
                 (e.g. MinIO). If None, AWS S3 is used. Defaults to None.
             filter_modified_at (bool, optional): If True, only upload files whose
-                modified time falls within `[asof_seconds - lookback, asof_seconds]`
-                when the task executes -- so a pipeline cadence uploads only new files.
+                modified time falls within `[asof_seconds - lookback, asof_seconds]`.
                 Defaults to False.
             skip_existing (bool, optional): If True, skip files whose SHA-256 checksum
                 matches the existing remote object. Defaults to True.
@@ -75,107 +52,40 @@ class UploadFilesToS3(base.Task):
         """
         if not bucket:
             raise ValueError("'bucket' must not be empty.")
-        if not source:
-            raise ValueError("'source' must not be empty.")
+        super().__init__(
+            source=source,
+            prefix=prefix,
+            filter_modified_at=filter_modified_at,
+            skip_existing=skip_existing,
+        )
         self._bucket = bucket
-        self._source = source
-        self._prefix = prefix.strip("/")
         self._region = region
         self._endpoint_url = endpoint_url
-        self._filter_modified_at = filter_modified_at
-        self._skip_existing = skip_existing
 
-    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
-        """Nothing to set up in this task."""
+    def _connect(self) -> object:
+        return boto3.client("s3", region_name=self._region, endpoint_url=self._endpoint_url)
 
-    def _source_files(self) -> list[tuple[pathlib.Path, str]]:
-        """Resolve the source into (local file, object key) pairs."""
-        source = pathlib.Path(self._source)
+    def _destination(self) -> str:
+        return f"s3://{self._bucket}/{self._prefix}"
 
-        if source.is_file():
-            pairs = [(source, source.name)]
-        elif source.is_dir():
-            pairs = [
-                (file, file.relative_to(source).as_posix())
-                for file in sorted(source.rglob("*"))
-                if file.is_file()
-            ]
-        else:
-            root = _glob_root(self._source)
-            pairs = [
-                (match, match.relative_to(root).as_posix())
-                for match in sorted(
-                    pathlib.Path(p) for p in glob.glob(self._source, recursive=True)
-                )
-                if match.is_file()
-            ]
-
-        if self._prefix:
-            pairs = [(file, f"{self._prefix}/{key}") for file, key in pairs]
-        return pairs
-
-    def _remote_matches(self, s3_client: object, key: str, local_sha256: str) -> bool:
-        """Return True if the remote object exists with the same SHA-256 checksum."""
+    def _remote_matches(self, client: object, local_file: pathlib.Path, key: str) -> bool:
         try:
-            response = s3_client.get_object_attributes(
+            response = client.get_object_attributes(
                 Bucket=self._bucket, Key=key, ObjectAttributes=["Checksum"]
             )
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NotFound"):
                 return False
             raise
+        local_sha256 = artifacts.checksum_sha256(local_file)
         return response.get("Checksum", {}).get("ChecksumSHA256") == local_sha256
 
-    def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> None:
-        """Execute the task at the given time."""
-        start_seconds = None
-        if self._filter_modified_at:
-            match lookback:
-                case base.Lookback(unit=base.Unit.FRAME):
-                    raise ValueError(f"Does not support lookback with FRAME unit: {lookback}")
-                case base.Lookback():
-                    start_seconds = asof_seconds - lookback.to_seconds()
-                case None:
-                    start_seconds = None
-        else:
-            logging.debug(
-                "'asof_seconds' and 'lookback' are ignored since 'filter_modified_at' is False"
-            )
-
-        s3_client = boto3.client(
-            "s3", region_name=self._region, endpoint_url=self._endpoint_url
-        )
-
-        uploaded, skipped = 0, 0
-        for local_file, key in self._source_files():
-            if self._filter_modified_at:
-                modified_at = local_file.stat().st_mtime
-                if start_seconds is not None and modified_at < start_seconds:
-                    continue
-                if modified_at > asof_seconds:
-                    continue
-
-            local_sha256 = artifacts.checksum_sha256(local_file)
-            if self._skip_existing and self._remote_matches(s3_client, key, local_sha256):
-                logging.info("'%s' already exists with matching SHA-256, skipping", key)
-                skipped += 1
-                continue
-
-            s3_client.upload_file(
-                Filename=str(local_file),
-                Bucket=self._bucket,
-                Key=key,
-                ExtraArgs={"ChecksumAlgorithm": "SHA256"},
-            )
-            logging.info("Uploaded s3://%s/%s", self._bucket, key)
-            uploaded += 1
-
-        logging.info(
-            "Upload complete: %d uploaded, %d skipped to s3://%s/%s",
-            uploaded,
-            skipped,
-            self._bucket,
-            self._prefix,
+    def _upload_file(self, client: object, local_file: pathlib.Path, key: str) -> None:
+        client.upload_file(
+            Filename=str(local_file),
+            Bucket=self._bucket,
+            Key=key,
+            ExtraArgs={"ChecksumAlgorithm": "SHA256"},
         )
 
 

--- a/test/pipeline/test_upload_clouds.py
+++ b/test/pipeline/test_upload_clouds.py
@@ -1,0 +1,145 @@
+"""Tests for the GCS and Azure upload tasks, using mocked SDK clients."""
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("google.cloud.storage")
+pytest.importorskip("azure.storage.blob")
+
+from azure.core.exceptions import ResourceNotFoundError
+
+from src.pipeline.tasks.upload.azure import UploadFilesToAzure, md5_digest
+from src.pipeline.tasks.upload.gcs import UploadFilesToGcs, md5_base64
+
+# -- GCS -----------------------------------------------------------------------------
+
+
+def _gcs_client(remote_md5: str | None = None) -> MagicMock:
+    """A fake GCS client: blob missing by default, or present with an md5."""
+    client = MagicMock()
+    bucket = client.bucket.return_value
+    if remote_md5 is None:
+        bucket.get_blob.return_value = None
+    else:
+        bucket.get_blob.return_value = MagicMock(md5_hash=remote_md5)
+    return client
+
+
+def _gcs_uploaded_keys(client: MagicMock) -> list[str]:
+    return [call.args[0] for call in client.bucket.return_value.blob.call_args_list]
+
+
+def test_gcs_uploads_directory_under_prefix(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "a.csv").write_text("a")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.csv").write_text("b")
+
+    client = _gcs_client()
+    task = UploadFilesToGcs(bucket="bkt", source=str(tmp_path), prefix="fleet/run1")
+    with patch("src.pipeline.tasks.upload.gcs.storage.Client", return_value=client):
+        task.execute(asof_seconds=1e12, lookback=None)
+
+    assert _gcs_uploaded_keys(client) == ["fleet/run1/a.csv", "fleet/run1/sub/b.csv"]
+
+
+def test_gcs_skips_matching_md5(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "same.bin"
+    source.write_bytes(b"identical")
+
+    client = _gcs_client(remote_md5=md5_base64(source))
+    task = UploadFilesToGcs(bucket="bkt", source=str(source))
+    with patch("src.pipeline.tasks.upload.gcs.storage.Client", return_value=client):
+        task.execute(asof_seconds=1e12, lookback=None)
+
+    client.bucket.return_value.blob.assert_not_called()
+
+
+def test_gcs_uploads_when_md5_differs(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "changed.bin"
+    source.write_bytes(b"new content")
+
+    client = _gcs_client(remote_md5="c29tZXRoaW5nIGVsc2U=")
+    task = UploadFilesToGcs(bucket="bkt", source=str(source))
+    with patch("src.pipeline.tasks.upload.gcs.storage.Client", return_value=client):
+        task.execute(asof_seconds=1e12, lookback=None)
+
+    assert _gcs_uploaded_keys(client) == ["changed.bin"]
+
+
+def test_gcs_empty_bucket_rejected() -> None:
+    with pytest.raises(ValueError, match="bucket"):
+        UploadFilesToGcs(bucket="", source="x")
+
+
+# -- Azure ---------------------------------------------------------------------------
+
+
+def _azure_client(remote_md5: bytes | None = None) -> MagicMock:
+    """A fake Azure container client: blob missing by default, or present with an md5."""
+    client = MagicMock()
+    blob = client.get_blob_client.return_value
+    if remote_md5 is None:
+        blob.get_blob_properties.side_effect = ResourceNotFoundError("missing")
+    else:
+        blob.get_blob_properties.return_value = MagicMock(
+            content_settings=MagicMock(content_md5=bytearray(remote_md5))
+        )
+    return client
+
+
+def test_azure_uploads_with_content_md5(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "reduced.mcap"
+    source.write_bytes(b"payload")
+
+    client = _azure_client()
+    task = UploadFilesToAzure(container="ctr", source=str(source), connection_string="cs")
+    with patch(
+        "src.pipeline.tasks.upload.azure.ContainerClient.from_connection_string",
+        return_value=client,
+    ):
+        task.execute(asof_seconds=1e12, lookback=None)
+
+    blob = client.get_blob_client.return_value
+    blob.upload_blob.assert_called_once()
+    settings_arg = blob.upload_blob.call_args.kwargs["content_settings"]
+    assert bytes(settings_arg.content_md5) == md5_digest(source)
+
+
+def test_azure_skips_matching_md5(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "same.bin"
+    source.write_bytes(b"identical")
+
+    client = _azure_client(remote_md5=md5_digest(source))
+    task = UploadFilesToAzure(container="ctr", source=str(source), connection_string="cs")
+    with patch(
+        "src.pipeline.tasks.upload.azure.ContainerClient.from_connection_string",
+        return_value=client,
+    ):
+        task.execute(asof_seconds=1e12, lookback=None)
+
+    client.get_blob_client.return_value.upload_blob.assert_not_called()
+
+
+def test_azure_requires_connection_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    with pytest.raises(ValueError, match="connection string"):
+        UploadFilesToAzure(container="ctr", source="x")
+
+
+def test_registry_discovers_all_upload_tasks() -> None:
+    from src.pipeline import capabilities
+
+    modules = {
+        entry["module"]: entry
+        for entry in capabilities.list_capabilities()
+        if entry["module"].startswith("src.pipeline.tasks.upload.")
+        and entry["module"] != "src.pipeline.tasks.upload.base"
+    }
+    assert set(modules) == {
+        "src.pipeline.tasks.upload.s3",
+        "src.pipeline.tasks.upload.gcs",
+        "src.pipeline.tasks.upload.azure",
+    }
+    assert all(entry["kind"] == "task" for entry in modules.values())

--- a/test/pipeline/test_upload_s3.py
+++ b/test/pipeline/test_upload_s3.py
@@ -7,7 +7,8 @@ import botocore.exceptions
 import pytest
 
 from src.pipeline import base
-from src.pipeline.tasks.upload.s3 import UploadFilesToS3, _glob_root
+from src.pipeline.tasks.upload.base import glob_root
+from src.pipeline.tasks.upload.s3 import UploadFilesToS3
 
 NO_SUCH_KEY = botocore.exceptions.ClientError(
     {"Error": {"Code": "NoSuchKey"}}, "GetObjectAttributes"
@@ -36,8 +37,8 @@ def _run(task: UploadFilesToS3, client: MagicMock, asof: float = 1e12) -> None:
 
 
 def test_glob_root_stops_at_first_wildcard() -> None:
-    assert _glob_root("logs/2026/*/imu.mcap") == pathlib.Path("logs/2026")
-    assert _glob_root("*.csv") == pathlib.Path(".")
+    assert glob_root("logs/2026/*/imu.mcap") == pathlib.Path("logs/2026")
+    assert glob_root("*.csv") == pathlib.Path(".")
 
 
 def test_directory_source_preserves_structure_under_prefix(tmp_path: pathlib.Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +253,10 @@ ros1 = [
 ros2 = [
     { name = "roslibpy" },
 ]
+upload = [
+    { name = "azure-storage-blob" },
+    { name = "google-cloud-storage" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -287,6 +319,10 @@ ros1 = [
     { name = "rospkg", specifier = ">=1.6.0,<2.0.0" },
 ]
 ros2 = [{ name = "roslibpy", specifier = ">=1.8.1,<2.0.0" }]
+upload = [
+    { name = "azure-storage-blob", specifier = ">=12.24.0,<13.0.0" },
+    { name = "google-cloud-storage", specifier = ">=2.18.0,<4.0.0" },
+]
 
 [[package]]
 name = "beautifulsoup4"
@@ -929,6 +965,114 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,6 +1273,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d0/274fbf7b0b12643cbbc001ce13e6a5b1607ac4929d1b11c72460152c9fc3/ipython-8.37.0-py3-none-any.whl", hash = "sha256:ed87326596b878932dbcb171e3e698845434d8c61b8d8cd474bf663041a9dcf2", size = 831864, upload-time = "2025-05-31T16:39:06.38Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -2275,6 +2428,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes issue #87's cloud coverage, stacked on #111.

- **`upload/base.py`** — the provider-independent skeleton (source file/dir/glob resolution, prefix key layout, modified-time window, skip-existing plumbing, per-file byte logging). The S3 task refactors onto it with an unchanged public API.
- **GCS** (`upload/gcs.py`) — standard Google credential chain; skip-existing via base64-MD5 vs the blob's `md5_hash`.
- **Azure Blob** (`upload/azure.py`) — connection string (arg or `AZURE_STORAGE_CONNECTION_STRING`); uploads set `Content-MD5` so re-runs can skip unchanged files.
- SDKs live in a new **`upload` dependency group** (deliberately not main deps — they're heavy; the capabilities registry gracefully reports the tasks unavailable where the group isn't installed). Runbook documents `uv sync --group upload`.

**Deferred**: progress-bar wiring (`report_progress` is a Pipeline-level flag not visible to tasks) — per-file byte counts are logged instead.

**Tests** (mocked SDK clients, no real cloud): key layout, checksum skip/upload decisions, Azure Content-MD5 on upload, validation, and registry discovery of all three tasks. 159 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)