### PR TITLE
test(data-source): skip permission-denied test under root

### DIFF
--- a/test/di/types/test_data_source.py
+++ b/test/di/types/test_data_source.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -179,9 +180,12 @@ def test_has_magic_bytes_should_return_false_for_symlink_to_nonexistent() -> Non
         assert result is False
 
 
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses file permission checks, so a 0o000 file is still readable",
+)
 def test_has_magic_bytes_should_return_false_for_permission_denied() -> None:
     # GIVEN
-    import os
     import pathlib
 
     with tempfile.NamedTemporaryFile(delete=False) as tmpfile:


### PR DESCRIPTION
Follow-up to #137.

## Problem

`test_has_magic_bytes_should_return_false_for_permission_denied` (added in #137) `chmod`s a file to `0o000` and asserts `has_magic_bytes` returns `False`. That only holds for a **non-root** user — root bypasses DAC permission checks, reads the `#ROSBAG V2` bytes, and the result becomes `True`, so the assertion fails.

It passed in #137's CI only because CI runs as non-root. Anyone running the suite as root (e.g. a root Docker shell) hits a failure. Reproduced as root:

```
has_magic_bytes on chmod-000 file returned: True   # expected False
```

## Fix

Guard the test with `@pytest.mark.skipif(os.geteuid() == 0, ...)` and hoist `import os` to module scope so the decorator evaluates at collection time. The FIFO / symlink / resolve tests are unaffected.

## Testing

```bash
uv run pytest test/di/types/test_data_source.py -q
# as root:      16 passed, 1 skipped
# as non-root:  17 passed
```

`ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha3QkkeGnp36jPZBj2ReX3)_