### PR TITLE
Add export_for_plotjuggler: pre-framed PlotJuggler sessions from one sentence

### DIFF
--- a/doc/runbooks/plotjuggler.md
+++ b/doc/runbooks/plotjuggler.md
@@ -37,6 +37,23 @@ Or conversationally:
 Non-scalar fields (lists, maps) are skipped; the `timestamp_seconds` column comes
 first, ready for PlotJuggler's "use column as X axis" prompt.
 
+## One-sentence sessions: pre-framed layouts
+
+Ask Bagel to hand an event straight to PlotJuggler:
+
+> Show me the second brake event in PlotJuggler.
+
+Bagel calls `export_for_plotjuggler`, which writes the flattened CSV **plus a layout
+file** with the curves pre-added and the window pre-framed, then returns the command:
+
+```bash
+plotjuggler -n -l ~/.bagel/artifacts/plotjuggler/brake_event_2/brake_event_2_layout.xml
+```
+
+PlotJuggler opens with the event already plotted and zoomed -- the layout references
+the data file, so a single `-l` flag reloads everything. Pass `signals` to choose
+which curves to plot (default: all numeric signals, capped at 8).
+
 ## Watching live data side by side
 
 PlotJuggler's MQTT/ROS streaming plugins can subscribe to the **same broker or bridge**

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
 from src.di.types.topic_sink import TopicSink, guess_host, guess_port
