### PR TITLE
Release 2.0.0 "Everything with Plain Cream Cheese"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "0.1.0"
+version = "2.0.0"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
Bumps the package version `0.1.0` to `2.0.0` for the Bagel 2.0 release.

## Why 2.0

One year after the July 2025 launch (retroactively `v1.0.0`), Bagel has grown from a chat-with-your-data tool into a full natural-language data pipeline platform. This is the second generation.

## Release notes

### Natural-language data reduction (headline)
- Describe an event in plain English; Bagel detects it, keeps a window around each occurrence, and drops the rest.
- `OnEvent` rising-edge cadence with debounce; symmetric pre/post snippet windows; reduce mode (a single reduced bag); live edge-recorder with a forward window; batch across many logs.
- `preview_pipeline` dry-run audit (event count, kept fraction) before a byte is written.
- MCP tools: `list_pipeline_capabilities`, `preview_pipeline`, `run_pipeline`, `save_pipeline`, `run_pipeline_batch`, plus a `compose_pipeline` authoring capability.

### Integrations
- PlotJuggler: open reduced MCAP natively, with flattened CSV / Parquet exports.
- Rerun: any window as a ready-to-open recording.
- Lichtblick / Foxglove: event windows as MCAP plus pre-framed layouts.
- Slack: pipelines post to your ops channel when they fire.
- Cloudini: decode cloudini-compressed lidar in pipelines.
- LeRobot (beta): detected events become training episodes (LeRobotDataset v3.0).

### New formats and sources
- Automotive: CAN / DBC (`.blf` / `.asc` + DBC), ASAM MDF4 (`.mf4`) (beta).
- IoT: MQTT (live, Sparkplug B), PostgreSQL / TimescaleDB, InfluxDB 3.
- ROS text logs (`~/.ros/log`) without a bag.
- CSV and JSON (PyArrow) sources.
- Local / on-prem LLM support.

### Robustness and fixes
- Data-source detection hardened against FIFOs, broken symlinks, and permission-denied files.
- Explicit `path` always beats a path passed via `args` (repo-wide sweep).
- Standardized artifact paths and an artifact mix-in.
- Cloud upload (S3 / GCS / Azure) as a pipeline step, skipping files already uploaded.

## Tagging (manual)

The `v1.0.0` and `v2.0.0` tags and the GitHub Release could not be created from this environment (tag pushes are blocked and there is no release API available). After this merges, create them locally:

```bash
git tag -a v1.0.0 6b9e527 -m "Bagel 1.0.0: initial public launch (July 2025)"
git tag -a v2.0.0 -m "Bagel 2.0.0: Everything with Scallion Cream Cheese"
git push origin v1.0.0 v2.0.0
```

Then draft the GitHub Release from `v2.0.0` using the notes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha3QkkeGnp36jPZBj2ReX3)_