### PR TITLE
Add PlotJuggler integration: flattened exports and a composition runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ meow 🐱 4 topics 🐱💤🎯
 - [MQTT](./doc/runbooks/iot_mqtt.md) — live IoT topics, Sparkplug B, edge recording
 - [PostgreSQL / TimescaleDB](./doc/runbooks/iot_postgres.md) — every table is a topic
 - [InfluxDB 3](./doc/runbooks/iot_influxdb.md) — every measurement is a topic
+- [PlotJuggler](./doc/runbooks/plotjuggler.md) — open Bagel's MCAP outputs directly; flattened CSV/Parquet exports
 
 ## 📦 Integrations
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-jazzy:
@@ -48,7 +48,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-iron:
@@ -74,7 +74,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-humble:
@@ -100,7 +100,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic:
@@ -124,7 +124,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic-cv:
@@ -148,7 +148,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   px4:
@@ -171,7 +171,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   ardupilot:
@@ -194,7 +194,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   betaflight:
@@ -217,7 +217,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   apache-arrow:
@@ -240,7 +240,7 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data
 
   iot:
@@ -265,5 +265,5 @@ services:
       # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
-      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      - "${HOME:?HOME must be set}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts"
       # - <path-to-local-data>:/home/ubuntu/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,8 +18,12 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-jazzy:
     image: ghcr.io/extelligence-ai/bagel/ros2-jazzy:latest
@@ -40,8 +44,12 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-iron:
     image: ghcr.io/extelligence-ai/bagel/ros2-iron:latest
@@ -62,8 +70,12 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-humble:
     image: ghcr.io/extelligence-ai/bagel/ros2-humble:latest
@@ -84,8 +96,12 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic:
     image: ghcr.io/extelligence-ai/bagel/ros1-noetic:latest
@@ -104,8 +120,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic-cv:
     image: ghcr.io/extelligence-ai/bagel/ros1-noetic-cv:latest
@@ -124,8 +144,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   px4:
     image: ghcr.io/extelligence-ai/bagel/px4:latest
@@ -143,8 +167,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   ardupilot:
     image: ghcr.io/extelligence-ai/bagel/ardupilot:latest
@@ -162,8 +190,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   betaflight:
     image: ghcr.io/extelligence-ai/bagel/betaflight:latest
@@ -181,8 +213,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   apache-arrow:
     image: ghcr.io/extelligence-ai/bagel/arrow:latest
@@ -200,8 +236,12 @@ services:
     ports:
       - "${MCP_SERVER_PORT}:${MCP_SERVER_PORT}"
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data
 
   iot:
     image: ghcr.io/extelligence-ai/bagel/iot:latest
@@ -221,5 +261,9 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # volumes:
-    #   - <path-to-local-data>:/home/ubuntu/data
+    volumes:
+      # Artifacts (reduced bags, snippets, exports) land on the host, so desktop
+      # tools like PlotJuggler can open them directly. On Linux, run
+      # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
+      - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # - <path-to-local-data>:/home/ubuntu/data

--- a/doc/runbooks/plotjuggler.md
+++ b/doc/runbooks/plotjuggler.md
@@ -11,7 +11,11 @@ PlotJuggler (≥ 3.6) opens them natively, any profile:
 
 > Find every hard brake in this bag and cut ±10s clips around each.
 
-…then drag the clips from `~/.bagel/artifacts/` into PlotJuggler.
+…then drag the clips from `~/.bagel/artifacts/` into PlotJuggler. This works even when
+Bagel runs in Docker: the compose services mount the artifact directory to the host, so
+everything Bagel writes is immediately visible to desktop tools. (On Linux, run
+`mkdir -p ~/.bagel/artifacts` once before the first `docker compose run` so the
+directory is owned by your user.)
 
 ## Flattened exports for the CSV/Parquet loaders
 

