### PR TITLE
Add SECURITY.md: private reporting, threat model, deployment hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately through
+[GitHub's private vulnerability reporting](https://github.com/Extelligence-ai/bagel/security/advisories/new)
+— do not open a public issue with details. If that route is unavailable to you,
+open a bare issue asking for a private channel (no details) and a maintainer will
+provide one.
+
+We aim to acknowledge reports within **3 business days**. Please include a working
+proof of concept and the exact code paths involved; reports without a reproducible
+PoC are hard to act on.
+
+Bagel tracks a single rolling branch (`stage`); fixes land there and in the next
+published Docker images.
+
+## Threat model (what counts)
+
+Bagel is an MCP server that an LLM drives to read and transform **local, trusted
+data** on behalf of the person operating it. Some behaviors that look alarming are
+the product working as intended:
+
+**In scope — we want these reports:**
+- Reaching Bagel's tools **without the operator's consent** (e.g., anything
+  exploitable by a remote party when the server is deployed as documented)
+- Escaping the operator's intent: crafted *data files* (bags, MCAP, logs, MQTT
+  payloads) that achieve code execution or read/write files the operator never
+  pointed Bagel at
+- Path handling that escapes the artifact/cache directories
+- Secrets leakage (broker credentials, DB DSNs, webhook URLs, cloud keys) into
+  artifacts, logs, or tool output
+
+**Out of scope — by design, not vulnerabilities:**
+- Executing operator-supplied SQL over operator-specified data — that is the
+  product (`query_messages` is an intentional SQL interface, as documented)
+- Reading files the operator's own prompts point Bagel at
+- Anything requiring the attacker to already control the MCP client or the
+  operator's machine
+
+## Deployment hardening
+
+- The MCP endpoint has **no authentication layer** — treat it like a database
+  socket. Bind it to localhost (`MCP_SERVER_HOST=127.0.0.1`) or keep it inside a
+  trusted network; never expose the port to the public internet. The compose files
+  publish it on the local host only for the documented single-machine setup.
+- Treat pipeline configs and startup manifests as sensitive: they can contain
+  broker credentials, DSNs, and webhook URLs.
+- Cloud upload tasks use your ambient credentials (AWS/GCS/Azure SDK chains);
+  scope those credentials to the destination buckets.


### PR DESCRIPTION
Stacked on #128. Pairs with issue #119, where a security researcher (LevinityCyber) asked for a private disclosure channel.

## What it establishes
- **Reporting route**: GitHub private vulnerability reporting (needs the repo setting enabled — one click in Settings → Advanced Security, @arunvenkatadri), with a no-details-issue fallback; 3-business-day acknowledgement target; PoC required
- **Threat model with the trust boundary drawn explicitly** — the part that matters for an MCP server, so triage of incoming reports is fast:
  - *In scope*: reaching tools without operator consent, crafted data files achieving code exec or out-of-scope file access, artifact/cache directory escapes, secrets leakage
  - *Out of scope by design*: operator-driven SQL over operator-specified data (that's the product), files the operator's own prompts point at
- **Deployment hardening**: the endpoint has no auth layer by design — bind localhost or trusted networks, never the public internet; configs can carry credentials; cloud tasks use ambient credential chains

GitHub surfaces this file in the repo's Security tab and links it from the advisory flow, so #119's reporter lands on the policy the moment PVR is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