-from src.pipeline import base, batch, capabilities, windows
+from src.pipeline import base, batch, capabilities, plotjuggler, windows
 from src.sink import startup
 
 server = FastMCP(
@@ -657,6 +657,76 @@ def run_pipeline_batch(config: dict[str, Any], paths: list[str]) -> dict[str, An
     expanded = batch.expand_paths(paths)
     results = batch.run_batch(config, expanded)
     return batch.summarize(results)
+
+
+@server.tool(
+    title="Export an event window for PlotJuggler",
+    description=(
+        "Export a time window of topic data as a PlotJuggler session: a flattened CSV "
+        "(one scalar column per signal) plus a layout file with the curves pre-added "
+        "and the window pre-framed. Opening the returned command shows the event "
+        "already plotted and zoomed. Use after preview_pipeline to hand an event to a "
+        "human for visual inspection."
+    ),
+)
+def export_for_plotjuggler(  # noqa: PLR0913
+    path: str,
+    topics: list[str],
+    start_seconds: float,
+    end_seconds: float,
+    name: str = "event",
+    signals: list[str] | None = None,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Export a time window as a ready-to-open PlotJuggler session.
+
+    Writes a flattened CSV of the window (columns named `topic/field/subfield`, the
+    naming PlotJuggler users expect) and a layout `.xml` that references the CSV,
+    pre-adds the signal curves, and frames the time range -- so PlotJuggler opens the
+    event already plotted and zoomed.
+
+    Args:
+        path (str): Filesystem path or URL to the data source.
+        topics (list[str]): The topics to include in the export.
+        start_seconds (float): Window start (also the plot's framed x range start).
+        end_seconds (float): Window end.
+        name (str, optional): Session name, used for the output files and the tab
+            title. Defaults to "event".
+        signals (list[str] | None, optional): Flattened signal names to plot (e.g.
+            "/imu/linear_acceleration/x"). If None, all numeric signals are plotted,
+            capped at 8. Defaults to None.
+        args (dict[str, Any] | None, optional): Additional constructor arguments used
+            to create the `SourceFactory` and `TopicRegistry`.
+
+    Returns:
+        dict[str, Any]: `csv` and `layout` paths, the plotted `curves`, and `command`
+            -- run it (or double-click the layout) to open the session in PlotJuggler.
+
+    Examples:
+        As an LLM prompt:
+            Show me the second brake event in PlotJuggler.
+
+        As a Python call:
+            >>> export_for_plotjuggler("./flight.mcap", ["/imu"], 118.9, 138.9)
+
+    """
+    ds_type = resolve(path)
+    factory = module.provide(
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": path, **(args or {})}
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+
+    relation = dataset.to_duckdb(
+        factory, registry, topics, start_seconds=start_seconds, end_seconds=end_seconds
+    )
+    return plotjuggler.export_window(
+        relation,
+        name=name,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        signals=signals,
+    )
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -712,7 +712,8 @@ def export_for_plotjuggler(  # noqa: PLR0913
     """
     ds_type = resolve(path)
     factory = module.provide(
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": path, **(args or {})}
+        # args first: the explicit `path` parameter must always win.
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})

--- a/src/pipeline/plotjuggler.py
+++ b/src/pipeline/plotjuggler.py
@@ -1,0 +1,184 @@
+"""Export an event window as a PlotJuggler session: flattened CSV + layout file.
+
+Generates a layout ``.xml`` (schema matching real PlotJuggler >= 3.x layouts, e.g. the
+PX4 sample views) that references the exported CSV, pre-adds the signal curves, and
+frames the time/value ranges -- so ``plotjuggler -l <layout>`` opens the event already
+plotted and zoomed. Curve names are the flattened column headers
+(``/imu/linear_acceleration/x``), which is exactly how PlotJuggler's CSV loader names
+series.
+"""
+
+import logging
+import pathlib
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import duckdb
+
+from settings import settings
+from src.pipeline import flatten as flatten_module
+from src.source.postgres import quote_identifier
+
+# PlotJuggler's default curve palette (as seen in its saved layouts).
+PALETTE = ("#1f77b4", "#d62728", "#1ac938", "#ff7f0e", "#f14cc1", "#9467bd", "#17becf")
+
+MAX_CURVES = 8
+
+_NUMERIC_PREFIXES = ("TINYINT", "SMALLINT", "INTEGER", "BIGINT", "HUGEINT", "UTINYINT",
+                     "USMALLINT", "UINTEGER", "UBIGINT", "FLOAT", "DOUBLE", "DECIMAL")
+
+
+def _numeric_columns(relation: duckdb.DuckDBPyRelation) -> list[str]:
+    """Return the plottable (numeric) columns, excluding the timestamp."""
+    return [
+        name
+        for name, dtype in zip(relation.columns, relation.types, strict=True)
+        if name != settings.TIMESTAMP_SECONDS_COLUMN_NAME
+        and str(dtype).upper().startswith(_NUMERIC_PREFIXES)
+    ]
+
+
+def build_layout(  # noqa: PLR0913
+    csv_file: pathlib.Path,
+    curves: list[str],
+    x_range: tuple[float, float],
+    y_range: tuple[float, float],
+    time_axis: str,
+    tab_name: str,
+) -> str:
+    """Build a PlotJuggler layout XML string with one pre-framed time-series plot."""
+    root = ET.Element("root")
+
+    tabbed = ET.SubElement(root, "tabbed_widget", parent="main_window", name="Main Window")
+    tab = ET.SubElement(tabbed, "Tab", containers="1", tab_name=tab_name)
+    container = ET.SubElement(tab, "Container")
+    splitter = ET.SubElement(container, "DockSplitter", count="1", orientation="-", sizes="1")
+    dock = ET.SubElement(splitter, "DockArea", name="...")
+    plot = ET.SubElement(
+        dock, "plot", style="Lines", mode="TimeSeries", flip_y="false", flip_x="false"
+    )
+    ET.SubElement(
+        plot,
+        "range",
+        bottom=f"{y_range[0]:.6f}",
+        top=f"{y_range[1]:.6f}",
+        left=f"{x_range[0]:.6f}",
+        right=f"{x_range[1]:.6f}",
+    )
+    ET.SubElement(plot, "limitY")
+    for i, curve in enumerate(curves):
+        ET.SubElement(plot, "curve", color=PALETTE[i % len(PALETTE)], name=curve)
+    ET.SubElement(tabbed, "currentTabIndex", index="0")
+
+    # Absolute timestamps so the framed range matches the data's epoch seconds.
+    ET.SubElement(root, "use_relative_time_offset", enabled="0")
+
+    plugins = ET.SubElement(root, "Plugins")
+    csv_plugin = ET.SubElement(plugins, "plugin", ID="DataLoad CSV")
+    ET.SubElement(csv_plugin, "default", delimiter="0", time_axis=time_axis)
+
+    datafiles = ET.SubElement(root, "previouslyLoaded_Datafiles")
+    file_info = ET.SubElement(datafiles, "fileInfo", prefix="", filename=str(csv_file))
+    ET.SubElement(file_info, "selected_datasources", value=";".join(curves))
+    ET.SubElement(file_info, "plugin", ID="DataLoad CSV")
+
+    ET.SubElement(root, "customMathEquations")
+    ET.SubElement(root, "snippets")
+
+    ET.indent(root, space=" ")
+    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+
+def export_window(  # noqa: PLR0913
+    relation: duckdb.DuckDBPyRelation,
+    name: str,
+    start_seconds: float,
+    end_seconds: float,
+    signals: list[str] | None = None,
+    output_directory: str | pathlib.Path | None = None,
+) -> dict[str, Any]:
+    """Write a flattened CSV of the relation plus a PlotJuggler layout framing it.
+
+    Args:
+        relation: A standard Bagel relation (timestamp_seconds + struct topic columns),
+            already restricted to the window of interest.
+        name: Session name (used for the output directory and tab title).
+        start_seconds: Window start (frames the plot's x range).
+        end_seconds: Window end.
+        signals: Flattened signal names to plot (e.g. "/imu/linear_acceleration/x").
+            If None, all numeric signals are plotted, capped at MAX_CURVES.
+        output_directory: Where to write. Defaults to
+            `<ARTIFACT_DIRECTORY>/plotjuggler/<name>`.
+
+    Returns:
+        ``{"csv", "layout", "curves", "command"}`` -- the written paths, plotted
+        curves, and the command that opens the session pre-framed.
+
+    Raises:
+        ValueError: If a requested signal does not exist or nothing is plottable.
+
+    """
+    flat = flatten_module.flatten(relation)
+
+    available = _numeric_columns(flat)
+    if signals is not None:
+        missing = sorted(set(signals) - set(flat.columns))
+        if missing:
+            raise ValueError(
+                f"Unknown signals: {missing}. Available numeric signals: {available}"
+            )
+        curves = list(signals)
+    else:
+        curves = available[:MAX_CURVES]
+        if len(available) > MAX_CURVES:
+            logging.info(
+                "Plotting the first %d of %d numeric signals; pass 'signals' to choose",
+                MAX_CURVES,
+                len(available),
+            )
+    if not curves:
+        raise ValueError("No numeric signals to plot in the selected topics.")
+
+    name = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "event"
+    directory = (
+        pathlib.Path(output_directory)
+        if output_directory
+        else pathlib.Path(settings.ARTIFACT_DIRECTORY) / "plotjuggler" / name
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    csv_file = directory / f"{name}.csv"
+    layout_file = directory / f"{name}_layout.xml"
+
+    flat.to_csv(file_name=str(csv_file))
+
+    # Frame the y range from the actual data (10% padding).
+    aggregates = ", ".join(
+        f"MIN({quote_identifier(c)}), MAX({quote_identifier(c)})" for c in curves
+    )
+    bounds = flat.aggregate(aggregates).fetchone()
+    minima = [b for b in bounds[0::2] if b is not None]
+    maxima = [b for b in bounds[1::2] if b is not None]
+    low = float(min(minima)) if minima else 0.0
+    high = float(max(maxima)) if maxima else 1.0
+    pad = (high - low) * 0.1 or 1.0
+    y_range = (low - pad, high + pad)
+
+    layout_file.write_text(
+        build_layout(
+            csv_file=csv_file,
+            curves=curves,
+            x_range=(start_seconds, end_seconds),
+            y_range=y_range,
+            time_axis=settings.TIMESTAMP_SECONDS_COLUMN_NAME,
+            tab_name=name,
+        )
+    )
+    logging.info("Wrote %s and %s", csv_file, layout_file)
+
+    return {
+        "csv": str(csv_file),
+        "layout": str(layout_file),
+        "curves": curves,
+        "command": f"plotjuggler -n -l '{layout_file}'",
+    }

--- a/src/pipeline/plotjuggler.py
+++ b/src/pipeline/plotjuggler.py
@@ -123,10 +123,13 @@ def export_window(  # noqa: PLR0913
 
     available = _numeric_columns(flat)
     if signals is not None:
-        missing = sorted(set(signals) - set(flat.columns))
-        if missing:
+        # Validate against the numeric set: a signal that exists but is not plottable
+        # (strings, timestamps) must fail cleanly here, not in the y-range math below.
+        unusable = sorted(set(signals) - set(available))
+        if unusable:
             raise ValueError(
-                f"Unknown signals: {missing}. Available numeric signals: {available}"
+                f"Unknown or non-numeric signals: {unusable}. "
+                f"Available numeric signals: {available}"
             )
         curves = list(signals)
     else:

--- a/test/pipeline/test_plotjuggler_export.py
+++ b/test/pipeline/test_plotjuggler_export.py
@@ -1,0 +1,99 @@
+"""Tests for the PlotJuggler session export (flattened CSV + framed layout)."""
+
+import pathlib
+import xml.etree.ElementTree as ET
+
+import duckdb
+import pytest
+
+import server
+from settings import settings
+from src.pipeline import plotjuggler
+
+TS = settings.TIMESTAMP_SECONDS_COLUMN_NAME
+SAMPLE = "./data/sample/pyarrow/csv/flight.csv"
+SAMPLE_ARGS = {"timestamp_column": "t", "timestamp_format": "seconds"}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def _export(**overrides: object) -> dict:
+    params = {
+        "path": SAMPLE,
+        "topics": ["message"],
+        "start_seconds": 15.0,
+        "end_seconds": 25.0,
+        "name": "brake event 1",
+        "args": SAMPLE_ARGS,
+    }
+    params.update(overrides)
+    return server.export_for_plotjuggler(**params)
+
+
+def test_layout_matches_plotjuggler_schema() -> None:
+    result = _export()
+    root = ET.parse(result["layout"]).getroot()  # noqa: S314 -- parsing our own output
+
+    plot = root.find("./tabbed_widget/Tab/Container/DockSplitter/DockArea/plot")
+    assert plot is not None
+    assert plot.get("mode") == "TimeSeries"
+
+    plot_range = plot.find("range")
+    assert float(plot_range.get("left")) == 15.0
+    assert float(plot_range.get("right")) == 25.0
+    assert float(plot_range.get("bottom")) < float(plot_range.get("top"))
+
+    # Absolute time so the framed range matches the data's epoch seconds.
+    assert root.find("use_relative_time_offset").get("enabled") == "0"
+
+    # The CSV loader defaults: our timestamp column is preconfigured as the time axis.
+    csv_plugin = root.find("./Plugins/plugin[@ID='DataLoad CSV']/default")
+    assert csv_plugin.get("time_axis") == TS
+
+    # The layout references the data file, so `plotjuggler -l layout` reloads it.
+    file_info = root.find("./previouslyLoaded_Datafiles/fileInfo")
+    assert file_info.get("filename") == result["csv"]
+    assert file_info.find("plugin").get("ID") == "DataLoad CSV"
+
+
+def test_every_curve_is_a_csv_column() -> None:
+    result = _export()
+    header = pathlib.Path(result["csv"]).read_text().splitlines()[0].split(",")
+    root = ET.parse(result["layout"]).getroot()  # noqa: S314 -- parsing our own output
+    curve_names = [curve.get("name") for curve in root.iter("curve")]
+
+    assert curve_names == result["curves"]
+    assert curve_names, "at least one curve must be plotted"
+    for name in curve_names:
+        assert name in header, f"curve '{name}' must match a CSV column exactly"
+
+
+def test_csv_is_windowed_and_command_points_at_layout() -> None:
+    result = _export()
+    lines = pathlib.Path(result["csv"]).read_text().splitlines()
+    timestamps = [float(line.split(",")[0]) for line in lines[1:]]
+    assert timestamps, "window must contain data"
+    assert min(timestamps) >= 15.0
+    assert max(timestamps) <= 25.0
+    assert result["layout"] in result["command"]
+    assert "brake_event_1" in result["layout"]  # name is snake_cased
+
+
+def test_signals_filter_and_unknown_signal_error() -> None:
+    result = _export(signals=["message/accel_x"])
+    assert result["curves"] == ["message/accel_x"]
+
+    with pytest.raises(Exception, match="Unknown signals"):
+        _export(signals=["message/not_a_signal"])
+
+
+def test_curve_cap_applies_without_explicit_signals() -> None:
+    columns = ", ".join(f"s{i:02d} := {float(i)}" for i in range(12))
+    relation = duckdb.sql(f'SELECT 1.0 AS "{TS}", struct_pack({columns}) AS wide')
+    result = plotjuggler.export_window(
+        relation, name="wide", start_seconds=0.0, end_seconds=2.0
+    )
+    assert len(result["curves"]) == plotjuggler.MAX_CURVES

--- a/test/pipeline/test_plotjuggler_export.py
+++ b/test/pipeline/test_plotjuggler_export.py
@@ -86,8 +86,24 @@ def test_signals_filter_and_unknown_signal_error() -> None:
     result = _export(signals=["message/accel_x"])
     assert result["curves"] == ["message/accel_x"]
 
-    with pytest.raises(Exception, match="Unknown signals"):
+    with pytest.raises(ValueError, match="Unknown or non-numeric signals"):
         _export(signals=["message/not_a_signal"])
+
+
+def test_non_numeric_signal_rejected_cleanly() -> None:
+    relation = duckdb.sql(
+        f'SELECT 1.0 AS "{TS}", struct_pack(temp := 20.0, mode := \'auto\') AS sensor'
+    )
+    # "sensor/mode" exists after flattening but is a string -- it must fail with a
+    # clean ValueError, not a TypeError from the y-range computation.
+    with pytest.raises(ValueError, match="non-numeric"):
+        plotjuggler.export_window(
+            relation,
+            name="x",
+            start_seconds=0.0,
+            end_seconds=2.0,
+            signals=["sensor/mode"],
+        )
 
 
 def test_curve_cap_applies_without_explicit_signals() -> None:


### PR DESCRIPTION
Level 2 of the PlotJuggler integration, stacked on #117. The Level 0/1 loop still had a manual last mile: PJ opened the exported file *empty* — you picked curves and zoomed by hand. Now:

> *"Show me the second brake event in PlotJuggler."*

…produces a **ready-to-open session**: flattened CSV + a layout `.xml` with the curves pre-added, the time range framed to the event window, and the y range fitted to the actual data. `plotjuggler -n -l <layout>` opens **already plotted and zoomed** — the layout embeds the datafile reference, so one flag reloads everything.

**Implementation notes**
- Layout schema derived from **real published PlotJuggler layouts** (PX4's official sample view), not guessed — including the two details that matter: plugin IDs use spaces (`DataLoad CSV`), and `previouslyLoaded_Datafiles` drives the auto-reload. The CSV time axis is preconfigured to `timestamp_seconds`.
- Curve names are the flattened column headers, guaranteeing they match what PJ's CSV loader produces — enforced by a test invariant (every `<curve name>` must equal a CSV column exactly).
- `signals` picks specific curves; default plots all numeric signals capped at 8.

**Verification**: 5 tests (schema assertions, curve↔column invariant, window bounds, sanitization, cap); 178 passing, ruff clean. Honesty note: validated against published layouts + ElementTree, **not eyeballed in the PJ GUI** — a demo session is generated at `~/.bagel/artifacts/plotjuggler/demo_brake_event/` for a one-double-click human check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