--- a/doc/runbooks/plotjuggler.md
+++ b/doc/runbooks/plotjuggler.md
@@ -1,0 +1,50 @@
+# Bagel + PlotJuggler
+
+[PlotJuggler](https://plotjuggler.com/) is where you *look* at signals; Bagel is where
+you *ask questions* and decide what data to keep. They compose naturally: chat with
+Bagel to find and cut the interesting windows, then eyeball them in PlotJuggler.
+
+## Open Bagel's outputs directly (no export needed)
+
+Every reduced bag and event snippet Bagel writes is a standard `.mcap` file —
+PlotJuggler (≥ 3.6) opens them natively, any profile:
+
+> Find every hard brake in this bag and cut ±10s clips around each.
+
+…then drag the clips from `~/.bagel/artifacts/` into PlotJuggler.
+
+## Flattened exports for the CSV/Parquet loaders
+
+Bagel's default CSV/Parquet exports keep each topic as a struct column (great for SQL,
+opaque to plotting tools). Pass `flatten: true` to get **one scalar column per
+signal**, named the way PlotJuggler users expect (`/imu/linear_acceleration/x`):
+
+```yaml
+tasks:
+  - module: src.pipeline.tasks.write_topics_to_file
+    args: {topics: ["/imu"], output_format: csv, flatten: true}
+    lookback: {last: 10, unit: second}
+```
+
+Or conversationally:
+
+> Export the 30 seconds around that anomaly as a flattened CSV for PlotJuggler.
+
+Non-scalar fields (lists, maps) are skipped; the `timestamp_seconds` column comes
+first, ready for PlotJuggler's "use column as X axis" prompt.
+
+## Watching live data side by side
+
+PlotJuggler's MQTT/ROS streaming plugins can subscribe to the **same broker or bridge**
+Bagel is watching — live curves in PlotJuggler while Bagel runs event detection and
+standing pipelines on the identical stream. No integration needed; point both at the
+same endpoint.
+
+## Which tool when?
+
+| You want to… | Use |
+| --- | --- |
+| Eyeball signals, zoom, compare curves | PlotJuggler |
+| Ask questions in plain language ("did it overheat?") | Bagel |
+| Find events and keep only the data around them | Bagel |
+| Inspect the reduced/snippet output | PlotJuggler (opens the `.mcap` directly) |

--- a/src/pipeline/flatten.py
+++ b/src/pipeline/flatten.py
@@ -1,0 +1,66 @@
+"""Flatten struct-shaped topic relations into plain scalar columns.
+
+Bagel's standard relation shape is `timestamp_seconds` plus one STRUCT column per
+topic -- great for SQL, but plotting tools (PlotJuggler's CSV/Parquet loaders, pandas,
+spreadsheets) want one scalar column per signal. `flatten()` expands every struct
+leaf into its own column named `topic/field/subfield`, matching the series naming
+PlotJuggler users know from ROS (e.g. `/imu/linear_acceleration/x`).
+
+Non-scalar leaves (lists, maps) are skipped -- they have no meaningful single-column
+representation for plotting.
+"""
+
+import logging
+
+import duckdb
+import pyarrow as pa
+
+from settings import settings
+from src.source.postgres import quote_identifier
+
+# Leaf types that become columns; anything else (lists, maps, unions) is skipped.
+_SCALAR_CHECKS = (
+    pa.types.is_integer,
+    pa.types.is_floating,
+    pa.types.is_boolean,
+    pa.types.is_string,
+    pa.types.is_large_string,
+    pa.types.is_timestamp,
+    pa.types.is_decimal,
+)
+
+
+def _is_scalar(dtype: pa.DataType) -> bool:
+    return any(check(dtype) for check in _SCALAR_CHECKS)
+
+
+def _leaf_selects(column: str, dtype: pa.DataType, path: list[str]) -> list[str]:
+    """Build SELECT expressions for every scalar leaf under a (possibly nested) type."""
+    if pa.types.is_struct(dtype):
+        selects: list[str] = []
+        for field in dtype:
+            selects.extend(_leaf_selects(column, field.type, [*path, field.name]))
+        return selects
+    if not _is_scalar(dtype):
+        logging.debug("Skipping non-scalar field '%s/%s'", column, "/".join(path))
+        return []
+    accessor = quote_identifier(column) + "".join(f"['{part}']" for part in path)
+    alias = quote_identifier("/".join([column, *path]) if path else column)
+    return [f"{accessor} AS {alias}"]
+
+
+def flatten(relation: duckdb.DuckDBPyRelation) -> duckdb.DuckDBPyRelation:
+    """Expand struct topic columns into one scalar column per signal.
+
+    The `timestamp_seconds` column is kept first and unchanged; every struct column
+    contributes `topic/field/subfield` columns for its scalar leaves.
+    """
+    schema = relation.limit(0).arrow().schema
+
+    selects = []
+    for field in schema:
+        if field.name == settings.TIMESTAMP_SECONDS_COLUMN_NAME:
+            selects.append(quote_identifier(field.name))
+        else:
+            selects.extend(_leaf_selects(field.name, field.type, []))
+    return relation.project(", ".join(selects))

--- a/src/pipeline/flatten.py
+++ b/src/pipeline/flatten.py
@@ -44,7 +44,11 @@ def _leaf_selects(column: str, dtype: pa.DataType, path: list[str]) -> list[str]
     if not _is_scalar(dtype):
         logging.debug("Skipping non-scalar field '%s/%s'", column, "/".join(path))
         return []
