### PR TITLE
Future-proof for MCP SDK v2 via a compatibility layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "mcap-protobuf-support >=0.5.0,<1.0.0",
     "mcap-ros1-support >=0.7.0,<1.0.0",
     "mcap-ros2-support >=0.5.0,<1.0.0",
+    # v2-ready via src/mcp_compat.py (verified against 2.0.0b1); raise the
+    # ceiling once v2 stable (2026-07-28) is validated end to end.
     "mcp >=1.11.0,<2.0.0",
     "pandas >=2.2.0,<3.0.0",
     "poml >=0.0.7,<1.0.0",

--- a/server.py
+++ b/server.py
@@ -5,10 +5,10 @@ from typing import Any
 
 import duckdb
 import yaml
-from mcp.server.fastmcp import FastMCP
 from poml import poml
 
 from settings import settings
+from src import mcp_compat
 from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
@@ -16,7 +16,7 @@ from src.di.types.topic_sink import TopicSink, guess_host, guess_port
 from src.pipeline import base, batch, capabilities, plotjuggler, windows
 from src.sink import startup
 
-server = FastMCP(
+server = mcp_compat.create_server(
     name="Bagel MCP Server",
     host=settings.MCP_SERVER_HOST,
     port=settings.MCP_SERVER_PORT,
@@ -735,4 +735,9 @@ if __name__ == "__main__":
         # Standing pipelines: re-establish subscriptions (and their attached pipelines)
         # on boot, so they survive container restarts.
         startup.start(settings.STARTUP_PIPELINES_FILE)
-    server.run(transport="sse")
+    mcp_compat.run_server(
+        server,
+        transport=settings.MCP_TRANSPORT,
+        host=settings.MCP_SERVER_HOST,
+        port=settings.MCP_SERVER_PORT,
+    )

--- a/settings.py
+++ b/settings.py
@@ -77,6 +77,10 @@ class Settings(BaseSettings):
     # Port of the MCP server
     MCP_SERVER_PORT: int
 
+    # MCP transport: "sse" (current default, matches the README quickstart) or
+    # "streamable-http" (the newer transport; both are supported by MCP SDK v1 and v2)
+    MCP_TRANSPORT: str = "sse"
+
 
 settings = Settings()
 

--- a/src/mcp_compat.py
+++ b/src/mcp_compat.py
@@ -1,0 +1,45 @@
+"""Compatibility layer across MCP Python SDK v1 and v2.
+
+The MCP spec revision of 2026-07-28 ships as `mcp` v2, which renames `FastMCP` to
+`MCPServer` (the legacy `mcp.server.fastmcp` module is removed) and moves the
+host/port configuration from the constructor to `run()`. The tool decorator API --
+including the `title`/`description` keywords Bagel uses -- is unchanged, and both
+the "sse" and "streamable-http" transports remain available.
+
+This module isolates those differences so `server.py` runs unmodified on either
+major version. Verified against `mcp==2.0.0b1` and the pinned 1.x release.
+See https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/.
+"""
+
+from typing import Any
+
+try:  # mcp >= 2.0
+    from mcp.server.mcpserver import MCPServer as _Server
+
+    MCP_SDK_V2 = True
+except ImportError:  # mcp 1.x
+    from mcp.server.fastmcp import FastMCP as _Server
+
+    MCP_SDK_V2 = False
+
+
+def create_server(name: str, host: str, port: int) -> Any:  # noqa: ANN401 -- SDK type varies by major version
+    """Create the MCP server object for whichever SDK major version is installed.
+
+    v1 takes host/port at construction; v2 takes them at `run()` (see `run_server`).
+    """
+    if MCP_SDK_V2:
+        return _Server(name=name)
+    return _Server(name=name, host=host, port=port)
+
+
+def run_server(server: Any, transport: str, host: str, port: int) -> None:  # noqa: ANN401
+    """Run the server on the given transport ("sse" or "streamable-http").
+
+    v2 accepts host/port as transport kwargs; v1 already received them at
+    construction and accepts only the transport name.
+    """
+    if MCP_SDK_V2:
+        server.run(transport=transport, host=host, port=port)
+    else:
+        server.run(transport=transport)

--- a/test/test_mcp_compat.py
+++ b/test/test_mcp_compat.py
@@ -1,0 +1,39 @@
+"""Tests for the MCP SDK v1/v2 compatibility layer."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import mcp_compat
+
+
+def test_create_server_exposes_the_decorator_api() -> None:
+    server = mcp_compat.create_server(name="test", host="127.0.0.1", port=18000)
+    assert hasattr(server, "tool")
+
+    @server.tool(title="Ping", description="test tool")
+    def ping() -> str:
+        """Reply with pong."""
+        return "pong"
+
+    assert callable(ping)
+    assert ping() == "pong"
+
+
+def test_run_routes_host_port_per_sdk_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = MagicMock()
+
+    monkeypatch.setattr(mcp_compat, "MCP_SDK_V2", False)
+    mcp_compat.run_server(server, transport="sse", host="h", port=1)
+    server.run.assert_called_once_with(transport="sse")
+
+    server.reset_mock()
+    monkeypatch.setattr(mcp_compat, "MCP_SDK_V2", True)
+    mcp_compat.run_server(server, transport="streamable-http", host="h", port=1)
+    server.run.assert_called_once_with(transport="streamable-http", host="h", port=1)
+
+
+def test_exactly_one_sdk_branch_is_active() -> None:
+    # Under the project venv this is v1; under the v2 beta venv it flips. Either
+    # way the flag must be a real bool and the server class importable.
+    assert isinstance(mcp_compat.MCP_SDK_V2, bool)


### PR DESCRIPTION
Prepares Bagel for the [MCP spec revision of 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/), stacked on #118.

## Exposure audit (small, by luck and by design)
- **One import**: `from mcp.server.fastmcp import FastMCP` — this module is **removed** in v2 (no alias; verified against the beta, not the announcement)
- **One run call**: `server.run(transport="sse")` — in v2, host/port move from the constructor to `run()`
- Pin already had the recommended `<2.0.0` ceiling ✅; no deprecated capabilities (roots/sampling/logging) and no `-32002` error-code literals anywhere

## Changes
- **`src/mcp_compat.py`** — isolates the two differences (import path, host/port routing); `server.py`'s 13 tools are untouched by the migration since the decorator API (`title`/`description`) is preserved in v2
- **`MCP_TRANSPORT` setting** — default `"sse"` (matches the README quickstart); `"streamable-http"` is one env var away on either SDK major
- Annotated pin with the upgrade plan (raise ceiling after v2 stable validation)

## Verification — both worlds
- **v1** (pinned SDK): full suite, **182 passing**, ruff clean
- **v2** (`mcp==2.0.0b1` in a scratch venv with the project's full dependency set): `server.py` imports on the v2 shim branch, **all 13 tools register with the v2 `MCPServer`**, and a real tool call (`query_messages` over the sample CSV) executes correctly

Every claim about the v2 API (module path `mcp.server.mcpserver`, `run()` transport literals, `run_sse_async(host, port, ...)` signature, decorator params) was probed against the installed beta, not inferred from the blog post.

## When v2 stable lands (July 28)
Raise the pin ceiling, re-run the same scratch-venv verification against `2.0.0` stable, and optionally flip `MCP_TRANSPORT` to `streamable-http` in a follow-up — no code changes expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
