### PR TITLE
Support MQTT wildcard subscriptions

### DIFF
--- a/doc/runbooks/iot_mqtt.md
+++ b/doc/runbooks/iot_mqtt.md
@@ -86,6 +86,8 @@ docker exec mosquitto mosquitto_pub -t 'freezer/1/status' \
 
 ## Notes and limits (v1)
 
-- Subscribe to exact topic names; wildcards are used internally for discovery only.
+- Wildcard subscriptions (`freezer/#`, `plant/+/temp`) expand against the topics seen
+  during discovery, each match getting its own buffer and schema; topics that first
+  appear later are not auto-added -- re-subscribe to pick them up.
 - Schema is inferred from early samples; fields that appear later read as NULL.
 - Messages carry no standard timestamp, so arrival time is used.

--- a/src/sink/mqtt.py
+++ b/src/sink/mqtt.py
@@ -262,9 +262,46 @@ class TopicSink(base.TopicSink):
         buffer_size_bytes: int | None = settings.JSONL_BUFFER_SIZE_PER_TOPIC_BYTES,
         extract_timestamp: Callable[[dict[str, Any]], float] | None = None,
     ) -> None:
-        """Subscribe to a topic, defaulting timestamps to the configured payload field."""
+        """Subscribe to a topic or wildcard, defaulting timestamps to the payload field.
+
+        MQTT wildcards (``+`` single level, ``#`` multi level) expand against the topics
+        seen during discovery -- each match gets its own buffer and inferred schema.
+        Topics that first appear after discovery are not auto-added; re-subscribe to
+        pick them up.
+
+        Raises:
+            TopicNotFoundError: If a wildcard matches no discovered topic.
+            ValueError: If a pipeline is attached to a wildcard matching several topics
+                (a pipeline's cadence is defined over exactly one topic).
+
+        """
         if extract_timestamp is None and self._timestamp_field is not None:
             extract_timestamp = self._extract_payload_timestamp
+
+        if "+" in topic or "#" in topic:
+            matches = [
+                candidate
+                for candidate in self.available_topics
+                if paho.topic_matches_sub(topic, candidate)
+            ]
+            if not matches:
+                raise base.TopicNotFoundError(topic)
+            if pipeline is not None and len(matches) > 1:
+                raise ValueError(
+                    f"Cannot attach a pipeline to wildcard '{topic}' matching "
+                    f"{len(matches)} topics; a pipeline's cadence is defined over one topic."
+                )
+            for match in matches:
+                super().subscribe(
+                    match,
+                    pipeline=pipeline,
+                    overwrite=overwrite,
+                    buffer_size_bytes=buffer_size_bytes,
+                    extract_timestamp=extract_timestamp,
+                )
+            logging.info("Wildcard '%s' expanded to %d topic(s)", topic, len(matches))
+            return
+
         super().subscribe(
             topic,
             pipeline=pipeline,

--- a/test/sink/test_mqtt.py
+++ b/test/sink/test_mqtt.py
@@ -204,3 +204,70 @@ def test_timestamp_field_used_for_buffered_messages(make_sink: MakeSink) -> None
     assert stamps[0] == pytest.approx(1700000000.5)  # retained, redelivered on subscribe
     assert stamps[1] == pytest.approx(1700000001.0)
     assert stamps[2] > 1750000000  # fell back to (much later) arrival time
+
+
+# -- wildcard subscriptions -----------------------------------------------------------
+
+
+def test_wildcard_hash_expands_to_all_matches(make_sink: MakeSink) -> None:
+    sink = make_sink(
+        retained={
+            "freezer/1/status": [b'{"temp": -18.5}'],
+            "freezer/2/status": [b'{"door": "open"}'],
+            "plant/pump": [b'{"pressure": 4.2}'],
+        }
+    )
+    sink.subscribe("freezer/#")
+
+    # Both freezer topics subscribed individually, each with its own schema; plant untouched.
+    assert "freezer/1/status" in sink._fake.topic_callbacks
+    assert "freezer/2/status" in sink._fake.topic_callbacks
+    assert "plant/pump" not in sink._fake.topic_callbacks
+    assert sink._struct("freezer/1/status").field("temp").type == pa.float64()
+    assert sink._struct("freezer/2/status").field("door").type == pa.string()
+
+    sink._fake.deliver("freezer/1/status", b'{"temp": -12.0}')
+    sink._fake.deliver("freezer/2/status", b'{"door": "closed"}')
+    buffers = sorted(pathlib.Path(settings.CACHE_DIRECTORY).rglob("current.jsonl"))
+    assert len(buffers) == 2  # one buffer per concrete topic
+
+
+def test_wildcard_plus_matches_single_level_only(make_sink: MakeSink) -> None:
+    sink = make_sink(
+        retained={
+            "plant/a/temp": [b'{"v": 1}'],
+            "plant/a/b/temp": [b'{"v": 2}'],
+        }
+    )
+    sink.subscribe("plant/+/temp")
+    assert "plant/a/temp" in sink._fake.topic_callbacks
+    assert "plant/a/b/temp" not in sink._fake.topic_callbacks
+
+
+def test_wildcard_without_matches_raises(make_sink: MakeSink) -> None:
+    from src.sink import base as sink_base
+
+    sink = make_sink(retained={"plant/pump": [b'{"v": 1}']})
+    with pytest.raises(sink_base.TopicNotFoundError):
+        sink.subscribe("garage/#")
+
+
+def test_wildcard_with_pipeline_requires_single_match(make_sink: MakeSink) -> None:
+    sink = make_sink(
+        retained={
+            "freezer/1/status": [b'{"temp": -18.5, "t": 0.0}'],
+            "freezer/2/status": [b'{"temp": -17.0, "t": 0.0}'],
+        }
+    )
+    pipeline = MagicMock()
+    pipeline.cadence = Cadence(
+        topic="freezer/1/status",
+        when=OnEvent(predicate="\"freezer/1/status\"['temp'] > -15"),
+    )
+    with pytest.raises(ValueError, match="wildcard"):
+        sink.subscribe("freezer/#", pipeline=pipeline)
+
+    # A wildcard resolving to exactly one topic accepts a pipeline.
+    sink.subscribe("freezer/1/+", pipeline=pipeline, extract_timestamp=lambda m: m["t"])
+    sink._fake.deliver("freezer/1/status", json.dumps({"temp": -12.0, "t": 1.0}).encode())
+    assert [call.args[0] for call in pipeline.run_at.call_args_list] == [1.0]


### PR DESCRIPTION
Closes the one deliberately deferred item from #108, stacked on #113.

**Wildcard subscriptions** (`freezer/#`, `plant/+/temp`) now work: patterns expand against the topics seen during discovery via paho's `topic_matches_sub`, and **each match gets its own buffer and inferred schema**, so per-unit fleet data stays independently queryable — the scoping doc's original use case (`factory/line3/#`) verbatim.

Scope rules, documented in the runbook:
- Topics that first appear **after** discovery are not auto-added (re-subscribe to pick them up) — consistent with the sink's discovery-window design; lazy pickup is possible follow-up work.
- Attaching a **pipeline** to a wildcard requires it to resolve to exactly one topic (a cadence is defined over a single topic); multi-match + pipeline raises a clear error.

**Verified against a real mosquitto broker**: one `freezer/#` subscription buffered three fleet units independently, each queryable by SQL. Fake-broker tests cover expansion, `+` single-level semantics, no-match `TopicNotFoundError`, and the pipeline rules. 164 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
