### PR TITLE
Add raw CAN captures (.blf/.asc + DBC) as a data source — automotive beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Can’t wait to try it out? 👉 Check out the [Quickstart](#️-quickstart).
 | ------------ | ------------------------------ |
 | **Robotics** | ROS1, ROS2, MCAP (any profile), ROS text logs (`~/.ros/log`) |
 | **Drones**   | PX4, ArduPilot, Betaflight     |
-| **Automotive** | ASAM MDF4 (`.mf4`, CANape/INCA/Vector measurements) |
+| **Automotive** | ASAM MDF4 (`.mf4`), CAN captures (`.blf`/`.asc` + DBC) — *beta* |
 | **IoT**      | MQTT (live, Sparkplug B), PostgreSQL / TimescaleDB, InfluxDB 3 |
 
 ## 🆚 Bagel vs. the Tools You Already Use
@@ -272,7 +272,7 @@ meow 🐱 4 topics 🐱💤🎯
 - [MQTT](./doc/runbooks/iot_mqtt.md) — live IoT topics, Sparkplug B, edge recording
 - [PostgreSQL / TimescaleDB](./doc/runbooks/iot_postgres.md) — every table is a topic
 - [InfluxDB 3](./doc/runbooks/iot_influxdb.md) — every measurement is a topic
-- [Automotive MDF4](./doc/runbooks/automotive_mdf.md) — channel groups are topics, channels are fields, units ride along
+- [Automotive MDF4 & CAN](./doc/runbooks/automotive_mdf.md) *(beta)* — channel groups and DBC messages are topics; units ride along
 - [Local LLMs](./doc/runbooks/local_llm.md) — fully offline with Ollama: your data and your model never leave the machine
 
 ## 📦 Integrations

--- a/doc/runbooks/automotive_mdf.md
+++ b/doc/runbooks/automotive_mdf.md
@@ -1,4 +1,4 @@
-# Automotive: ASAM MDF (.mf4)
+# Automotive: ASAM MDF (.mf4) and raw CAN (.blf / .asc) — beta
 
 MDF is the measurement format the automotive world runs on — CANape, INCA, Vector
 tooling, and most DAQ hardware write it. Bagel reads `.mf4` (and older MDF)
@@ -27,12 +27,31 @@ Everything is pure pip (`asammdf`) — no vendor tooling required.
 Channel units and comments from the file ride along into the schema, so the LLM
 knows `EngineSpeed` is in rpm without being told.
 
+## Raw CAN captures with a DBC
+
+Vector BLF and ASC captures work too — pass the DBC that describes the bus, and
+**DBC messages become topics, signals become fields** with physical values
+(scaling applied) and units attached:
+
+> Using ./vehicle.dbc, what's the max EngineSpeed in ./drive.blf?
+
+which calls `query_messages(path="./drive.blf", args={"dbc": "./vehicle.dbc"}, ...)`.
+Frames whose IDs aren't in the DBC are skipped (and counted in the logs), so a
+partial DBC still works.
+
+## Beta status
+
+Both readers are verified against files we generate with the same libraries that
+read them (`asammdf`, `python-can`) — real CANape/INCA/Vector-produced captures
+haven't crossed our test bench yet. If you have one, trying Bagel on it and
+[reporting what happens](https://github.com/Extelligence-ai/bagel/issues) is the
+single most useful contribution.
+
 ## Notes
 
 - Timestamps are exposed as **absolute epoch seconds** (the file's measurement
   start time plus each sample's offset), consistent with every other Bagel source —
   so time windows and cross-source comparisons behave as expected.
 - Unnamed channel groups appear as `ChannelGroup_<index>`.
-- Raw CAN logs (`.blf` / `.asc`) with DBC decoding are the planned follow-up; if
-  you need them, [open a ticket](https://github.com/Extelligence-ai/bagel/issues)
-  or 👍 the existing one.
+- MDF4 files with DBC-referenced CAN raw frames inside are best decoded by your
+  DAQ tool into channel groups first; direct in-MDF CAN decoding is demand-driven.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ viz = [
 ]
 automotive = [
     "asammdf>=7.4,<8",
+    "cantools>=42.0.3",
+    "python-can>=4.6.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -27,6 +27,7 @@ class DataSource(Enum):
     INFLUXDB = "influxdb"
     ROS_LOG = "ros.log"
     MDF = "automotive.mf4"
+    CAN = "automotive.can"
 
 
 # URL schemes mapped to their data source types.
@@ -77,6 +78,8 @@ def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # n
         return DataSource.BETAFLIGHT_BFL
     elif is_mdf_file(path):
         return DataSource.MDF
+    elif is_can_blf_file(path) or is_can_asc_file(path):
+        return DataSource.CAN
     elif is_ros_log_file(path) or is_ros_log_directory(path):
         # Checked before JSON/CSV: free-form log lines can fool the CSV sniffer.
         return DataSource.ROS_LOG
@@ -260,6 +263,22 @@ def is_json_lines_file(path: pathlib.Path) -> bool:
 def is_mdf_file(path: pathlib.Path) -> bool:
     """Check if the given path is an ASAM MDF measurement file (.mf4 and older)."""
     return has_magic_bytes(path, b"MDF     ")
+
+
+def is_can_blf_file(path: pathlib.Path) -> bool:
+    """Check if the given path is a Vector BLF CAN capture."""
+    return has_magic_bytes(path, b"LOGG")
+
+
+def is_can_asc_file(path: pathlib.Path) -> bool:
+    """Check if the given path is a Vector ASC CAN capture (text, starts with a date line)."""
+    if not path.is_file() or path.suffix.lower() != ".asc":
+        return False
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.readline().strip().lower().startswith("date")
+    except OSError:
+        return False
 
 
 def is_ros_log_file(path: pathlib.Path) -> bool:

--- a/src/message/automotive/can.py
+++ b/src/message/automotive/can.py
@@ -1,0 +1,43 @@
+"""A message dataset for DBC-decoded CAN logs."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pyarrow as pa
+
+from src.di import module
+from src.message import base
+from src.source.automotive.can import CanLog
+
+
+class MessageDataset(base.MessageDataset):
+    """A message dataset for DBC-decoded CAN logs.
+
+    Topics are DBC messages; each message is one decoded frame with a field per
+    signal (physical values, scaling applied by the DBC).
+    """
+
+    def _messages(
+        self,
+        data_source: CanLog,
+        topics: list[str],
+        start_seconds_inclusive: float | None,
+        end_seconds_inclusive: float | None,
+    ) -> Iterator[tuple[str, float, dict[str, Any]]]:
+        wanted = set(topics)
+        for timestamp, name, decoded in data_source.records:
+            if name not in wanted:
+                continue
+            if start_seconds_inclusive is not None and timestamp < start_seconds_inclusive:
+                continue
+            if end_seconds_inclusive is not None and timestamp > end_seconds_inclusive:
+                continue
+            yield (name, timestamp, {key: float(value) for key, value in decoded.items()})
+
+    def _to_json(self, message: dict[str, Any], struct: pa.StructType) -> dict[str, Any]:
+        return message
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = MessageDataset

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -1,0 +1,127 @@
+"""Provide a data source for raw CAN logs (.blf / .asc) decoded through a DBC.
+
+A DBC file is the schema of a CAN bus: it names messages and scales their signals
+to physical values. Bagel maps DBC messages to topics and signals to fields, so a
+raw bus capture becomes queryable like any other source. Requires the optional
+``automotive`` dependency group: ``uv sync --group automotive``.
+"""
+
+import functools
+import logging
+import pathlib
+from typing import Any
+
+import can
+import cantools
+
+from src.di import module
+from src.source import base, errors
+
+BLF_MAGIC = b"LOGG"
+
+
+class CanLog:
+    """A DBC-decoded view over a raw CAN log file."""
+
+    def __init__(self, path: str, dbc: str) -> None:
+        """Initialize the decoded log.
+
+        Args:
+            path (str): Path to the .blf or .asc capture.
+            dbc (str): Path to the DBC database describing the bus.
+
+        """
+        self.database = cantools.database.load_file(dbc)
+        self._path = path
+        self._records: list[tuple[float, str, dict[str, Any]]] | None = None
+
+    @property
+    def records(self) -> list[tuple[float, str, dict[str, Any]]]:
+        """(timestamp, message_name, decoded_signals) tuples, sorted by time."""
+        if self._records is None:
+            known = {message.frame_id: message.name for message in self.database.messages}
+            records = []
+            unknown = 0
+            with can.LogReader(self._path) as reader:
+                for frame in reader:
+                    name = known.get(frame.arbitration_id)
+                    if name is None:
+                        unknown += 1
+                        continue
+                    decoded = self.database.decode_message(
+                        frame.arbitration_id, frame.data, decode_choices=False
+                    )
+                    records.append((float(frame.timestamp), name, dict(decoded)))
+            if unknown:
+                logging.info("Skipped %d frames with IDs not in the DBC", unknown)
+            records.sort(key=lambda record: record[0])
+            self._records = records
+        return self._records
+
+
+class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
+    """A data source factory for DBC-decoded raw CAN logs."""
+
+    def __init__(self, path: str, dbc: str) -> None:
+        """Initialize the CAN log data source factory.
+
+        Args:
+            path (str): Path to the .blf or .asc capture.
+            dbc (str): Path to the DBC database describing the bus (pass via the
+                tool's `args`, e.g. ``args={"dbc": "./vehicle.dbc"}``).
+
+        """
+        self._dbc = dbc
+        super().__init__(path)
+        self._log = CanLog(path=path, dbc=dbc)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return metadata about the capture and its DBC."""
+        return {
+            **self._bounded_metadata,
+            **self._file_based_metadata,
+            "dbc": self._dbc,
+            "dbc_messages": [message.name for message in self._log.database.messages],
+        }
+
+    @property
+    def total_message_count(self) -> int:
+        """Return the number of decodable frames."""
+        return len(self._log.records)
+
+    @functools.cached_property
+    def start_seconds(self) -> float:
+        """Return the first frame's timestamp in seconds."""
+        records = self._log.records
+        return records[0][0] if records else 0.0
+
+    @functools.cached_property
+    def end_seconds(self) -> float:
+        """Return the last frame's timestamp in seconds."""
+        records = self._log.records
+        return records[-1][0] if records else 0.0
+
+    def build(self) -> CanLog:
+        """Return the decoded log."""
+        return self._log
+
+    def validate_path(self) -> tuple[bool, Exception | None]:
+        """Validate that the path is a BLF or ASC capture and the DBC exists."""
+        if not self.path.exists():
+            return False, FileNotFoundError(self.path)
+
+        if not pathlib.Path(self._dbc).is_file():
+            return False, FileNotFoundError(f"DBC database not found: {self._dbc}")
+
+        with open(self.path, "rb") as stream:
+            is_blf = stream.read(len(BLF_MAGIC)) == BLF_MAGIC
+        if not is_blf and self.path.suffix.lower() != ".asc":
+            return False, errors.InvalidPathError(f"{self.path} is not a BLF or ASC CAN capture.")
+
+        return True, None
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = SourceFactory

--- a/src/topic/automotive/can.py
+++ b/src/topic/automotive/can.py
@@ -1,0 +1,62 @@
+"""A topic registry for DBC-decoded CAN logs: DBC messages are topics."""
+
+import pyarrow as pa
+
+from src.di import module
+from src.source.automotive.can import CanLog
+from src.topic import base
+
+NATIVE_TYPE_NAME = "can/dbc_message"
+
+
+class TopicRegistry(base.TopicRegistry):
+    """A topic registry for DBC-decoded CAN logs."""
+
+    def available_topics(self, data_source: CanLog) -> list[str]:
+        """Return the DBC message names observed in the capture."""
+        return sorted({name for _, name, _ in data_source.records})
+
+    def native_type_name(self, topic: str, data_source: CanLog) -> str:
+        """Return the native type name for the given topic."""
+        self._message(topic, data_source)
+        return NATIVE_TYPE_NAME
+
+    def message_count(self, topic: str, data_source: CanLog) -> int | None:
+        """Return the number of decoded frames for the message."""
+        self._message(topic, data_source)
+        return sum(1 for _, name, _ in data_source.records if name == topic)
+
+    def struct(self, topic: str, data_source: CanLog) -> pa.StructType:
+        """Return one float field per DBC signal, with units attached as metadata."""
+        message = self._message(topic, data_source)
+        return pa.struct(
+            [
+                pa.field(
+                    signal.name,
+                    pa.float64(),
+                    metadata={
+                        "description": signal.comment or f"DBC signal '{signal.name}'",
+                        "units": signal.unit or "",
+                    },
+                )
+                for signal in message.signals
+            ]
+        )
+
+    def describe(self, topic: str, data_source: CanLog) -> str | None:
+        """Return a human-readable description of the DBC message."""
+        message = self._message(topic, data_source)
+        signals = ", ".join(f"{s.name} ({s.unit})" if s.unit else s.name for s in message.signals)
+        comment = message.comment or f"CAN message 0x{message.frame_id:X}"
+        return f"{comment}. Signals: {signals}."
+
+    def _message(self, topic: str, data_source: CanLog) -> object:
+        try:
+            return data_source.database.get_message_by_name(topic)
+        except KeyError as error:
+            raise base.TopicNotFoundError(topic) from error
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = TopicRegistry

--- a/test/message/automotive/test_message_can.py
+++ b/test/message/automotive/test_message_can.py
@@ -1,0 +1,125 @@
+"""Tests for the DBC-decoded CAN adapter family, over a generated BLF capture."""
+
+import pathlib
+
+import duckdb
+import pytest
+
+can = pytest.importorskip("can", reason="python-can is optional (uv sync --group automotive)")
+cantools = pytest.importorskip("cantools")
+
+from src.di import module  # noqa: E402
+from src.di.types.base_module import BaseModule  # noqa: E402
+from src.di.types.data_source import DataSource, resolve  # noqa: E402
+from src.topic import base as topic_base  # noqa: E402
+
+DBC = """
+VERSION ""
+BO_ 256 EngineData: 8 ECU
+ SG_ EngineSpeed : 0|16@1+ (0.25,0) [0|16383] "rpm" Vector__XXX
+ SG_ ThrottlePos : 16|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+BO_ 512 Brakes: 8 ECU
+ SG_ BrakePressure : 0|16@1+ (0.1,0) [0|6553] "bar" Vector__XXX
+"""
+T0 = 1662400000.0
+
+
+@pytest.fixture(scope="module")
+def capture(tmp_path_factory: pytest.TempPathFactory) -> tuple[pathlib.Path, pathlib.Path]:
+    """A BLF capture with two DBC messages plus one frame the DBC doesn't know."""
+    root = tmp_path_factory.mktemp("can")
+    dbc_file = root / "vehicle.dbc"
+    dbc_file.write_text(DBC)
+    database = cantools.database.load_file(dbc_file)
+
+    blf_file = root / "drive.blf"
+    with can.BLFWriter(blf_file) as writer:
+        for i in range(10):
+            engine = database.encode_message(
+                "EngineData", {"EngineSpeed": 3000 - 100 * i, "ThrottlePos": 40.0}
+            )
+            writer.on_message_received(
+                can.Message(
+                    arbitration_id=0x100, data=engine, is_extended_id=False, timestamp=T0 + i
+                )
+            )
+        brakes = database.encode_message("Brakes", {"BrakePressure": 12.5})
+        writer.on_message_received(
+            can.Message(arbitration_id=0x200, data=brakes, is_extended_id=False, timestamp=T0 + 5)
+        )
+        # A frame whose ID is not in the DBC: skipped, not fatal.
+        writer.on_message_received(
+            can.Message(arbitration_id=0x7FF, data=b"\x00" * 8, timestamp=T0 + 6)
+        )
+    return blf_file, dbc_file
+
+
+def _provide(capture: tuple[pathlib.Path, pathlib.Path]) -> tuple:
+    blf_file, dbc_file = capture
+    ds_type = resolve(str(blf_file))
+    factory = module.provide(
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {"path": str(blf_file), "dbc": str(dbc_file)},
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+    return factory, registry, dataset
+
+
+def test_resolves_blf_captures(capture: tuple[pathlib.Path, pathlib.Path]) -> None:
+    assert resolve(str(capture[0])) is DataSource.CAN
+
+
+def test_factory_decodes_and_skips_unknown_ids(
+    capture: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    factory, _, _ = _provide(capture)
+
+    assert factory.total_message_count == 11  # 10 engine + 1 brakes; unknown ID skipped
+    assert factory.start_seconds == T0
+    assert factory.end_seconds == T0 + 9
+    assert factory.metadata["dbc_messages"] == ["EngineData", "Brakes"]
+
+
+def test_topics_struct_and_units(capture: tuple[pathlib.Path, pathlib.Path]) -> None:
+    factory, registry, _ = _provide(capture)
+    log = factory.build()
+
+    assert registry.available_topics(log) == ["Brakes", "EngineData"]
+    assert registry.message_count("EngineData", log) == 10
+
+    struct = registry.struct("EngineData", log)
+    assert struct.names == ["EngineSpeed", "ThrottlePos"]
+    assert struct.field("EngineSpeed").metadata[b"units"] == b"rpm"
+    assert "BrakePressure (bar)" in registry.describe("Brakes", log)
+
+    with pytest.raises(topic_base.TopicNotFoundError):
+        registry.struct("Gearbox", log)
+
+
+def test_sql_over_decoded_physical_values(capture: tuple[pathlib.Path, pathlib.Path]) -> None:
+    factory, registry, dataset = _provide(capture)
+
+    relation = dataset.to_duckdb(factory, registry, ["EngineData"])
+    duckdb.register("engine", relation)
+    row = duckdb.sql(
+        "SELECT MAX(\"EngineData\"['EngineSpeed']) AS top, "
+        "MIN(\"EngineData\"['EngineSpeed']) AS low FROM engine"
+    ).fetchone()
+    assert row == (3000.0, 2100.0)  # physical values: DBC scaling applied
+
+
+def test_time_window(capture: tuple[pathlib.Path, pathlib.Path]) -> None:
+    factory, registry, dataset = _provide(capture)
+
+    relation = dataset.to_duckdb(
+        factory, registry, ["EngineData"], start_seconds=T0 + 2, end_seconds=T0 + 4
+    )
+    assert relation.shape[0] == 3
+
+
+def test_missing_dbc_fails_cleanly(capture: tuple[pathlib.Path, pathlib.Path]) -> None:
+    from src.source.automotive.can import SourceFactory
+
+    with pytest.raises(FileNotFoundError, match="DBC"):
+        SourceFactory(str(capture[0]), dbc="./no/such.dbc")

--- a/uv.lock
+++ b/uv.lock
@@ -80,6 +80,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argparse-addons"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/35/33ecca1cdbebc5397a77f66edbc20ab76265176f7e3511b7696008ad9038/argparse_addons-0.12.0.tar.gz", hash = "sha256:6322a0dcd706887e76308d23136d5b86da0eab75a282dc6496701d1210b460af", size = 3780, upload-time = "2023-01-29T15:52:13.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/41/629e70c4cb32c1ddb88de970cd174bbb43d8241c8e07bdffc62a8280297c/argparse_addons-0.12.0-py3-none-any.whl", hash = "sha256:48b70ecd719054fcb0d7e6f25a1fecc13607aac61d446e83f47d211b4ead0d61", size = 3310, upload-time = "2023-01-29T15:52:12.255Z" },
+]
+
+[[package]]
 name = "arrow"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -243,6 +252,8 @@ ardupilot = [
 ]
 automotive = [
     { name = "asammdf" },
+    { name = "cantools" },
+    { name = "python-can" },
 ]
 betaflight = [
     { name = "orangebox" },
@@ -317,7 +328,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ardupilot = [{ name = "pymavlink", specifier = ">=2.4.0,<3.0.0" }]
-automotive = [{ name = "asammdf", specifier = ">=7.4,<8" }]
+automotive = [
+    { name = "asammdf", specifier = ">=7.4,<8" },
+    { name = "cantools", specifier = ">=42.0.3" },
+    { name = "python-can", specifier = ">=4.6.1" },
+]
 betaflight = [{ name = "orangebox", specifier = ">=0.4.0,<1.0.0" }]
 cloudini = [
     { name = "numpy", specifier = ">=1.24.0,<3.0.0" },
@@ -371,6 +386,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
+name = "bitstruct"
+version = "8.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/13/d8b56ef2e6b6ae2cc1b23e509ea7cc8d3423aa0d8a7d7634c23c0bf845e2/bitstruct-8.22.1.tar.gz", hash = "sha256:97588318c906c60d33129e0061dd830b03d793c517033d312487c75426d1e808", size = 35616, upload-time = "2026-02-17T14:14:23.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/c9/a6a74c645b8a8d151c9bc0830a66a20e293fecfddbe37f4d8f3e0fa12819/bitstruct-8.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c250d8dbd6350dfd73cf4bccab700122072388bd388d284ada37149eeb49979", size = 37862, upload-time = "2026-02-17T14:12:58.826Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c8/09a16455af0941635cf2f37c18a43d9bc7529e02f8b591c6c265c084ccdd/bitstruct-8.22.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7fb40f50be4e60cb7a345ca4ceb16afcbcfecfa7cedf1cded44b8e1d8b8c3109", size = 38387, upload-time = "2026-02-17T14:13:00.389Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/30/e66995833d4d9c01e74371a7e8a2ed0ee0d4d9f7eeb3e5de3603d3101862/bitstruct-8.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ebcc2ad3b9addd4a6a409481754c78ade65a8d24a4d34352e37df9b48aeabea", size = 80590, upload-time = "2026-02-17T14:13:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3c/adaaeb93f37958221152ea6af85b10cef71b9c57a3481ad589540aff012e/bitstruct-8.22.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ec4d4e8308b3098e4de43f7ccd05d626bf2e4b650bea2b5fec9581f7bd7b4d01", size = 84216, upload-time = "2026-02-17T14:13:02.666Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/2f/29022203b6c93a609e4e8f8ec5e92594522bc82a59bc2528415f3af65e73/bitstruct-8.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e44c42bbfa9540a3df261c9a9613a88e5e5df0ad3931bcc76b9f1cc215f4ece", size = 79627, upload-time = "2026-02-17T14:13:04.038Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ef/662577f57c11cf82926a9aa2081b798d5981fee759eb74439a3390218c66/bitstruct-8.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8140c51b2e663d0efba9a6f5a77be4f26f3e147e65579be83f7c9b370df56cbe", size = 79775, upload-time = "2026-02-17T14:13:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/55/62/7d347087e330822cd433ce1e49dc049c5b26444cc8900d3436d2ddea5a27/bitstruct-8.22.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f7e6bff01ea3765d28d8e426b49e6a0e4f581a4d47329f54d3a83f3f0c23380e", size = 75893, upload-time = "2026-02-17T14:13:06.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4c/6b0e029339280377413c920f49114163d82fa4324703d877ac62637f9156/bitstruct-8.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9430cc3849c24549578210c3e185427d01bc48734acaa9d7d17a767b19719381", size = 79025, upload-time = "2026-02-17T14:13:07.446Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/bc/f6bb7e709a6b40a857d41be272b4e251a497e1aad73334c8d279f72abfb3/bitstruct-8.22.1-cp310-cp310-win32.whl", hash = "sha256:9a00e7077c81318a2d7aea6a5e2988301ef316621136ddede68b4a361afc7581", size = 34806, upload-time = "2026-02-17T14:13:08.371Z" },
+    { url = "https://files.pythonhosted.org/packages/29/21/16ebf2b053e3e890f02435800ac6acc369e3a5c51e3b2b7304a23faf19cc/bitstruct-8.22.1-cp310-cp310-win_amd64.whl", hash = "sha256:43e3d8113263894e2ca107d2f7376f2767cb880a6f9952b0f66087545a230994", size = 36860, upload-time = "2026-02-17T14:13:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/02/04/63f9b2569aaf89db734b685388cb6676f958f7fb4ba5566555a2c79f5fb8/bitstruct-8.22.1-cp310-cp310-win_arm64.whl", hash = "sha256:86f68adf8945b80007cfed2318277fc2d5de5fb253d7df5d7a703dc10b54e149", size = 35704, upload-time = "2026-02-17T14:13:10.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/48/7eae09e61478167ab084c503e384e203271c04213828db830af835fa8997/bitstruct-8.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4d235cbdba2df0747d4e4a6a6d3d46505cc2b52b16e9d3d4431423401c565f6", size = 37853, upload-time = "2026-02-17T14:13:10.965Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5a/4a4790504f98328f5576f6b27d4366da4fcd00cf7d5e6871b546730905b5/bitstruct-8.22.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b3c29ee922e68538c575667bdc924e3ef09d21da94fd48a4a430f9c32c70997", size = 38380, upload-time = "2026-02-17T14:13:12.322Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7b/156d71cb6b99e7b4e9802a1853a0f1dbdab5b4090c90eaee8eae1aa0371b/bitstruct-8.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a493a66fac64f989f3c8043e40f9ceb6b8169592c7e5a9d37a1409f00cb757a", size = 82235, upload-time = "2026-02-17T14:13:13.385Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e2/068ecb8078229bc9d3a0f53a6c988aba221e3fbb08ddaeb1305a24c30e8f/bitstruct-8.22.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:32f8ffe2f26f25dc4339e9c69acf2ba7ada877a377111bd2b1f6a8804953b51a", size = 86682, upload-time = "2026-02-17T14:13:14.823Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a8/41c7461a2832480b431cbf1322cc3ce798adf3a321c99dbd614324ae793d/bitstruct-8.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02bddf1893550a6e7e6fefb7065a222e1b10447f903cac4fbff38766df35712a", size = 81302, upload-time = "2026-02-17T14:13:16.235Z" },
+    { url = "https://files.pythonhosted.org/packages/16/46/792ad10ada0b527b2811b75962f0bdd1a0268553116367348fdb54f974e2/bitstruct-8.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3e829b10672f5ea5ed60f9d835cc2f3c2e1190448429051719600a2f6d891a0a", size = 81456, upload-time = "2026-02-17T14:13:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/91/0a562d267ca5a39df1be2f556d88aba02739d046e455bc7cb163327d24dc/bitstruct-8.22.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:956a3998e5e031bc2d1c2312afb9f714ec6131621c40123d3bb79ff1b69b82a8", size = 77588, upload-time = "2026-02-17T14:13:18.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e1/6046e08a8e8e0053cb4afb35e3c101d67d0fd6cf0e3a55f97f310c21feae/bitstruct-8.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fa74a1b7426f94d1a4917944164230ef34aa85e5a01164d6dbc150a71f90c2ca", size = 80604, upload-time = "2026-02-17T14:13:19.964Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/24/c1791e0f8c9272453a6c2ac306979ebe499bc0afbe7b58b4852fcdacaf58/bitstruct-8.22.1-cp311-cp311-win32.whl", hash = "sha256:8fd1b73c9c2c613c385f9f4fd9feaabedf88c1c740bff25a4738b1c6a70d4111", size = 34796, upload-time = "2026-02-17T14:13:21.356Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/e1434a6714e9a86e99ca9b1b98fe39f2427acb877ec916b71da52fffcb25/bitstruct-8.22.1-cp311-cp311-win_amd64.whl", hash = "sha256:419e3ce7d1d89a809a7d966d72de16cb869bd3fe80b587e5bc7cf80debd7df8d", size = 36846, upload-time = "2026-02-17T14:13:22.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f7/1186d105b2be96bb6b1c0e49733ce8c447453eaa1da3cc7362c2815f1c10/bitstruct-8.22.1-cp311-cp311-win_arm64.whl", hash = "sha256:6e548bfc4e289cacae704458ac51c6c76188c305701bd14f3f4fec600fce58e8", size = 35698, upload-time = "2026-02-17T14:13:23.005Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fe/54da38fdc4b4888cef6b330d0ea14ef787943f79bcb02aa5cd370379ea0d/bitstruct-8.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:18ff3842c89596f88307f458696ebdcbd4af718af9f0f2cad863102387200b26", size = 38219, upload-time = "2026-02-17T14:13:24.225Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b6/c24ea4436cebe30408a06bf93315b83e7ad6825d5f30c49a41b2af3e05d9/bitstruct-8.22.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:837629e72aaf247ee214d19ae0580571c2ba0ddeb3144dff12f7014cb8f3d94d", size = 38441, upload-time = "2026-02-17T14:13:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/2707c1c83e5484d6e14a30094f69d0ce681a66e107a9e7e8ac72fcd0f9d1/bitstruct-8.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2bef6f3309b39880e6f5ea4f274899062a3511eb630563858a8be6332c332eac", size = 82549, upload-time = "2026-02-17T14:13:27.026Z" },
+    { url = "https://files.pythonhosted.org/packages/34/39/37ea1c149bf634eb679552242c5c96064dfb64bed030013bd409ff6736de/bitstruct-8.22.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5958ea7f61c45e6d769bcbd0f4357cb91f1ba5cbea9323855a1c45d8bcd03b34", size = 87441, upload-time = "2026-02-17T14:13:28.915Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/cf/9236415400d4d64009086c4051e36f4c386dc640146565e2219f36696624/bitstruct-8.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f965015d75e7cc949dff3783f82378a135fe67ac549a41d7b90eb0abf06fa81d", size = 81936, upload-time = "2026-02-17T14:13:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e8/ec8e71a23ee71c84282416a245c4eff1de1cf40a2060ad19c95dca1ed374/bitstruct-8.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88573f965ce5042113e236c74fdec828abfdabec3d1cceda1e9766c86de74978", size = 81701, upload-time = "2026-02-17T14:13:30.803Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c9/aa4f3b0af3dc0f5c35c5975dacbe82f77807d93b82017344b332d316d134/bitstruct-8.22.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ec6eaf863c85d99fe3cdc6426c77f03320ff42d0905810cef73499f92c388a30", size = 78258, upload-time = "2026-02-17T14:13:31.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fd/39823ce5c43b195a24ddfec7ecff04d7846b9e55071dd51f40b5a90f2e87/bitstruct-8.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6aeee6bfcdcf0d158cae706b1fe20f42c97b06bd778eca794aa097973e782c31", size = 81206, upload-time = "2026-02-17T14:13:32.686Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3c/aa5ef9272b3531dfb588a1125ebbfa0c2bbd298841905c4aeeac0f0e7449/bitstruct-8.22.1-cp312-cp312-win32.whl", hash = "sha256:275aeaf08bf3967ed7afa568c5d9726af17ff4b558f1d82e1c587118cad988c3", size = 34788, upload-time = "2026-02-17T14:13:33.609Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/db/aa9459a497b2a5c7406787437f280df71db5686670630c37d6e4fc736f71/bitstruct-8.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:4d5bb7484ff55a18d4cc1370b9e4cd94893e2ec33d9eb985c313c1cbdca756e6", size = 36952, upload-time = "2026-02-17T14:13:34.482Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fe/0bf9cf0ae93645eb09f6eb0b31244e1f2bf7d068a35170d60fde17a3ab1a/bitstruct-8.22.1-cp312-cp312-win_arm64.whl", hash = "sha256:a38e90197bd1bc87863e5180c5556af71528ad03940d41e7a74d602c2255c4ba", size = 35681, upload-time = "2026-02-17T14:13:35.527Z" },
 ]
 
 [[package]]
@@ -434,6 +490,22 @@ wheels = [
 [package.optional-dependencies]
 arxml = [
     { name = "lxml" },
+]
+
+[[package]]
+name = "cantools"
+version = "42.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argparse-addons" },
+    { name = "bitstruct" },
+    { name = "crccheck" },
+    { name = "python-can" },
+    { name = "textparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/4b/8d9b63bfdacff0cbbefc5250bd0f4eaf591670c7cf8e94aa1d1b9c974e3b/cantools-42.0.3.tar.gz", hash = "sha256:13d2ed955ca3a8d4e46763a76ec791f3d9c4b6e73efb394625d4ea2b805f1cfc", size = 1045993, upload-time = "2026-07-05T18:48:19.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/94/68aea1bd6d6850788dadea10baab33e24ebc4c5916b86842d534820467c7/cantools-42.0.3-py3-none-any.whl", hash = "sha256:81732fe0cb6c9b10d8bee74f716ad551ead7b73b6b4d2c78b5e932b5ed61c217", size = 164097, upload-time = "2026-07-05T18:48:18.432Z" },
 ]
 
 [[package]]
@@ -701,6 +773,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
     { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
     { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "crccheck"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/d1/a943f4f1ca899917cc3fe1cb89d59348edd1b407503e4b02608e8d6b421e/crccheck-1.3.1.tar.gz", hash = "sha256:1544c0110bf0a697d875d4f29dc40d7079f9d4d402a9317383f55f90ca72563a", size = 41696, upload-time = "2025-07-10T07:01:08.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/b5/68a9054be852e61f31de1be4e8d95802646b93344ce17c2380a1748706fa/crccheck-1.3.1-py3-none-any.whl", hash = "sha256:1680c9a7bb1ca4bec45fa19b8ca64319f10d2ce4eb8b0d25d51cb99a20ca0108", size = 24608, upload-time = "2025-07-10T07:01:07.25Z" },
 ]
 
 [[package]]
@@ -2878,6 +2959,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python-can"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/f9/a9d99d36dd33be5badb747801c9255c3c526171a5542092eaacc73350fb8/python_can-4.6.1.tar.gz", hash = "sha256:290fea135d04b8504ebff33889cc6d301e2181a54099116609f940825ffe5005", size = 1206049, upload-time = "2025-08-12T07:44:58.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/34/e4ac153acdbcfba7f48bc73d6586a74c91cc919fcc2e29acbf81be329d1f/python_can-4.6.1-py3-none-any.whl", hash = "sha256:17f95255868a95108dcfcb90565a684dad32d5a3ebb35afd14f739e18c84ff6c", size = 276996, upload-time = "2025-08-12T07:44:56.55Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3484,6 +3579,15 @@ wheels = [
 ]
 
 [[package]]
+name = "textparser"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/f4/5825bb4dc4d91ab0eef62496e1a1495a698a433fc016159934fa2a854aba/textparser-0.26.2.tar.gz", hash = "sha256:859825876a9c38f7c313ee1cf991a59d6b56232a9f67be6dcc0a758d84654fba", size = 100264, upload-time = "2026-06-20T07:49:28.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/cc/812fe3ae07a1917bb4cfb6dec5f6fc6e8825d65b4e77cd25bc52cd59230f/textparser-0.26.2-py3-none-any.whl", hash = "sha256:e14ec4fd58d3515d897196a71f4ccf8d354f5c5c6b87910571b4d250de073c4b", size = 9638, upload-time = "2026-06-20T07:49:27.777Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3839,6 +3943,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #132. Automotive PR-B, completing the lane opened by #131.

## The mapping
A DBC is the schema of a CAN bus: **DBC messages → topics, signals → fields**, physical values with DBC scaling applied and units in the Arrow schema. `python-can` reads Vector BLF (magic `LOGG`) and ASC captures; `cantools` decodes. The DBC path flows through standard tool args:

> Using ./vehicle.dbc, what's the max EngineSpeed in ./drive.blf?

- Frames with IDs not in the DBC are **skipped and counted** — a partial DBC works
- Missing DBC fails at construction with a clear FileNotFoundError

## Beta labeling (per Arun)
The whole automotive lane — MDF4 (#131) and CAN — is now labeled **beta** in the README formats table, the Guides entry, and the runbook: both readers are verified against files we *generate* with the same libraries that read them, not against real CANape/INCA/Vector-produced captures. The runbook explicitly asks anyone with a real capture to try it and report. (The LeRobot export got the same treatment on #132.)

## Verification
- 6 tests over a generated BLF: resolution, decode + unknown-ID skip, topics/struct/units from the DBC, SQL over **physical** values (`MAX(EngineSpeed) = 3000.0` after 0.25 scaling), inclusive time windows, missing-DBC error
- Full non-ROS suite: **271 passed**, ruff clean
- Runbook extended with the CAN section; README row now "ASAM MDF4 (`.mf4`), CAN captures (`.blf`/`.asc` + DBC) — *beta*"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
