### PR TITLE
Add a natural-language pipelines concept runbook, hooked from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Can’t wait to try it out? 👉 Check out the [Quickstart](#️-quickstart).
 
 - **Ask in plain language**: No deep domain expertise needed.
 - **Transparent calculations**: Deterministic SQL queries. No black-box LLM math.
-- **Event-driven data reduction**: "Keep 10s around every hard brake, drop the rest" —
-  previewed before a byte is written, live or in [batch](./doc/runbooks/data_reduction.md).
+- **Natural-language pipelines**: "Keep 10s around every hard brake, drop the rest" —
+  one sentence becomes an auditable [pipeline](./doc/runbooks/pipelines.md): previewed
+  before a byte is written, then run once, across a fleet, or standing at the edge.
 - **Broad LLM support**: Claude Code, Gemini, Cursor, Codex, and more.
 - **Dockerized environments**: No local dependencies required.
 - **Extensible capabilities**: Bagel can learn [new tricks](#-teach-bagel-a-new-trick).
@@ -72,7 +73,8 @@ answers the questions they make you work for, then hands off to them:
 | Write a one-off pandas script per question | Ask the question; Bagel writes and runs the query |
 
 One sentence of plain language, one answer — instead of a pipeline of commands and
-a script you'll delete tomorrow. Here it is reducing a bag around detected events:
+a script you'll delete tomorrow. Here's a sentence becoming a
+[data pipeline](./doc/runbooks/pipelines.md) that reduces a bag around detected events:
 
 <p align="center">
   <picture>
@@ -260,6 +262,8 @@ meow 🐱 4 topics 🐱💤🎯
 
 ## 📚 Guides
 
+- [Natural-language pipelines](./doc/runbooks/pipelines.md) — the model: a cadence, gates,
+  and tasks; preview → run → save → batch → standing at the edge
 - [Event-driven data reduction](./doc/runbooks/data_reduction.md) — detect events, keep
   windows around them (snippets or one reduced bag), batch across fleets, upload to the cloud
 - [Live ROS2 robots over rosbridge](./doc/tutorials/live_ros2_bridge.md) — a step-by-step tutorial

--- a/doc/runbooks/pipelines.md
+++ b/doc/runbooks/pipelines.md
@@ -1,0 +1,104 @@
+# Natural-language pipelines
+
+Every pipeline starts as a sentence:
+
+> Every time the drone decelerates harder than -10 m/s², keep 10 seconds before and
+> after. Drop everything else.
+
+Bagel turns that into a small, auditable config — *when* to fire, *whether* to proceed,
+*what* to do — previews the effect before writing a byte, and can then run it once,
+across a whole fleet, or standing at the edge. Reduction is the flagship use, but it's
+one task among many: the same machinery exports PlotJuggler sessions, computes summaries
+on a schedule, and ships artifacts to the cloud.
+
+## Anatomy of a pipeline
+
+```yaml
+name: hard_decel_reduce
+site: warehouse          # labels: where and what this ran on
+asset: forklift
+path: ./data/logs/flight_042
+cadence:                 # WHEN the pipeline fires
+  topic: /imu
+  when: once_at_end
+gates: []                # WHETHER to proceed once fired (optional)
+tasks:                   # WHAT to do
+  - module: src.pipeline.tasks.reduce.ros2.db3
+    args:
+      event_topic: /imu
+      predicate: "\"/imu\"['linear_acceleration']['x'] < -10"
+      pre_seconds: 10
+      post_seconds: 10
+      debounce_seconds: 2
+```
+
+Artifacts land under `~/.bagel/artifacts/pipeline=<name>/...`, tagged with `site` and
+`asset` so fleet output stays sorted.
+
+### Cadence — when it fires
+
+| `when` | Fires | Example sentence |
+| --- | --- | --- |
+| `once_at_end` | Once, at the end of the source (or when a live stream stops) | "After the flight, ..." |
+| `{every: 5, unit: minutes}` | On a fixed schedule along the topic's timeline | "Every 5 minutes, ..." |
+| `{on_event: {predicate: ...}}` | On the rising edge of a SQL predicate, with optional `debounce` and `forward` windows | "Whenever the battery dips below 20%, ..." |
+
+`on_event` fires once per transition — a condition that stays true for 400 messages is
+one event, and `debounce` coalesces bursts. On live streams, `forward` waits long enough
+to capture the post-event window before firing.
+
+### Predicates — the one contract to learn
+
+Topic columns are DuckDB `STRUCT`s, so fields are addressed as
+`"<topic>"['field']['subfield']`:
+
+```sql
+"/imu"['linear_acceleration']['x'] < -10
+```
+
+Ask `describe_topic` for the exact field paths and units first — or just describe the
+event in words and let your LLM write the predicate; that's the point.
+
+### Gates and tasks — what it does
+
+A **gate** decides whether a fired pipeline proceeds (e.g. `SqlQuery`: run a boolean SQL
+check at the fire timestamp). **Tasks** do the work. Ask Bagel to
+*"list the pipeline capabilities"* (`list_pipeline_capabilities`) for the live catalog on
+your install; today it includes:
+
+| Task (`src.pipeline.tasks.`…) | What it does |
+| --- | --- |
+| `reduce.mcap`, `reduce.ros2.mcap`, `reduce.ros2.db3`* | Rewrite the bag keeping only event windows |
+| `snippet.mcap`, `snippet.ros1.bag`* | Cut a standalone snippet around the fire timestamp |
+| `topic_sql` | Run SQL over a topic and write the result to a file |
+| `write_topics_to_file` | Dump topics to CSV/Parquet/JSON |
+| `generate_gif` | Render an image topic into a GIF |
+| `cloudini.decode_pointcloud` | Decode compressed pointclouds mid-pipeline |
+| `upload.s3`, `upload.gcs`, `upload.azure` | Ship artifacts to the cloud, skipping files already there |
+| `rsync_files`, `send_email` | Pull files in; send results out |
+
+\* the `ros2.db3` and `ros1.bag` writers need rosbag CLIs, so they show up inside the
+ROS compose services.
+
+Tasks chain: reduce → upload → email is one pipeline.
+
+## The lifecycle
+
+1. **Preview** — `preview_pipeline` is a dry run: events found, seconds kept, nothing
+   written. Same discipline as auditing SQL before trusting the math.
+2. **Run** — `run_pipeline` builds and executes the config, returning artifact paths.
+3. **Save** — `save_pipeline` persists it as YAML (like
+   [`pipelines/hard_decel_reduce.yaml`](../../pipelines/hard_decel_reduce.yaml)) for
+   review, version control, and `run.py pipelines/<name>.yaml`.
+4. **Scale out** — `run_pipeline_batch` runs one config over globs of sources
+   (`logs/*.mcap`), isolating failures per source and returning a combined report.
+5. **Stand it up** — attach a pipeline to a live subscription
+   (`subscribe_live_topics`), or list it in `STARTUP_PIPELINES_FILE` so the edge
+   container re-establishes it on every restart: record continuously, keep only what
+   matters.
+
+## Go deeper
+
+- [Event-driven data reduction](./data_reduction.md) — the flagship use, end to end
+- [PlotJuggler](./plotjuggler.md) — pre-framed sessions from pipeline outputs
+- [MQTT](./iot_mqtt.md) — standing pipelines on live IoT streams


### PR DESCRIPTION
Stacked on #123.

Arun's question "do we have something that explains natural language pipelines?" had an unsatisfying answer: only by example, and only for reduction. This adds the concept doc.

## What's new
- **`doc/runbooks/pipelines.md`** — the mental model in one page: a pipeline is a *cadence* (once-at-end / fixed frequency / on-event with debounce+forward) + *gates* + *tasks*; the predicate contract; the lifecycle (`preview_pipeline` → `run_pipeline` → `save_pipeline` → `run_pipeline_batch` → standing via `STARTUP_PIPELINES_FILE`); and the full task catalog — taken from a live `list_pipeline_capabilities` call, not from memory (14 entries; footnote for the rosbag-CLI writers that only appear inside ROS services).
- **README hooks** (per Arun: "put it in key features... and maybe we can reinforce it somewhere else"):
  - Key Features: the reduction bullet is now the broader **natural-language pipelines** hook — "one sentence becomes an auditable pipeline: previewed before a byte is written, then run once, across a fleet, or standing at the edge"
  - The comparison-section GIF caption now names what the GIF shows: a sentence becoming a data pipeline (links the doc)
  - Guides: new top entry for the concept doc, with data reduction beneath it as the deep-dive

## Verification
- Task table cross-checked against the live capability registry on this machine (14 modules, exact `src.pipeline.tasks.*` names)
- Cadence table matches `src/pipeline/base.py` (`OnceAtEnd`, `Frequency{every,unit}`, `OnEvent{predicate,debounce,forward}`) and the YAML shapes accepted by `Cadence.build`
- Example YAML is the committed `pipelines/hard_decel_reduce.yaml`, abbreviated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
