### PR TITLE
Add ASAM MDF (.mf4) data source: the automotive lane opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Can’t wait to try it out? 👉 Check out the [Quickstart](#️-quickstart).
 | ------------ | ------------------------------ |
 | **Robotics** | ROS1, ROS2, MCAP (any profile), ROS text logs (`~/.ros/log`) |
 | **Drones**   | PX4, ArduPilot, Betaflight     |
+| **Automotive** | ASAM MDF4 (`.mf4`, CANape/INCA/Vector measurements) |
 | **IoT**      | MQTT (live, Sparkplug B), PostgreSQL / TimescaleDB, InfluxDB 3 |
 
 ## 🆚 Bagel vs. the Tools You Already Use
@@ -271,6 +272,7 @@ meow 🐱 4 topics 🐱💤🎯
 - [MQTT](./doc/runbooks/iot_mqtt.md) — live IoT topics, Sparkplug B, edge recording
 - [PostgreSQL / TimescaleDB](./doc/runbooks/iot_postgres.md) — every table is a topic
 - [InfluxDB 3](./doc/runbooks/iot_influxdb.md) — every measurement is a topic
+- [Automotive MDF4](./doc/runbooks/automotive_mdf.md) — channel groups are topics, channels are fields, units ride along
 - [Local LLMs](./doc/runbooks/local_llm.md) — fully offline with Ollama: your data and your model never leave the machine
 
 ## 📦 Integrations

--- a/doc/runbooks/automotive_mdf.md
+++ b/doc/runbooks/automotive_mdf.md
@@ -1,0 +1,38 @@
+# Automotive: ASAM MDF (.mf4)
+
+MDF is the measurement format the automotive world runs on — CANape, INCA, Vector
+tooling, and most DAQ hardware write it. Bagel reads `.mf4` (and older MDF)
+files directly: **channel groups become topics, channels become fields**, and every
+prompt that works on a ROS bag works on a measurement.
+
+## Setup
+
+The MDF reader needs the optional `automotive` dependency group:
+
+```bash
+uv sync --group automotive
+```
+
+Everything is pure pip (`asammdf`) — no vendor tooling required.
+
+## Prompts to try
+
+> Summarize the measurement at ./drive_042.mf4
+
+> What's the max EngineSpeed in ./drive_042.mf4, and when did it happen?
+
+> Find every hard deceleration below -3 m/s² in the Vehicle group and show me
+> VehicleSpeed 10 seconds around each one.
+
+Channel units and comments from the file ride along into the schema, so the LLM
+knows `EngineSpeed` is in rpm without being told.
+
+## Notes
+
+- Timestamps are exposed as **absolute epoch seconds** (the file's measurement
+  start time plus each sample's offset), consistent with every other Bagel source —
+  so time windows and cross-source comparisons behave as expected.
+- Unnamed channel groups appear as `ChannelGroup_<index>`.
+- Raw CAN logs (`.blf` / `.asc`) with DBC decoding are the planned follow-up; if
+  you need them, [open a ticket](https://github.com/Extelligence-ai/bagel/issues)
+  or 👍 the existing one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ upload = [
 viz = [
     "rerun-sdk>=0.23.1",
 ]
+automotive = [
+    "asammdf>=7.4,<8",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -26,6 +26,7 @@ class DataSource(Enum):
     POSTGRES = "postgres"
     INFLUXDB = "influxdb"
     ROS_LOG = "ros.log"
+    MDF = "automotive.mf4"
 
 
 # URL schemes mapped to their data source types.
@@ -52,7 +53,7 @@ def resolve(path: str) -> DataSource:
         return resolve_file_based_data_source(path)
 
 
-def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # noqa: C901, PLR0911
+def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # noqa: C901, PLR0911, PLR0912 -- one branch per supported format
     """Resolve the data source type from the given file or directory path."""
     path = pathlib.Path(path)
     if is_bagel_sink_directory(path):
@@ -74,6 +75,8 @@ def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # n
         return DataSource.BETAFLIGHT_BBL
     elif is_betaflight_bfl_file(path):
         return DataSource.BETAFLIGHT_BFL
+    elif is_mdf_file(path):
+        return DataSource.MDF
     elif is_ros_log_file(path) or is_ros_log_directory(path):
         # Checked before JSON/CSV: free-form log lines can fool the CSV sniffer.
         return DataSource.ROS_LOG
@@ -252,6 +255,11 @@ def is_json_lines_file(path: pathlib.Path) -> bool:
             return True
         except json.JSONDecodeError:
             return False
+
+
+def is_mdf_file(path: pathlib.Path) -> bool:
+    """Check if the given path is an ASAM MDF measurement file (.mf4 and older)."""
+    return has_magic_bytes(path, b"MDF     ")
 
 
 def is_ros_log_file(path: pathlib.Path) -> bool:

--- a/src/message/automotive/mf4.py
+++ b/src/message/automotive/mf4.py
@@ -1,0 +1,62 @@
+"""A message dataset for ASAM MDF (.mf4) files."""
+
+import heapq
+from collections.abc import Iterator
+from typing import Any
+
+import pyarrow as pa
+from asammdf import MDF
+
+from src.di import module
+from src.message import base
+from src.topic.automotive.mf4 import _channels, topic_names
+
+
+class MessageDataset(base.MessageDataset):
+    """A message dataset for ASAM MDF files.
+
+    Topics are channel groups; each message is one sample cycle with a field per
+    channel. Timestamps are absolute epoch seconds (the file's measurement start
+    plus each sample's master time).
+    """
+
+    def _messages(
+        self,
+        data_source: MDF,
+        topics: list[str],
+        start_seconds_inclusive: float | None,
+        end_seconds_inclusive: float | None,
+    ) -> Iterator[tuple[str, float, dict[str, Any]]]:
+        names = topic_names(data_source)
+        start_epoch = data_source.header.start_time.timestamp()
+
+        def stream(topic: str) -> Iterator[tuple[float, int, str, dict[str, Any]]]:
+            index = names[topic]
+            master = data_source.get_master(index)
+            columns = {
+                name: data_source.get(name, group=index, raw=False).samples.tolist()
+                for name in _channels(data_source, index)
+            }
+            for position, relative in enumerate(master.tolist()):
+                timestamp = start_epoch + relative
+                if start_seconds_inclusive is not None and timestamp < start_seconds_inclusive:
+                    continue
+                if end_seconds_inclusive is not None and timestamp > end_seconds_inclusive:
+                    continue
+                yield (
+                    timestamp,
+                    position,
+                    topic,
+                    {name: values[position] for name, values in columns.items()},
+                )
+
+        for timestamp, _, topic, message in heapq.merge(*(stream(topic) for topic in topics)):
+            yield (topic, timestamp, message)
+
+    def _to_json(self, message: dict[str, Any], struct: pa.StructType) -> dict[str, Any]:
+        return message
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = MessageDataset

--- a/src/source/automotive/mf4.py
+++ b/src/source/automotive/mf4.py
@@ -1,0 +1,92 @@
+"""Provide a data source for reading ASAM MDF (.mf4) measurement files.
+
+MDF is the standard measurement format in automotive (ASAM MDF4, written by CANape,
+INCA, vector tooling, and most DAQ hardware). Channel groups map to Bagel topics and
+channels to fields. Requires the optional ``automotive`` dependency group:
+``uv sync --group automotive``.
+"""
+
+import functools
+from typing import Any
+
+from asammdf import MDF
+
+from src.di import module
+from src.source import base, errors
+
+MDF_MAGIC = b"MDF     "
+
+
+class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
+    """A data source factory for reading ASAM MDF (.mf4) files."""
+
+    def __init__(self, path: str) -> None:
+        """Initialize the MDF data source factory.
+
+        Args:
+            path (str): Path to the .mf4 (or older .mdf) measurement file.
+
+        """
+        super().__init__(path)
+        self._mdf = MDF(path)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return metadata about the measurement file."""
+        return {
+            **self._bounded_metadata,
+            **self._file_based_metadata,
+            "mdf_version": self._mdf.version,
+            "measurement_start": str(self._mdf.header.start_time),
+            "channel_groups": [
+                {
+                    "name": group.channel_group.acq_name or f"ChannelGroup_{index}",
+                    "cycles": group.channel_group.cycles_nr,
+                    "channels": [channel.name for channel in group.channels],
+                }
+                for index, group in enumerate(self._mdf.groups)
+            ],
+        }
+
+    @property
+    def total_message_count(self) -> int:
+        """Return the total number of samples across all channel groups."""
+        return sum(group.channel_group.cycles_nr for group in self._mdf.groups)
+
+    @functools.cached_property
+    def start_seconds(self) -> float:
+        """Return the measurement start as epoch seconds."""
+        return self._mdf.header.start_time.timestamp()
+
+    @functools.cached_property
+    def end_seconds(self) -> float:
+        """Return the epoch seconds of the last sample in any channel group."""
+        last = 0.0
+        for index in range(len(self._mdf.groups)):
+            master = self._mdf.get_master(index)
+            if len(master):
+                last = max(last, float(master[-1]))
+        return self.start_seconds + last
+
+    def build(self) -> MDF:
+        """Return the MDF reader object."""
+        return self._mdf
+
+    def validate_path(self) -> tuple[bool, Exception | None]:
+        """Validate that the path is an ASAM MDF file."""
+        if not self.path.exists():
+            return False, FileNotFoundError(self.path)
+
+        if not self.path.is_file():
+            return False, errors.PathNotFileError(self.path)
+
+        with open(self.path, "rb") as stream:
+            if stream.read(len(MDF_MAGIC)) != MDF_MAGIC:
+                return False, errors.InvalidPathError(f"{self.path} is not an ASAM MDF file.")
+
+        return True, None
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = SourceFactory

--- a/src/topic/automotive/mf4.py
+++ b/src/topic/automotive/mf4.py
@@ -1,0 +1,101 @@
+"""A topic registry for ASAM MDF (.mf4) files: channel groups are topics."""
+
+import numpy as np
+import pyarrow as pa
+from asammdf import MDF
+
+from src.di import module
+from src.topic import base
+
+NATIVE_TYPE_NAME = "mdf/channel_group"
+
+
+def topic_names(mdf: MDF) -> dict[str, int]:
+    """Map each topic name to its channel group index.
+
+    Uses the group's acquisition name when present (CANape/INCA set these to the
+    message or measurement name); unnamed groups get a positional name. Duplicate
+    names are disambiguated with their group index.
+    """
+    names: dict[str, int] = {}
+    for index, group in enumerate(mdf.groups):
+        name = group.channel_group.acq_name or f"ChannelGroup_{index}"
+        if name in names:
+            name = f"{name}_{index}"
+        names[name] = index
+    return names
+
+
+def _channels(mdf: MDF, index: int) -> list[str]:
+    """Non-master channel names for a group (the master/time channel is implicit)."""
+    master_index = mdf.masters_db.get(index)
+    return [
+        channel.name
+        for position, channel in enumerate(mdf.groups[index].channels)
+        if position != master_index
+    ]
+
+
+def _arrow_type(dtype: np.dtype) -> pa.DataType:
+    if dtype.kind == "b":
+        return pa.bool_()
+    if dtype.kind in "iu":
+        return pa.int64()
+    if dtype.kind == "f":
+        return pa.float64()
+    return pa.string()
+
+
+class TopicRegistry(base.TopicRegistry):
+    """A topic registry for ASAM MDF files."""
+
+    def available_topics(self, data_source: MDF) -> list[str]:
+        """Return channel group names as topics."""
+        return sorted(topic_names(data_source))
+
+    def native_type_name(self, topic: str, data_source: MDF) -> str:
+        """Return the native type name for the given topic."""
+        self._group_index(topic, data_source)
+        return NATIVE_TYPE_NAME
+
+    def message_count(self, topic: str, data_source: MDF) -> int | None:
+        """Return the sample count (cycles) of the channel group."""
+        index = self._group_index(topic, data_source)
+        return data_source.groups[index].channel_group.cycles_nr
+
+    def struct(self, topic: str, data_source: MDF) -> pa.StructType:
+        """Return one field per channel, with units attached as metadata."""
+        index = self._group_index(topic, data_source)
+        fields = []
+        for name in _channels(data_source, index):
+            signal = data_source.get(name, group=index, raw=False)
+            fields.append(
+                pa.field(
+                    name,
+                    _arrow_type(signal.samples.dtype),
+                    metadata={
+                        "description": signal.comment or f"MDF channel '{name}'",
+                        "units": signal.unit or "",
+                    },
+                )
+            )
+        return pa.struct(fields)
+
+    def describe(self, topic: str, data_source: MDF) -> str | None:
+        """Return a human-readable description of the channel group."""
+        index = self._group_index(topic, data_source)
+        group = data_source.groups[index]
+        channels = ", ".join(_channels(data_source, index))
+        comment = group.channel_group.comment or "ASAM MDF channel group"
+        return f"{comment}. Channels: {channels}."
+
+    def _group_index(self, topic: str, data_source: MDF) -> int:
+        names = topic_names(data_source)
+        if topic not in names:
+            raise base.TopicNotFoundError(topic)
+        return names[topic]
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = TopicRegistry

--- a/test/message/automotive/test_message_mf4.py
+++ b/test/message/automotive/test_message_mf4.py
@@ -1,0 +1,118 @@
+"""Tests for the ASAM MDF (.mf4) adapter family, over a generated measurement file."""
+
+import pathlib
+
+import duckdb
+import pytest
+
+asammdf = pytest.importorskip(
+    "asammdf", reason="asammdf is optional (uv sync --group automotive)"
+)
+import numpy as np  # noqa: E402
+from asammdf import MDF, Signal  # noqa: E402
+
+from src.di import module  # noqa: E402
+from src.di.types.base_module import BaseModule  # noqa: E402
+from src.di.types.data_source import DataSource, resolve  # noqa: E402
+from src.topic import base as topic_base  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def mf4_file(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """A deterministic two-group measurement: engine data at 2 Hz, vehicle at 2 Hz."""
+    path = tmp_path_factory.mktemp("mdf") / "measurement.mf4"
+    t = np.arange(0, 10, 0.5)
+    mdf = MDF(version="4.10")
+    mdf.append(
+        [
+            Signal(samples=3000.0 - 100 * t, timestamps=t, name="EngineSpeed", unit="rpm"),
+            Signal(samples=np.linspace(0, 100, len(t)), timestamps=t, name="ThrottlePos", unit="%"),
+        ],
+        acq_name="EngineData",
+        comment="engine group",
+    )
+    mdf.append(
+        [Signal(samples=2.0 * t, timestamps=t, name="VehicleSpeed", unit="km/h")],
+        acq_name="Vehicle",
+    )
+    mdf.save(path, overwrite=True)
+    return path
+
+
+def test_resolves_mdf_files(mf4_file: pathlib.Path) -> None:
+    assert resolve(str(mf4_file)) is DataSource.MDF
+
+
+def _provide(mf4_file: pathlib.Path) -> tuple:
+    ds_type = resolve(str(mf4_file))
+    factory = module.provide(
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": str(mf4_file)}
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+    return factory, registry, dataset
+
+
+def test_factory_metadata_and_bounds(mf4_file: pathlib.Path) -> None:
+    factory, _, _ = _provide(mf4_file)
+
+    assert factory.total_message_count == 40  # 20 cycles in each of 2 groups
+    assert factory.end_seconds - factory.start_seconds == 9.5
+
+    metadata = factory.metadata
+    assert metadata["mdf_version"] == "4.10"
+    groups = {g["name"]: g for g in metadata["channel_groups"]}
+    assert set(groups) == {"EngineData", "Vehicle"}
+    assert groups["EngineData"]["cycles"] == 20
+
+
+def test_topic_registry_groups_channels_and_units(mf4_file: pathlib.Path) -> None:
+    factory, registry, _ = _provide(mf4_file)
+    mdf = factory.build()
+
+    assert registry.available_topics(mdf) == ["EngineData", "Vehicle"]
+    assert registry.native_type_name("Vehicle", mdf) == "mdf/channel_group"
+    assert registry.message_count("EngineData", mdf) == 20
+
+    struct = registry.struct("EngineData", mdf)
+    assert struct.names == ["EngineSpeed", "ThrottlePos"]
+    assert struct.field("EngineSpeed").metadata[b"units"] == b"rpm"
+
+    assert "EngineSpeed" in registry.describe("EngineData", mdf)
+    with pytest.raises(topic_base.TopicNotFoundError):
+        registry.struct("Gearbox", mdf)
+
+
+def test_sql_over_channel_group(mf4_file: pathlib.Path) -> None:
+    factory, registry, dataset = _provide(mf4_file)
+
+    relation = dataset.to_duckdb(factory, registry, ["EngineData"])
+    duckdb.register("engine", relation)
+    row = duckdb.sql(
+        'SELECT COUNT(*) AS n, MIN("EngineData"[\'EngineSpeed\']) AS low FROM engine'
+    ).fetchone()
+    assert row == (20, 3000.0 - 100 * 9.5)
+
+
+def test_time_window_uses_absolute_epoch_seconds(mf4_file: pathlib.Path) -> None:
+    factory, registry, dataset = _provide(mf4_file)
+
+    # The file's timestamps are relative; Bagel exposes measurement-start + offset.
+    start = factory.start_seconds
+    relation = dataset.to_duckdb(
+        factory,
+        registry,
+        ["Vehicle"],
+        start_seconds=start + 2.0,
+        end_seconds=start + 4.0,
+    )
+    assert relation.shape[0] == 5  # 2.0, 2.5, 3.0, 3.5, 4.0
+
+
+def test_multi_topic_relation_merges_by_time(mf4_file: pathlib.Path) -> None:
+    factory, registry, dataset = _provide(mf4_file)
+
+    relation = dataset.to_duckdb(factory, registry, ["EngineData", "Vehicle"])
+    assert relation.shape[0] == 40
+    columns = set(relation.columns)
+    assert {"EngineData", "Vehicle"} <= columns

--- a/uv.lock
+++ b/uv.lock
@@ -93,6 +93,34 @@ wheels = [
 ]
 
 [[package]]
+name = "asammdf"
+version = "7.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "canmatrix", extra = ["arxml"] },
+    { name = "isal", marker = "platform_machine == 'AMD64' or platform_machine == 'x86_64'" },
+    { name = "lxml" },
+    { name = "lz4" },
+    { name = "numexpr" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/2a/dd0e1e65a7b7d196d3114b3b1819c329f5576282cf377b55376572b84455/asammdf-7.4.5.tar.gz", hash = "sha256:b0c149daea22c5b2a47ceb2f63099f78adbd68117894473f21ed9dfc2c5217a4", size = 751571, upload-time = "2024-06-19T09:20:01.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/7e/2b6977fa09d8fe044e2bae82f955a8e7504c00f4c8e1d3a21fc7b04d4e4a/asammdf-7.4.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d6e10232bb1b35c90e0f1f0c72a5562f45c23e6035046d631eea67c2d6d88b9", size = 828920, upload-time = "2024-06-19T09:20:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c5/e4d34177218f782e581212dff303ad1108d01e05bfd842abd6754c25a468/asammdf-7.4.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8448e2aee40fb2509fe1e4ec88c1ef861e95c35deafa1df595f4e5a1cb3a7c6a", size = 856778, upload-time = "2024-06-19T09:20:58.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/47/784abda660801ab95b171f71bfd8b8af57611e288fc1baf54ef421375df9/asammdf-7.4.5-cp310-cp310-win_amd64.whl", hash = "sha256:8dccc6989108873fc0043feba3b078c81dbadd9cd6edc20d81d9f6fd8470f863", size = 833354, upload-time = "2024-06-19T09:21:06.515Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f6/b30902e2ab38632bc6fb9651411dc067e06de44da1cdf94ff8dec3766cc0/asammdf-7.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c85d1136ccce61bec6e39df06075f99bf36b46ac6c83b54065f4e545dd690130", size = 828923, upload-time = "2024-06-19T09:21:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e8/07f3c1b1fa7c203ed122ef6a2125ae9880c0690d9fd2f2c40b3204c49d8c/asammdf-7.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50c37645eb54ed96d06a677a4b021b68d60c53436d12e07e27dda1a28bce5d08", size = 857732, upload-time = "2024-06-19T09:21:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c3/942fa05153fe9b28a17806ac51e82cf81991b2adeca7b800d23abd37a8ee/asammdf-7.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:15544078c17ea5718484f233bafcdcaedea2a3773e22c1589afde657478745d5", size = 833358, upload-time = "2024-06-19T09:21:31.081Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5a/8662bdf8a2fe0accde43d9011f5a7d3de47fce842ec59da61e8f3233456c/asammdf-7.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3523a2e8297748e43fff809964ecf7fd8053566efa48dfb7a75bfd584d45cef3", size = 828999, upload-time = "2024-06-19T09:21:38.941Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/cf/2ee738d80bf711e2b6e78ef59383036f7dfdf87abf8efeb6aac91efc35ef/asammdf-7.4.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9e5809e4bb20e0b7bfb9aae411a1088f93176d7dbf59fb6023e4f57da6ff958", size = 858187, upload-time = "2024-06-19T09:21:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ff/2911dabd9ed4e62803d606e81dd24e66f0d88f060b789b19298b936d60e3/asammdf-7.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:1fb96492e4fbb764b01d9dce17e3ca036f6690651fb4d0c64004cb4a43447dd1", size = 833390, upload-time = "2024-06-19T09:21:54.25Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +241,9 @@ dependencies = [
 ardupilot = [
     { name = "pymavlink" },
 ]
+automotive = [
+    { name = "asammdf" },
+]
 betaflight = [
     { name = "orangebox" },
 ]
@@ -286,6 +317,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ardupilot = [{ name = "pymavlink", specifier = ">=2.4.0,<3.0.0" }]
+automotive = [{ name = "asammdf", specifier = ">=7.4,<8" }]
 betaflight = [{ name = "orangebox", specifier = ">=0.4.0,<1.0.0" }]
 cloudini = [
     { name = "numpy", specifier = ">=1.24.0,<3.0.0" },
@@ -384,6 +416,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/f3/5dae6e3b06493f2ac769c6764543b84fa50a8de3fec1e33252271166b394/botocore-1.40.66.tar.gz", hash = "sha256:e49a55ad54426c4ea853a59ff9d8243023a90c935782d4c287e9b3424883c3fa", size = 14411853, upload-time = "2025-11-04T20:28:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/48/43f9335e28351f35a939dce366a3943296f381ecd4660bd1c8d2bb8f3006/botocore-1.40.66-py3-none-any.whl", hash = "sha256:98d5766e17e72110b1d08ab510a8475a6597c59d9560235e2d28ae1a4b043b92", size = 14076509, upload-time = "2025-11-04T20:28:44.233Z" },
+]
+
+[[package]]
+name = "canmatrix"
+version = "1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/ed/a05ab5923cd2a6e239317992cf876753cbb8d4f9ff729ce916599dcd0abb/canmatrix-1.2.tar.gz", hash = "sha256:19d5ba3fd69974bd41985b90198503bfde6ae3639dfc8ce6a2f7a0338787dbf7", size = 218767, upload-time = "2025-02-17T10:22:40.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/9c/6c2dc03d2aa30176985257b64bf3393c77d28bc019db28654c8c514493f2/canmatrix-1.2-py3-none-any.whl", hash = "sha256:9fbb03c58404489f7d2832ec31b8b10f3e7d5525f15456f60f852b89e721ebf9", size = 328653, upload-time = "2025-02-17T10:22:38.13Z" },
+]
+
+[package.optional-dependencies]
+arxml = [
+    { name = "lxml" },
 ]
 
 [[package]]
@@ -1280,6 +1330,26 @@ wheels = [
 ]
 
 [[package]]
+name = "isal"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/35/40ff3eabd401036f792cf55ba9cd19dcd5e3cb79aa5798332885ab0ff1b9/isal-1.8.0.tar.gz", hash = "sha256:124233e9a31a62030a07aafd48c26689561926f4e10417ed3ea46c211218f2b4", size = 4133365, upload-time = "2025-09-10T08:47:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/18/74c89da55020b80cec9206546bdb8c7c6f6421f48449ee1c6fd92825346c/isal-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:17cd9014a42d486e5d85d51d0d2b7b7b10d035b69851bfcdf0c30fa764c427d0", size = 237399, upload-time = "2025-09-10T08:47:29.391Z" },
+    { url = "https://files.pythonhosted.org/packages/67/12/b7599feab957c4e92fe40db873c82a88b384965fe9cd5c30c6fa47bf93b8/isal-1.8.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:256615b3d4a7fd52f3b7d7ef6c0b88df83acbb5ddf360fcb3497c922dc483103", size = 264377, upload-time = "2025-09-10T08:46:56.567Z" },
+    { url = "https://files.pythonhosted.org/packages/be/76/f3286d6ef182bc7fe24618599eda3e6f4ed0736661bad2a5c381fd9caf51/isal-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:71af9ca177ede4ad94f699143ed93d78771fcee1715e98fcea4233ee75192731", size = 266011, upload-time = "2025-09-10T08:46:57.555Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e9/d075cdeb55ff7a40667109915ca72775ccb87c8250bbcd09d92f3f633b0e/isal-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:180de61e6fcbabff6eb42650e86aa3254396da09acfb9022c6fd948da5b7a555", size = 202807, upload-time = "2025-09-10T08:49:12.549Z" },
+    { url = "https://files.pythonhosted.org/packages/24/30/5eb3dfe9eeac0013f608a664d65d57868afa11c008237c09d21896beae90/isal-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c74dfc2c5917d99c5d7a22d508654c7285e5d1e21a7465ce5a80b824784d302b", size = 237400, upload-time = "2025-09-10T08:47:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/99/04/a8b6578437a104763d1821d33abc9a6a12e4b2dd3bb766913ee7ea16bbb4/isal-1.8.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4207dde1088b899c461792c1fb5db6b0cbfeb453460fb176042b2104559fc4f1", size = 264385, upload-time = "2025-09-10T08:46:58.85Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/47/53db35a997f9853133b38960a028f8a7aac1bca80551a5736d9a7a4b5cc2/isal-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b84ae086529fd83de5bec4c7da1abd6cc164de1ca3ca1e373f344ee313a30ecb", size = 266018, upload-time = "2025-09-10T08:47:00.288Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e2/3ba4c2fdff2b663dbb5173e97c3e726c7c08f6cffa3d229cf7d11783a3be/isal-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:b09a7353c58728296878a7a762d4a352f52f66f11dd497657b991839a84a6a48", size = 202798, upload-time = "2025-09-10T08:49:13.856Z" },
+    { url = "https://files.pythonhosted.org/packages/58/6f/e170e758293712e4f7ac1d0cf92290a80816d0eea8eb0871d82877ca7372/isal-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3255b5dd6ac0238d410a6d630761e3826d4360400e88d6106e8ad85fe9042966", size = 237652, upload-time = "2025-09-10T08:47:31.57Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/c10343738c170c31a5e25f0a1d024f8160ec107c5a2935a1a07587821100/isal-1.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3c28ff61f2f300e498ea0f50cb1528d8c14631fce4cdfce191ed05775952de3", size = 264663, upload-time = "2025-09-10T08:47:01.294Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/72/5cbc30d59821bcf93be44eab758ca999794fbd6e47b67954193d11e92000/isal-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ce55960f53603145d35188ca6363848b79675d81c95a3ff2cfb4b2cb806873e", size = 266327, upload-time = "2025-09-10T08:47:02.178Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a0/3cdaac7caab7e5e2660afbf03d16616f8c3fb91ec3b75596e2388d42b90b/isal-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d376b7644434d50fedfb670483150ece64082212b6e1f23976f92a91fa1b99b", size = 203025, upload-time = "2025-09-10T08:49:15.206Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2031,6 +2101,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "numexpr"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/91/ccd504cbe5b88d06987c77f42ba37a13ef05065fdab4afe6dcfeb2961faf/numexpr-2.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d0fab3fd06a04f6b86102552b26aa5d85e20ac7d8296c15764c726eeabae6cc8", size = 163200, upload-time = "2025-10-13T16:16:25.47Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/89/6b07977baf2af75fb6692f9e7a1fb612a15f600fc921f3f565366de01f4a/numexpr-2.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:64ae5dfd62d74a3ef82fe0b37f80527247f3626171ad82025900f46ffca4b39a", size = 152085, upload-time = "2025-10-13T16:16:29.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c2/c5775541256c4bf16b4d88fa1cffa74a0126703e513093c8774d911b0bb7/numexpr-2.14.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:955c92b064f9074d2970cf3138f5e3b965be673b82024962ed526f39bc25a920", size = 449435, upload-time = "2025-10-13T16:13:16.257Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/d1a410901c620f7a6a3c5c2b1fc9dab22170be05a89d2c02ae699e27bd3f/numexpr-2.14.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75440c54fc01e130396650fdf307aa9d41a67dc06ddbfb288971b591c13a395b", size = 440197, upload-time = "2025-10-13T16:14:44.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c8/fa85f0cc5c39db587ba4927b862a92477c017ee8476e415e8120a100457b/numexpr-2.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dde9fa47ed319e1e1728940a539df3cb78326b7754bc7c6ab3152afc91808f9b", size = 1414125, upload-time = "2025-10-13T16:13:19.882Z" },
+    { url = "https://files.pythonhosted.org/packages/08/72/a58ddc05e0eabb3fa8d3fcd319f3d97870e6b41520832acfd04a6734c2c0/numexpr-2.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:76db0bc6267e591ab9c4df405ffb533598e4c88239db7338d11ae9e4b368a85a", size = 1463041, upload-time = "2025-10-13T16:14:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c5/bdd1862302bb71a78dba941eaf7060e1274f1cf6af2d1b0f1880bfcb289b/numexpr-2.14.1-cp310-cp310-win32.whl", hash = "sha256:0d1dcbdc4d0374c0d523cee2f94f06b001623cbc1fd163612841017a3495427c", size = 166833, upload-time = "2025-10-13T16:17:03.543Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/26773a246716922794388786529e5640676399efabb0ee217ce034df9d27/numexpr-2.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:823cd82c8e7937981339f634e7a9c6a92cb2d0b9d0a5cf627a5e394fffc05377", size = 160068, upload-time = "2025-10-13T16:17:05.191Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/67999bdd1ed1f938d38f3fedd4969632f2f197b090e50505f7cc1fa82510/numexpr-2.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2d03fcb4644a12f70a14d74006f72662824da5b6128bf1bcd10cc3ed80e64c34", size = 163195, upload-time = "2025-10-13T16:16:31.212Z" },
+    { url = "https://files.pythonhosted.org/packages/25/95/d64f680ea1fc56d165457287e0851d6708800f9fcea346fc1b9957942ee6/numexpr-2.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2773ee1133f77009a1fc2f34fe236f3d9823779f5f75450e183137d49f00499f", size = 152088, upload-time = "2025-10-13T16:16:33.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7f/3bae417cb13ae08afd86d08bb0301c32440fe0cae4e6262b530e0819aeda/numexpr-2.14.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebe4980f9494b9f94d10d2e526edc29e72516698d3bf95670ba79415492212a4", size = 451126, upload-time = "2025-10-13T16:13:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/1a/edbe839109518364ac0bd9e918cf874c755bb2c128040e920f198c494263/numexpr-2.14.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a381e5e919a745c9503bcefffc1c7f98c972c04ec58fc8e999ed1a929e01ba6", size = 442012, upload-time = "2025-10-13T16:14:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b1/be4ce99bff769a5003baddac103f34681997b31d4640d5a75c0e8ed59c78/numexpr-2.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d08856cfc1b440eb1caaa60515235369654321995dd68eb9377577392020f6cb", size = 1415975, upload-time = "2025-10-13T16:13:26.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/33/b33b8fdc032a05d9ebb44a51bfcd4b92c178a2572cd3e6c1b03d8a4b45b2/numexpr-2.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03130afa04edf83a7b590d207444f05a00363c9b9ea5d81c0f53b1ea13fad55a", size = 1464683, upload-time = "2025-10-13T16:14:58.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/ddcf0ac6cf0a1d605e5aecd4281507fd79a9628a67896795ab2e975de5df/numexpr-2.14.1-cp311-cp311-win32.whl", hash = "sha256:db78fa0c9fcbaded3ae7453faf060bd7a18b0dc10299d7fcd02d9362be1213ed", size = 166838, upload-time = "2025-10-13T16:17:06.765Z" },
+    { url = "https://files.pythonhosted.org/packages/64/72/4ca9bd97b2eb6dce9f5e70a3b6acec1a93e1fb9b079cb4cba2cdfbbf295d/numexpr-2.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:e9b2f957798c67a2428be96b04bce85439bed05efe78eb78e4c2ca43737578e7", size = 160069, upload-time = "2025-10-13T16:17:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/c473fc04a371f5e2f8c5749e04505c13e7a8ede27c09e9f099b2ad6f43d6/numexpr-2.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:91ebae0ab18c799b0e6b8c5a8d11e1fa3848eb4011271d99848b297468a39430", size = 162790, upload-time = "2025-10-13T16:16:34.903Z" },
+    { url = "https://files.pythonhosted.org/packages/45/93/b6760dd1904c2a498e5f43d1bb436f59383c3ddea3815f1461dfaa259373/numexpr-2.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47041f2f7b9e69498fb311af672ba914a60e6e6d804011caacb17d66f639e659", size = 152196, upload-time = "2025-10-13T16:16:36.593Z" },
+    { url = "https://files.pythonhosted.org/packages/72/94/cc921e35593b820521e464cbbeaf8212bbdb07f16dc79fe283168df38195/numexpr-2.14.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d686dfb2c1382d9e6e0ee0b7647f943c1886dba3adbf606c625479f35f1956c1", size = 452468, upload-time = "2025-10-13T16:13:29.531Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/43/560e9ba23c02c904b5934496486d061bcb14cd3ebba2e3cf0e2dccb6c22b/numexpr-2.14.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee6d4fbbbc368e6cdd0772734d6249128d957b3b8ad47a100789009f4de7083", size = 443631, upload-time = "2025-10-13T16:15:02.473Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6c/78f83b6219f61c2c22d71ab6e6c2d4e5d7381334c6c29b77204e59edb039/numexpr-2.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3a2839efa25f3c8d4133252ea7342d8f81226c7c4dda81f97a57e090b9d87a48", size = 1417670, upload-time = "2025-10-13T16:13:33.464Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/bb/1ccc9dcaf46281568ce769888bf16294c40e98a5158e4b16c241de31d0d3/numexpr-2.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f9137f1351b310436662b5dc6f4082a245efa8950c3b0d9008028df92fefb9b", size = 1466212, upload-time = "2025-10-13T16:15:12.828Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9f/203d82b9e39dadd91d64bca55b3c8ca432e981b822468dcef41a4418626b/numexpr-2.14.1-cp312-cp312-win32.whl", hash = "sha256:36f8d5c1bd1355df93b43d766790f9046cccfc1e32b7c6163f75bcde682cda07", size = 166996, upload-time = "2025-10-13T16:17:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/ffe750b5452eb66de788c34e7d21ec6d886abb4d7c43ad1dc88ceb3d998f/numexpr-2.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:fdd886f4b7dbaf167633ee396478f0d0aa58ea2f9e7ccc3c6431019623e8d68f", size = 160187, upload-time = "2025-10-13T16:17:11.974Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #130. PR-A of the automotive arc (PR-B: raw CAN + DBC decoding; the `canmatrix` DBC parser already rides in with this group).

## Why this lane
MDF4 is the ASAM-standard measurement format that CANape, INCA, Vector tooling, and most automotive DAQ hardware emit. Everything is pure pip (`asammdf`) — a perfect fit for the no-ROS-deps distribution thesis — and it opens an industry that the existing robotics/drone tooling doesn't serve.

## The mapping
- **Channel groups → topics** (acquisition names like `EngineData`; unnamed groups get positional names, duplicates disambiguated)
- **Channels → struct fields**, with the file's units and comments attached as Arrow field metadata — the LLM sees `EngineSpeed (rpm)` without being told
- **Timestamps → absolute epoch seconds** (measurement start + sample offset), consistent with every other source
- Detection by magic bytes (`MDF     `), which also covers older MDF3 files that asammdf reads transparently

## Engineering notes
- New optional `automotive` dependency group; pinned `asammdf <8` — 8.x ships no wheel for this platform and its source build fails (scikit-build-core); 7.4.5 verified
- Tests `importorskip` asammdf, so environments without the group still pass
- `resolve()` picked up a `PLR0912` at 13 branches — annotated rather than refactored (one branch per supported format is the honest shape of that function)

## Verification
- 6 tests over a **generated deterministic measurement** (2 channel groups, 20 cycles each): resolution, bounded metadata, topics/struct/units round-trip, SQL over a channel group, epoch-seconds time windows (5 rows for a 2s window at 0.5s cadence), multi-topic merge
- Real MCP tool calls against a synthetic 60s drive: `describe_data_source` and `query_messages` (`top: 80.0 km/h, hardest_decel: -1.67 m/s²`)
- Full non-ROS suite: **261 passed**, ruff clean
- Runbook `doc/runbooks/automotive_mdf.md`; README gains an **Automotive** row in the formats table + a Guides entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
