### PR TITLE
ci: cancel superseded runs and prepare for the main rename

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,10 +4,15 @@ on:
   pull_request:
     branches:
       - stage
+      - main
     types:
       - opened
       - synchronize
       - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ruff:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - stage
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,10 +4,15 @@ on:
   pull_request:
     branches:
       - stage
+      - main
     types:
       - opened
       - synchronize
       - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker:


### PR DESCRIPTION
Small, low-risk CI hygiene.

## What

- **Concurrency**: lint and test now cancel an in-progress run when a new commit is pushed to the same PR, instead of letting runs pile up. Saves CI minutes. Publish deliberately does not cancel in-progress, so no push is skipped.
- **`main` trigger**: added `main` alongside `stage` to the lint/test PR triggers and the publish push trigger, so CI keeps working the moment the default branch is renamed (issue #70). Harmless before the rename since `main` does not exist yet.

## Not in this PR

The fast unit-test job is intentionally left out. While investigating it I found that several "unit" tests hang on the network (the Slack notify test hits a real webhook, and at least one more), so a fast/reliable `pytest` job is not possible until those are mocked and the suite is marked `unit` vs `integration`. That is a separate test-hygiene PR (and it fixes a real bug: unit tests should not touch the network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha3QkkeGnp36jPZBj2ReX3)_