### PR TITLE
Add export_for_lichtblick: event windows as MCAP + pre-framed layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ meow 🐱 4 topics 🐱💤🎯
 ## 📦 Integrations
 
 - [Rerun](./doc/runbooks/rerun.md) — "show me that event in Rerun": any time window as a ready-to-open recording
+- [Lichtblick / Foxglove](./doc/runbooks/lichtblick.md) — event windows as MCAP + pre-framed layouts for either viewer
 - [PlotJuggler](./doc/runbooks/plotjuggler.md) — open Bagel's MCAP outputs directly; one-sentence pre-framed sessions, flattened CSV/Parquet exports
 - [Cloudini](./doc/runbooks/cloudini.md) — Decode cloudini-compressed pointcloud data in pipelines
 - [Slack](./doc/runbooks/pipelines.md) — pipelines post to your ops channel when they fire: "🚨 hard brake on {asset}"

--- a/doc/runbooks/lichtblick.md
+++ b/doc/runbooks/lichtblick.md
@@ -1,0 +1,44 @@
+# Lichtblick / Foxglove integration
+
+[Lichtblick](https://github.com/lichtblick-suite/lichtblick) is BMW's open-source
+fork of Foxglove Studio (Apache-2.0). Bagel exports any time window as a Lichtblick
+session: an MCAP file plus a layout with the plot series and time/value ranges
+pre-set, so the event is on screen as soon as you import both. The same files open
+in Foxglove, which shares the layout format.
+
+## From a prompt
+
+> Find the hardest brake in ./flight_042 and show it to me in Lichtblick.
+
+Behind the scenes this chains `preview_pipeline` (find the event) with
+`export_for_lichtblick` (write the window):
+
+```text
+export_for_lichtblick(
+  path="./flight_042", topics=["/imu"],
+  start_seconds=118.9, end_seconds=138.9, name="brake event 2",
+)
+-> { "mcap": ".../lichtblick/brake_event_2/brake_event_2.mcap",
+     "layout": ".../lichtblick/brake_event_2/brake_event_2_layout.json",
+     "curves": ["/imu.linear_acceleration.x", ...],
+     "instructions": "Open Lichtblick, drop in the .mcap, then Layouts -> Import from file." }
+```
+
+## Opening the session
+
+1. Open Lichtblick (desktop or web) and drag the exported `.mcap` in.
+2. **Layouts → Import from file** → the exported `_layout.json`.
+
+The Plot panel opens with the event's signals plotted and the time/value ranges
+framed to the window.
+
+## Notes
+
+- The MCAP uses JSON-encoded channels (`jsonschema` schemas) — readable by
+  Lichtblick, Foxglove, and Bagel itself, so you can keep querying the exported
+  window with SQL.
+- Signal names in `signals=[...]` use the flattened `topic/field/subfield`
+  convention shared with the [PlotJuggler](./plotjuggler.md) and
+  [Rerun](./rerun.md) exports; pick the viewer your team already uses.
+- If Bagel runs in Docker, artifacts land in `~/.bagel/artifacts` on the host
+  (the compose services mount it).

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
 from src.di.types.topic_sink import TopicSink, guess_host, guess_port
-from src.pipeline import base, batch, capabilities, plotjuggler, rerun_export, windows
+from src.pipeline import base, batch, capabilities, lichtblick, plotjuggler, rerun_export, windows
 from src.sink import startup
 
 server = mcp_compat.create_server(
@@ -791,6 +791,75 @@ def export_for_rerun(  # noqa: PLR0913
         factory, registry, topics, start_seconds=start_seconds, end_seconds=end_seconds
     )
     return rerun_export.export_window(
+        relation,
+        name=name,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        signals=signals,
+    )
+
+
+@server.tool(
+    title="Export an event window for Lichtblick / Foxglove",
+    description=(
+        "Export a time window of topic data as a Lichtblick session: an MCAP file "
+        "with JSON-encoded channels plus a layout with the plot series and time/value "
+        "ranges pre-set. Works in Lichtblick (open source) and Foxglove, which share "
+        "the layout format. Use after preview_pipeline to hand an event to a human."
+    ),
+)
+def export_for_lichtblick(  # noqa: PLR0913
+    path: str,
+    topics: list[str],
+    start_seconds: float,
+    end_seconds: float,
+    name: str = "event",
+    signals: list[str] | None = None,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Export a time window as a ready-to-open Lichtblick session.
+
+    Writes an MCAP of the window (JSON-encoded channels, readable by Lichtblick,
+    Foxglove, and Bagel itself) and a layout `.json` with a Plot panel whose series
+    and x/y ranges are pre-set to the event.
+
+    Args:
+        path (str): Filesystem path or URL to the data source.
+        topics (list[str]): The topics to include in the export.
+        start_seconds (float): Window start (also the plot's framed x range start).
+        end_seconds (float): Window end.
+        name (str, optional): Session name, used for the output files and the plot
+            title. Defaults to "event".
+        signals (list[str] | None, optional): Flattened signal names to plot (e.g.
+            "/imu/linear_acceleration/x"). If None, all numeric signals are plotted,
+            capped at 8. Defaults to None.
+        args (dict[str, Any] | None, optional): Additional constructor arguments used
+            to create the `SourceFactory` and `TopicRegistry`.
+
+    Returns:
+        dict[str, Any]: `mcap` and `layout` paths, the plotted `curves` (as Lichtblick
+            message paths), and `instructions` for opening the session.
+
+    Examples:
+        As an LLM prompt:
+            Show me the second brake event in Lichtblick.
+
+        As a Python call:
+            >>> export_for_lichtblick("./flight.mcap", ["/imu"], 118.9, 138.9)
+
+    """
+    ds_type = resolve(path)
+    factory = module.provide(
+        # args first: the explicit `path` parameter must always win.
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+
+    relation = dataset.to_duckdb(
+        factory, registry, topics, start_seconds=start_seconds, end_seconds=end_seconds
+    )
+    return lichtblick.export_window(
         relation,
         name=name,
         start_seconds=start_seconds,

--- a/src/pipeline/lichtblick.py
+++ b/src/pipeline/lichtblick.py
@@ -1,0 +1,231 @@
+"""Export an event window as a Lichtblick session: MCAP data + a pre-framed layout.
+
+Writes the window as an MCAP file with JSON-encoded channels (schema encoding
+``jsonschema``), which Lichtblick -- BMW's open-source fork of Foxglove Studio --
+reads natively, plus a layout ``.json`` (schema matching real Lichtblick layout
+fixtures) with a Plot panel whose series and x/y ranges are pre-set to the event.
+The same files open in Foxglove, which shares the layout format.
+
+Signal names follow the flattened ``topic/field/subfield`` convention used by the
+PlotJuggler and Rerun exports; they are translated to Lichtblick message paths
+(``/imu.linear_acceleration.x``) in the layout.
+"""
+
+import json
+import logging
+import pathlib
+import re
+from typing import Any
+
+import duckdb
+import pyarrow as pa
+from mcap.writer import Writer
+
+from settings import settings
+from src.pipeline import flatten as flatten_module
+from src.pipeline.plotjuggler import MAX_CURVES, _numeric_columns
+from src.source.postgres import quote_identifier
+
+SECOND_NS = 1_000_000_000
+
+
+def _jsonschema_type(dtype: pa.DataType) -> dict[str, Any]:
+    """Map an Arrow type to a JSON-Schema fragment (reverse of the MCAP reader's mapper)."""
+    if pa.types.is_struct(dtype):
+        return {
+            "type": "object",
+            "properties": {field.name: _jsonschema_type(field.type) for field in dtype},
+        }
+    if pa.types.is_list(dtype) or pa.types.is_large_list(dtype):
+        return {"type": "array", "items": _jsonschema_type(dtype.value_type)}
+    if pa.types.is_integer(dtype):
+        return {"type": "integer"}
+    if pa.types.is_floating(dtype) or pa.types.is_decimal(dtype):
+        return {"type": "number"}
+    if pa.types.is_boolean(dtype):
+        return {"type": "boolean"}
+    return {"type": "string"}
+
+
+def _message_paths(schema: pa.Schema) -> dict[str, str]:
+    """Map every flattened scalar signal name to its Lichtblick message path."""
+    paths: dict[str, str] = {}
+
+    def walk(topic: str, dtype: pa.DataType, parts: list[str]) -> None:
+        if pa.types.is_struct(dtype):
+            for field in dtype:
+                walk(topic, field.type, [*parts, field.name])
+        elif parts:
+            paths["/".join([topic, *parts])] = topic + "." + ".".join(parts)
+
+    for field in schema:
+        if field.name != settings.TIMESTAMP_SECONDS_COLUMN_NAME:
+            walk(field.name, field.type, [])
+    return paths
+
+
+def write_mcap(relation: duckdb.DuckDBPyRelation, mcap_file: pathlib.Path) -> None:
+    """Write the relation's topics as JSON-encoded MCAP channels."""
+    table = relation.arrow()
+    topics = [
+        field.name for field in table.schema if field.name != settings.TIMESTAMP_SECONDS_COLUMN_NAME
+    ]
+    with open(mcap_file, "wb") as stream:
+        writer = Writer(stream)
+        writer.start(profile="", library="bagel")
+        channels = {}
+        for topic in topics:
+            schema_id = writer.register_schema(
+                name=topic,
+                encoding="jsonschema",
+                data=json.dumps(_jsonschema_type(table.schema.field(topic).type)).encode(),
+            )
+            channels[topic] = writer.register_channel(
+                topic=topic, message_encoding="json", schema_id=schema_id
+            )
+        for row in table.to_pylist():
+            log_time = int(row[settings.TIMESTAMP_SECONDS_COLUMN_NAME] * SECOND_NS)
+            for topic in topics:
+                if row[topic] is None:
+                    continue
+                writer.add_message(
+                    channel_id=channels[topic],
+                    log_time=log_time,
+                    publish_time=log_time,
+                    data=json.dumps(row[topic]).encode(),
+                )
+        writer.finish()
+
+
+def build_layout(
+    paths: list[str],
+    x_range: tuple[float, float],
+    y_range: tuple[float, float],
+    tab_title: str,
+) -> str:
+    """Build a Lichtblick layout JSON string with one pre-framed Plot panel."""
+    plot_id = "Plot!bagel"
+    layout = {
+        "configById": {
+            plot_id: {
+                "title": tab_title,
+                "paths": [
+                    {"value": path, "enabled": True, "timestampMethod": "receiveTime"}
+                    for path in paths
+                ],
+                "showXAxisLabels": True,
+                "showYAxisLabels": True,
+                "showLegend": True,
+                "legendDisplay": "floating",
+                "showPlotValuesInLegend": False,
+                "isSynced": True,
+                "xAxisVal": "timestamp",
+                "minXValue": x_range[0],
+                "maxXValue": x_range[1],
+                "minYValue": y_range[0],
+                "maxYValue": y_range[1],
+                "sidebarDimension": 240,
+            }
+        },
+        "globalVariables": {},
+        "userNodes": {},
+        "playbackConfig": {"speed": 1},
+        "layout": plot_id,
+    }
+    return json.dumps(layout, indent=2)
+
+
+def export_window(  # noqa: PLR0913
+    relation: duckdb.DuckDBPyRelation,
+    name: str,
+    start_seconds: float,
+    end_seconds: float,
+    signals: list[str] | None = None,
+    output_directory: str | pathlib.Path | None = None,
+) -> dict[str, Any]:
+    """Write an MCAP of the relation plus a Lichtblick layout framing it.
+
+    Args:
+        relation: A standard Bagel relation (timestamp_seconds + struct topic columns),
+            already restricted to the window of interest.
+        name: Session name (used for the output directory and plot title).
+        start_seconds: Window start (frames the plot's x range).
+        end_seconds: Window end.
+        signals: Flattened signal names to plot (e.g. "/imu/linear_acceleration/x").
+            If None, all numeric signals are plotted, capped at MAX_CURVES.
+        output_directory: Where to write. Defaults to
+            `<ARTIFACT_DIRECTORY>/lichtblick/<name>`.
+
+    Returns:
+        ``{"mcap", "layout", "curves", "instructions"}`` -- the written paths, plotted
+        message paths, and how to open the session.
+
+    Raises:
+        ValueError: If a requested signal does not exist or nothing is plottable.
+
+    """
+    flat = flatten_module.flatten(relation)
+
+    available = _numeric_columns(flat)
+    if signals is not None:
+        unusable = sorted(set(signals) - set(available))
+        if unusable:
+            raise ValueError(
+                f"Unknown or non-numeric signals: {unusable}. "
+                f"Available numeric signals: {available}"
+            )
+        curves = list(signals)
+    else:
+        curves = available[:MAX_CURVES]
+        if len(available) > MAX_CURVES:
+            logging.info(
+                "Plotting the first %d of %d numeric signals; pass 'signals' to choose",
+                MAX_CURVES,
+                len(available),
+            )
+    if not curves:
+        raise ValueError("No numeric signals to plot in the selected topics.")
+
+    name = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "event"
+    directory = (
+        pathlib.Path(output_directory)
+        if output_directory
+        else pathlib.Path(settings.ARTIFACT_DIRECTORY) / "lichtblick" / name
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    mcap_file = directory / f"{name}.mcap"
+    layout_file = directory / f"{name}_layout.json"
+
+    write_mcap(relation, mcap_file)
+
+    # Frame the y range from the actual data (10% padding), like the PlotJuggler export.
+    aggregates = ", ".join(
+        f"MIN({quote_identifier(c)}), MAX({quote_identifier(c)})" for c in curves
+    )
+    bounds = flat.aggregate(aggregates).fetchone()
+    minima = [b for b in bounds[0::2] if b is not None]
+    maxima = [b for b in bounds[1::2] if b is not None]
+    low = float(min(minima)) if minima else 0.0
+    high = float(max(maxima)) if maxima else 1.0
+    pad = (high - low) * 0.1 or 1.0
+
+    message_paths = _message_paths(relation.limit(0).arrow().schema)
+    paths = [message_paths[curve] for curve in curves]
+    layout_file.write_text(
+        build_layout(
+            paths,
+            x_range=(start_seconds, end_seconds),
+            y_range=(low - pad, high + pad),
+            tab_title=name,
+        )
+    )
+
+    return {
+        "mcap": str(mcap_file),
+        "layout": str(layout_file),
+        "curves": paths,
+        "instructions": (
+            f"Open Lichtblick (or Foxglove), drop in {mcap_file}, then "
+            f"Layouts -> Import from file -> {layout_file}."
+        ),
+    }

--- a/test/pipeline/test_lichtblick_export.py
+++ b/test/pipeline/test_lichtblick_export.py
@@ -1,0 +1,85 @@
+"""Tests for the Lichtblick session export (JSON-channel MCAP + framed layout).
+
+The strongest check dogfoods Bagel itself: the exported MCAP is read back through
+Bagel's own generic MCAP source (the jsonschema reader), proving the file is valid
+MCAP with usable schemas -- if Bagel can query it, Lichtblick can plot it.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+import server
+from settings import settings
+
+SAMPLE = "./data/sample/pyarrow/csv/flight.csv"
+SAMPLE_ARGS = {"timestamp_column": "t", "timestamp_format": "seconds"}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+
+
+def _export(**overrides: object) -> dict:
+    params = {
+        "path": SAMPLE,
+        "topics": ["message"],
+        "start_seconds": 15.0,
+        "end_seconds": 25.0,
+        "name": "brake event 1",
+        "args": SAMPLE_ARGS,
+    }
+    params.update(overrides)
+    return server.export_for_lichtblick(**params)
+
+
+def test_layout_matches_lichtblick_schema() -> None:
+    result = _export()
+    layout = json.loads(pathlib.Path(result["layout"]).read_text())
+
+    assert layout["layout"] == "Plot!bagel"
+    assert set(layout) == {"configById", "globalVariables", "userNodes", "playbackConfig", "layout"}
+
+    plot = layout["configById"]["Plot!bagel"]
+    assert plot["xAxisVal"] == "timestamp"
+    assert plot["minXValue"] == 15.0
+    assert plot["maxXValue"] == 25.0
+    assert plot["minYValue"] < plot["maxYValue"]
+    assert {"value", "enabled", "timestampMethod"} <= set(plot["paths"][0])
+    assert "message.vel" in {p["value"] for p in plot["paths"]}
+
+
+def test_exported_mcap_is_readable_by_bagel_itself() -> None:
+    result = _export()
+
+    # Dogfood: resolve + query the export through Bagel's own MCAP jsonschema reader.
+    from src.di.types.data_source import DataSource, resolve
+
+    assert resolve(result["mcap"]) is DataSource.MCAP
+    rows = server.query_messages(
+        path=result["mcap"],
+        sql_statement=(
+            "SELECT COUNT(*) AS n, MIN(timestamp_seconds) AS lo, MAX(timestamp_seconds) AS hi "
+            'FROM "message"'
+        ),
+        topic="message",
+    )
+    assert rows[0]["n"] == 21  # 15.0..25.0 inclusive at 0.5s cadence
+    assert rows[0]["lo"] == 15.0
+    assert rows[0]["hi"] == 25.0
+
+
+def test_signal_validation_and_selection() -> None:
+    picked = _export(signals=["message/vel"])
+    assert picked["curves"] == ["message.vel"]
+
+    with pytest.raises(ValueError, match="Unknown or non-numeric"):
+        _export(signals=["message/no_such_field"])
+
+
+def test_instructions_reference_both_files() -> None:
+    result = _export()
+    assert result["mcap"] in result["instructions"]
+    assert result["layout"] in result["instructions"]


### PR DESCRIPTION
Stacked on #126. Completes the open-source viewer trio: PlotJuggler (#117/#118), Rerun (#126), and now **Lichtblick** — BMW's Apache-2.0 fork of Foxglove Studio. The same files open in Foxglove proper (shared layout format), so commercial-Foxglove teams are covered without us headlining a proprietary tool.

## UX — same shape as the other two exporters
> Find the hardest brake in ./flight_042 and show it to me in Lichtblick.

`export_for_lichtblick(path, topics, start_seconds, end_seconds, name, signals?)` → writes `<name>.mcap` + `<name>_layout.json`, returns the plotted message paths and open instructions (drop the MCAP in, Layouts → Import). `signals` uses the flattened `topic/field/subfield` names shared with the PJ/Rerun exports.

## Engineering notes
- **The MCAP uses JSON-encoded channels**: an Arrow→JSON-Schema mapper (the reverse of the #110 reader's mapper) builds each channel's `jsonschema`. That makes the export **format-agnostic** — any Bagel source (CSV, Postgres, ROS bags) becomes a Lichtblick-openable MCAP — and self-consistent: Bagel can re-query its own export.
- **Layout JSON grounded in real fixtures**, not guessed: structure matches `benchmark/src/layouts/SinewaveSinglePlot.json` and `e2e/fixtures/assets/default-layout.json` from the Lichtblick repo (`configById` / `Plot!id` / `paths[{value,enabled,timestampMethod}]` / `xAxisVal: timestamp`), with `min/maxXValue` framing the window and y-range computed from the data with 10% padding.
- 15th MCP tool; no new dependencies (the `mcap` lib is already a main dep).

## Verification
- **Dogfood round-trip**: the exported MCAP is resolved (`DataSource.MCAP`) and SQL-queried back through Bagel's own jsonschema MCAP reader — 21 rows, timestamps spanning exactly [15.0, 25.0]
- Layout asserted against the fixture schema; signal validation/selection covered
- Pipeline suite: **127 passed**, ruff clean
- Runbook `doc/runbooks/lichtblick.md` + README Integrations entry
- Honest caveat: layout verified against Lichtblick's committed fixtures, not GUI-eyeballed — same 10-second human check as the PlotJuggler PR: open the sample export once

🤖 Generated with [Claude Code](https://claude.com/claude-code)
