### PR TITLE
Add export_for_rerun: event windows as ready-to-open Rerun recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ meow 🐱 4 topics 🐱💤🎯
 
 ## 📦 Integrations
 
+- [Rerun](./doc/runbooks/rerun.md) — "show me that event in Rerun": any time window as a ready-to-open recording
 - [PlotJuggler](./doc/runbooks/plotjuggler.md) — open Bagel's MCAP outputs directly; one-sentence pre-framed sessions, flattened CSV/Parquet exports
 - [Cloudini](./doc/runbooks/cloudini.md) — Decode cloudini-compressed pointcloud data in pipelines
 

--- a/doc/runbooks/rerun.md
+++ b/doc/runbooks/rerun.md
@@ -1,0 +1,45 @@
+# Rerun integration
+
+[Rerun](https://rerun.io) is the open-source visualization SDK the robotics and
+robot-learning communities are converging on. Bagel exports any time window as a
+Rerun recording (`.rrd`): every scalar signal becomes a time series, and the viewer
+opens with the full signal tree ready to explore.
+
+## Setup
+
+The export needs the optional `rerun-sdk` dependency, and the viewer itself:
+
+```bash
+uv sync --group viz          # the SDK, for the export
+uvx rerun-sdk@latest --help  # or: pip install rerun-sdk / the desktop app
+```
+
+## From a prompt
+
+> Find the hardest brake in ./flight_042 and show it to me in Rerun.
+
+Behind the scenes this chains `preview_pipeline` (find the event) with
+`export_for_rerun` (write the window):
+
+```text
+export_for_rerun(
+  path="./flight_042", topics=["/imu"],
+  start_seconds=118.9, end_seconds=138.9, name="brake event 2",
+)
+-> { "rrd": "~/.bagel/artifacts/rerun/brake_event_2/brake_event_2.rrd",
+     "signals": ["/imu/linear_acceleration/x", ...],
+     "command": "rerun '~/.bagel/artifacts/rerun/brake_event_2/brake_event_2.rrd'" }
+```
+
+Run the returned command and the event is on screen.
+
+Signal names are the flattened `topic/field/subfield` paths — the same naming as the
+[PlotJuggler export](./plotjuggler.md), so the two integrations are interchangeable:
+pick the viewer your team already uses. Pass `signals=[...]` to narrow the export;
+by default every numeric signal in the selected topics is included.
+
+## Docker note
+
+If Bagel runs in Docker, artifacts land in `~/.bagel/artifacts` on the host (the
+compose services mount it), so the returned `rerun` command works as-is on your
+desktop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ upload = [
     "azure-storage-blob>=12.24.0,<13.0.0",
     "google-cloud-storage>=2.18.0,<4.0.0",
 ]
+viz = [
+    "rerun-sdk>=0.23.1",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
 from src.di.types.topic_sink import TopicSink, guess_host, guess_port
-from src.pipeline import base, batch, capabilities, plotjuggler, windows
+from src.pipeline import base, batch, capabilities, plotjuggler, rerun_export, windows
 from src.sink import startup
 
 server = mcp_compat.create_server(
@@ -722,6 +722,75 @@ def export_for_plotjuggler(  # noqa: PLR0913
         factory, registry, topics, start_seconds=start_seconds, end_seconds=end_seconds
     )
     return plotjuggler.export_window(
+        relation,
+        name=name,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        signals=signals,
+    )
+
+
+@server.tool(
+    title="Export an event window for the Rerun viewer",
+    description=(
+        "Export a time window of topic data as a Rerun recording (.rrd): every scalar "
+        "signal becomes a Rerun time series, so `rerun <file>` opens the event in the "
+        "Rerun viewer. Use after preview_pipeline to hand an event to a human for "
+        "visual inspection. Needs the optional rerun-sdk dependency (uv sync --group viz)."
+    ),
+)
+def export_for_rerun(  # noqa: PLR0913
+    path: str,
+    topics: list[str],
+    start_seconds: float,
+    end_seconds: float,
+    name: str = "event",
+    signals: list[str] | None = None,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Export a time window as a Rerun recording.
+
+    Writes an `.rrd` file where every scalar signal in the window is a Rerun time
+    series (entity paths named `topic/field/subfield`, matching the PlotJuggler
+    export's naming).
+
+    Args:
+        path (str): Filesystem path or URL to the data source.
+        topics (list[str]): The topics to include in the export.
+        start_seconds (float): Window start.
+        end_seconds (float): Window end.
+        name (str, optional): Recording name, used for the output files. Defaults to
+            "event".
+        signals (list[str] | None, optional): Flattened signal names to include (e.g.
+            "/imu/linear_acceleration/x"). If None, all numeric signals are included.
+            Defaults to None.
+        args (dict[str, Any] | None, optional): Additional constructor arguments used
+            to create the `SourceFactory` and `TopicRegistry`.
+
+    Returns:
+        dict[str, Any]: The `rrd` path, included `signals`, and `command` -- run it to
+            open the recording in the Rerun viewer.
+
+    Examples:
+        As an LLM prompt:
+            Show me the second brake event in Rerun.
+
+        As a Python call:
+            >>> export_for_rerun("./flight.mcap", ["/imu"], 118.9, 138.9)
+
+    """
+    ds_type = resolve(path)
+    factory = module.provide(
+        # args first: the explicit `path` parameter must always win.
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+
+    relation = dataset.to_duckdb(
+        factory, registry, topics, start_seconds=start_seconds, end_seconds=end_seconds
+    )
+    return rerun_export.export_window(
         relation,
         name=name,
         start_seconds=start_seconds,

--- a/src/pipeline/rerun_export.py
+++ b/src/pipeline/rerun_export.py
@@ -1,0 +1,106 @@
+"""Export an event window as a Rerun recording (.rrd).
+
+Writes every scalar signal in the window as a Rerun time series, so
+``rerun <file>.rrd`` opens the event in the Rerun viewer with the full signal tree
+ready to explore. Entity paths are the flattened signal names
+(``/imu/linear_acceleration/x``), matching the naming used by the PlotJuggler export.
+
+Requires the optional ``rerun-sdk`` dependency: ``uv sync --group viz``.
+"""
+
+import pathlib
+import re
+from typing import Any
+
+import duckdb
+
+from settings import settings
+from src.pipeline import flatten as flatten_module
+from src.pipeline.plotjuggler import _numeric_columns
+
+
+def export_window(  # noqa: PLR0913
+    relation: duckdb.DuckDBPyRelation,
+    name: str,
+    start_seconds: float,
+    end_seconds: float,
+    signals: list[str] | None = None,
+    output_directory: str | pathlib.Path | None = None,
+) -> dict[str, Any]:
+    """Write a Rerun recording of the relation's scalar signals.
+
+    Args:
+        relation: A standard Bagel relation (timestamp_seconds + struct topic columns),
+            already restricted to the window of interest.
+        name: Recording name (used for the output directory and file).
+        start_seconds: Window start, echoed into the result for context.
+        end_seconds: Window end.
+        signals: Flattened signal names to include (e.g. "/imu/linear_acceleration/x").
+            If None, all numeric signals are included.
+        output_directory: Where to write. Defaults to
+            `<ARTIFACT_DIRECTORY>/rerun/<name>`.
+
+    Returns:
+        ``{"rrd", "signals", "command"}`` -- the written recording, included signals,
+        and the command that opens it in the Rerun viewer.
+
+    Raises:
+        ImportError: If the optional rerun-sdk dependency is not installed.
+        ValueError: If a requested signal does not exist or nothing is plottable.
+
+    """
+    try:
+        import rerun as rr
+    except ImportError as error:  # pragma: no cover -- exercised only without the dep
+        raise ImportError(
+            "The Rerun export needs the optional 'rerun-sdk' dependency; "
+            "install it with: uv sync --group viz"
+        ) from error
+
+    flat = flatten_module.flatten(relation)
+
+    available = _numeric_columns(flat)
+    if signals is not None:
+        unusable = sorted(set(signals) - set(available))
+        if unusable:
+            raise ValueError(
+                f"Unknown or non-numeric signals: {unusable}. "
+                f"Available numeric signals: {available}"
+            )
+        included = list(signals)
+    else:
+        included = available
+    if not included:
+        raise ValueError("No numeric signals to export in the selected topics.")
+
+    name = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "event"
+    directory = (
+        pathlib.Path(output_directory)
+        if output_directory
+        else pathlib.Path(settings.ARTIFACT_DIRECTORY) / "rerun" / name
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    rrd_file = directory / f"{name}.rrd"
+
+    columns = flat.select(
+        ", ".join(f'"{c}"' for c in [settings.TIMESTAMP_SECONDS_COLUMN_NAME, *included])
+    ).fetchnumpy()
+    times = columns[settings.TIMESTAMP_SECONDS_COLUMN_NAME]
+
+    recording = rr.RecordingStream(f"bagel/{name}")
+    recording.save(str(rrd_file))
+    for signal in included:
+        recording.send_columns(
+            signal,
+            indexes=[rr.TimeColumn("time", duration=times)],
+            columns=rr.Scalars.columns(scalars=columns[signal]),
+        )
+    recording.flush(blocking=True)
+
+    return {
+        "rrd": str(rrd_file),
+        "signals": included,
+        "start_seconds": start_seconds,
+        "end_seconds": end_seconds,
+        "command": f"rerun '{rrd_file}'",
+    }

--- a/test/pipeline/test_rerun_export.py
+++ b/test/pipeline/test_rerun_export.py
@@ -1,0 +1,65 @@
+"""Tests for the Rerun recording export (.rrd), verified by reading the file back."""
+
+import pathlib
+
+import pytest
+
+import server
+from settings import settings
+
+rr = pytest.importorskip("rerun", reason="rerun-sdk is optional (uv sync --group viz)")
+
+SAMPLE = "./data/sample/pyarrow/csv/flight.csv"
+SAMPLE_ARGS = {"timestamp_column": "t", "timestamp_format": "seconds"}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def _export(**overrides: object) -> dict:
+    params = {
+        "path": SAMPLE,
+        "topics": ["message"],
+        "start_seconds": 15.0,
+        "end_seconds": 25.0,
+        "name": "brake event 1",
+        "args": SAMPLE_ARGS,
+    }
+    params.update(overrides)
+    return server.export_for_rerun(**params)
+
+
+def test_writes_readable_recording_with_window_contents() -> None:
+    import rerun.dataframe as rrd
+
+    result = _export()
+
+    rrd_file = pathlib.Path(result["rrd"])
+    assert rrd_file.exists()
+    assert rrd_file.name == "brake_event_1.rrd"
+    assert result["command"] == f"rerun '{rrd_file}'"
+
+    # Read the recording back: every exported signal is present with the window's rows.
+    recording = rrd.load_recording(str(result["rrd"]))
+    for signal in result["signals"]:
+        view = recording.view(index="time", contents=signal)
+        table = view.select().read_all()
+        assert table.num_rows == 21  # 15.0..25.0 inclusive at 0.5s cadence
+        times = [t.total_seconds() for t in table.column("time").to_pylist()]
+        assert min(times) == 15.0
+        assert max(times) == 25.0
+
+
+def test_signal_selection_and_validation() -> None:
+    picked = _export(signals=["message/vel"])
+    assert picked["signals"] == ["message/vel"]
+
+    with pytest.raises(ValueError, match="Unknown or non-numeric"):
+        _export(signals=["message/no_such_field"])
+
+
+def test_all_numeric_signals_by_default() -> None:
+    result = _export()
+    assert set(result["signals"]) == {"message/t", "message/accel_x", "message/vel"}

--- a/uv.lock
+++ b/uv.lock
@@ -257,6 +257,9 @@ upload = [
     { name = "azure-storage-blob" },
     { name = "google-cloud-storage" },
 ]
+viz = [
+    { name = "rerun-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -323,6 +326,7 @@ upload = [
     { name = "azure-storage-blob", specifier = ">=12.24.0,<13.0.0" },
     { name = "google-cloud-storage", specifier = ">=2.18.0,<4.0.0" },
 ]
+viz = [{ name = "rerun-sdk", specifier = ">=0.23.1" }]
 
 [[package]]
 name = "beautifulsoup4"
@@ -3040,6 +3044,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "rerun-sdk"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pyarrow" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/6e/a125f4fe2de3269f443b7cb65d465ffd37a836a2dac7e4318e21239d78c8/rerun_sdk-0.23.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fe06d21cfcf4d84a9396f421d4779efabec7e9674d232a2c552c8a91d871c375", size = 66094053, upload-time = "2025-04-25T13:15:48.669Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f6/b6d13322b05dc77bd9a0127e98155c2b7ee987a236fd4d331eed2e547a90/rerun_sdk-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:823ae87bfa644e06fb70bada08a83690dd23d9824a013947f80a22c6731bdc0d", size = 62047843, upload-time = "2025-04-25T13:15:54.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7f/6a7422cb727e14a65b55b0089988eeea8d0532c429397a863e6ba395554a/rerun_sdk-0.23.1-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:dc5129f8744f71249bf45558c853422c51ef39b6b5eea0ea1f602c6049ce732f", size = 68214509, upload-time = "2025-04-25T13:15:59.339Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/86/3aee9eadbfe55188a2c7d739378545b4319772a4d3b165e8d3fc598fa630/rerun_sdk-0.23.1-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ee0d0e17df0e08be13b77cc74884c5d8ba8edb39b6f5a60dc2429d39033d90f6", size = 71442196, upload-time = "2025-04-25T13:16:04.405Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ba/028bd382e2ae21e6643cec25f423285dbc6b328ce56d55727b4101ef9443/rerun_sdk-0.23.1-cp39-abi3-win_amd64.whl", hash = "sha256:d4273db55b56310b053a2de6bf5927a8692cf65f4d234c6e6928fb24ed8a960d", size = 57583198, upload-time = "2025-04-25T13:16:08.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #125. Completes the agreed visualization arc: Rerun as the open-source-aligned viewer (Foxglove went proprietary in 2024, so it stays a "your MCAP opens there anyway" bonus, not a headline).

## UX — identical shape to the PlotJuggler export
> Find the hardest brake in ./flight_042 and show it to me in Rerun.

`export_for_rerun(path, topics, start_seconds, end_seconds, name, signals?)` → flattens the window, logs one Rerun time series per scalar signal, writes `<artifacts>/rerun/<name>/<name>.rrd`, returns the `rerun '<file>'` command. Entity paths are the flattened `topic/field/subfield` names — the same naming as the PlotJuggler export, so the two viewers are interchangeable.

## Engineering notes
- **`rerun-sdk` is a new optional `viz` group** — server boots without it (verified with an import blocker); calling the tool without it raises "install with: uv sync --group viz"
- Bulk-writes via `send_columns` (columnar, not per-row logging)
- 14th MCP tool; shares the numeric-signal validation with the PJ exporter

## Verification
- Tests **read the .rrd back** with `rerun.dataframe` rather than trusting file existence: every exported signal present, exactly 21 rows for the 10s window at 0.5s cadence, timestamps spanning [15.0, 25.0]
- Signal selection + unknown-signal rejection; default = all numeric signals
- Full non-ROS suite: **237 passed**, ruff clean
- Runbook `doc/runbooks/rerun.md` + README Integrations entry (listed above PlotJuggler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