-    accessor = quote_identifier(column) + "".join(f"['{part}']" for part in path)
+    # Escape quotes: struct field names come from data (CSV headers, JSON keys) and
+    # may contain them.
+    accessor = quote_identifier(column) + "".join(
+        "['{}']".format(part.replace("'", "''")) for part in path
+    )
     alias = quote_identifier("/".join([column, *path]) if path else column)
     return [f"{accessor} AS {alias}"]
 

--- a/src/pipeline/tasks/write_topics_to_file.py
+++ b/src/pipeline/tasks/write_topics_to_file.py
@@ -5,7 +5,7 @@ import pathlib
 from enum import Enum
 
 from src.di import module
-from src.pipeline import base, messages
+from src.pipeline import base, flatten, messages
 
 
 class OutputFormat(Enum):
@@ -23,6 +23,7 @@ class WriteTopicsToFile(base.ArtifactMixin, messages.TopicMessageMixin, base.Tas
         topics: list[str] | None,
         output_format: str,
         ffill: bool = False,
+        flatten: bool = False,
     ) -> None:
         """Initialize the task.
 
@@ -31,6 +32,10 @@ class WriteTopicsToFile(base.ArtifactMixin, messages.TopicMessageMixin, base.Tas
                 topics will be written.
             output_format (str): The format of the output files (e.g., "csv", "parquet").
             ffill (bool): Whether to apply forward-fill to the topic messages.
+            flatten (bool): If True, expand each topic's struct into one scalar column per
+                signal, named `topic/field/subfield` -- the shape plotting tools expect
+                (e.g. PlotJuggler's CSV/Parquet loaders). Non-scalar fields (lists, maps)
+                are skipped. Defaults to False (structs preserved).
 
         Raises:
             ValueError: If the topics list is empty when specified.
@@ -41,6 +46,7 @@ class WriteTopicsToFile(base.ArtifactMixin, messages.TopicMessageMixin, base.Tas
         self._topics = topics
         self._output_format = OutputFormat(output_format)
         self._ffill = ffill
+        self._flatten = flatten
 
     def execute(self, asof_seconds: float, lookback: base.Lookback | None) -> list[pathlib.Path]:
         """Execute the task at the given time."""
@@ -48,6 +54,8 @@ class WriteTopicsToFile(base.ArtifactMixin, messages.TopicMessageMixin, base.Tas
         relation = self.to_duckdb(
             topics=topics, asof_seconds=asof_seconds, lookback=lookback, ffill=self._ffill
         )
+        if self._flatten:
+            relation = flatten.flatten(relation)
 
         output_file = self.artifact_path(asof_seconds, f".{self._output_format.value}")
 

--- a/test/pipeline/test_flatten.py
+++ b/test/pipeline/test_flatten.py
@@ -124,3 +124,16 @@ def test_end_to_end_flattened_parquet(
         f'SELECT MIN("message/accel_x") FROM \'{artifact}\''  # noqa: S608
     ).fetchone()
     assert minimum == -13.0
+
+
+def test_field_names_with_quotes_are_escaped() -> None:
+    # Field names come from data (CSV headers, JSON keys) and may contain quotes.
+    relation = _relation(
+        f"""
+        SELECT 1.0 AS "{TS}",
+               struct_pack("it's" := 20.0::DOUBLE) AS "sensor"
+        """
+    )
+    flat = flatten.flatten(relation)
+    assert flat.columns == [TS, "sensor/it's"]
+    assert flat.fetchone() == (1.0, 20.0)

--- a/test/pipeline/test_flatten.py
+++ b/test/pipeline/test_flatten.py
@@ -1,0 +1,126 @@
+"""Tests for flattening struct topic relations into plot-ready scalar columns."""
+
+import pathlib
+
+import duckdb
+import pytest
+
+import server
+from settings import settings
+from src.pipeline import flatten
+
+TS = settings.TIMESTAMP_SECONDS_COLUMN_NAME
+
+
+def _relation(sql: str) -> duckdb.DuckDBPyRelation:
+    return duckdb.sql(sql)
+
+
+def test_flattens_nested_structs_with_slash_names() -> None:
+    relation = _relation(
+        f"""
+        SELECT 1.5::DOUBLE AS "{TS}",
+               struct_pack(
+                   linear_acceleration := struct_pack(x := -12.0::DOUBLE, z := 9.8::DOUBLE),
+                   frame := 'base'
+               ) AS "/imu"
+        """
+    )
+    flat = flatten.flatten(relation)
+    assert flat.columns == [
+        TS,
+        "/imu/linear_acceleration/x",
+        "/imu/linear_acceleration/z",
+        "/imu/frame",
+    ]
+    assert flat.fetchone() == (1.5, -12.0, 9.8, "base")
+
+
+def test_multiple_topics_and_timestamp_stays_first() -> None:
+    relation = _relation(
+        f"""
+        SELECT 1.0 AS "{TS}",
+               struct_pack(temp := -18.5) AS "freezer/1/status",
+               struct_pack(pressure := 4.2) AS "plant/pump"
+        """
+    )
+    flat = flatten.flatten(relation)
+    assert flat.columns == [TS, "freezer/1/status/temp", "plant/pump/pressure"]
+
+
+def test_non_scalar_leaves_are_skipped() -> None:
+    relation = _relation(
+        f"""
+        SELECT 1.0 AS "{TS}",
+               struct_pack(temp := 20.0, alarms := ['a', 'b']) AS "sensor"
+        """
+    )
+    flat = flatten.flatten(relation)
+    assert flat.columns == [TS, "sensor/temp"]
+
+
+def test_end_to_end_flattened_csv_is_plot_ready(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+    result = server.run_pipeline(
+        {
+            "name": "flat_export",
+            "site": "test_site",
+            "asset": "test_asset",
+            "path": "./data/sample/pyarrow/csv/flight.csv",
+            "allow_failure": False,
+            "cadence": {"topic": "message", "when": "once_at_end"},
+            "tasks": [
+                {
+                    "module": "src.pipeline.tasks.write_topics_to_file",
+                    "setup": {"timestamp_column": "t", "timestamp_format": "seconds"},
+                    "args": {
+                        "topics": ["message"],
+                        "output_format": "csv",
+                        "flatten": True,
+                    },
+                }
+            ],
+        }
+    )
+    (artifact,) = result["artifacts"]
+    header, first = pathlib.Path(artifact).read_text().splitlines()[:2]
+    # One scalar column per signal -- what PlotJuggler's CSV loader expects.
+    assert header == f"{TS},message/t,message/accel_x,message/vel"
+    values = first.split(",")
+    assert float(values[2]) == -0.5  # accel_x is numeric, not a struct blob
+
+
+def test_end_to_end_flattened_parquet(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+    result = server.run_pipeline(
+        {
+            "name": "flat_parquet",
+            "site": "test_site",
+            "asset": "test_asset",
+            "path": "./data/sample/pyarrow/csv/flight.csv",
+            "allow_failure": False,
+            "cadence": {"topic": "message", "when": "once_at_end"},
+            "tasks": [
+                {
+                    "module": "src.pipeline.tasks.write_topics_to_file",
+                    "setup": {"timestamp_column": "t", "timestamp_format": "seconds"},
+                    "args": {
+                        "topics": ["message"],
+                        "output_format": "parquet",
+                        "flatten": True,
+                    },
+                }
+            ],
+        }
+    )
+    (artifact,) = result["artifacts"]
+    table = duckdb.sql(f"SELECT * FROM '{artifact}'")  # noqa: S608
+    assert "message/accel_x" in table.columns
+    (minimum,) = duckdb.sql(
+        f'SELECT MIN("message/accel_x") FROM \'{artifact}\''  # noqa: S608
+    ).fetchone()
+    assert minimum == -13.0


### PR DESCRIPTION
Makes Bagel and PlotJuggler compose cleanly, stacked on #116.

**Level 0 — already true, now documented**: every reduced bag and event snippet Bagel writes is a standard `.mcap` that [PlotJuggler ≥ 3.6 opens natively](https://foxglove.dev/blog/plotjuggler-adds-support-for-mcap); PJ's MQTT/ROS streaming plugins can watch the same broker/bridge Bagel does. The new runbook captures the workflow and includes a which-tool-when table — the honest answer to #63's "compare yourselves to PlotJuggler" (they compose, not compete).

**Level 1 — the real gap, closed**: our CSV/Parquet exports kept topics as STRUCT columns (opaque blobs to plotting tools). `write_topics_to_file` gains **`flatten: true`**: one scalar column per signal, named `topic/field/subfield` — the series naming PJ users know from ROS. `timestamp_seconds` first, non-scalar leaves skipped, works for CSV and Parquet (both PJ loaders).

Real-data check: flattening the bundled ROS2 MCAP sample yields `/fluid_pressure/header/stamp/sec`-style columns exactly matching PJ's conventions.

**Deferred (Level 2)**: an `export_for_plotjuggler` tool that also generates a PJ layout `.xml` with the right curves pre-framed — "show me the second brake event in PlotJuggler" as one chat message.

**Tests**: nested-struct flattening with slash names, multi-topic ordering, non-scalar skipping, CSV + Parquet end-to-end through `run_pipeline`. 173 passed, ruff clean. (Honesty note: output shape verified structurally against PJ's documented loader expectations; not eyeballed inside the PJ GUI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
