### PR TITLE
ci: retarget workflows to main and update branch references (#70)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,11 +3,15 @@ name: lint
 on:
   pull_request:
     branches:
-      - stage
+      - main
     types:
       - opened
       - synchronize
       - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ruff:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     branches:
-      - stage
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,11 +3,15 @@ name: test
 on:
   pull_request:
     branches:
-      - stage
+      - main
     types:
       - opened
       - synchronize
       - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ First, create a GitHub issue as described above. Then, create a new branch using
 
 Please use **kebab-case** for "short-description." Refer to the [kebab-case guide](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) if you're unfamiliar with it.
 
-Once your branch is ready, file a Pull Request (PR) against the `stage` branch. In the PR description, please add text like "Closes #10" to automatically link and close the associated issue once the PR is merged.
+Once your branch is ready, file a Pull Request (PR) against the `main` branch. In the PR description, please add text like "Closes #10" to automatically link and close the associated issue once the PR is merged.
 
 ## Developing Bagel
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 </p>
 
 <h1 align="center">
-  <a href="https://github.com/Extelligence-ai/bagel/blob/stage/LICENSE">
+  <a href="https://github.com/Extelligence-ai/bagel/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square">
   </a>
   <a>
     <img src="https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square">
   </a>
   <a href="https://github.com/Extelligence-ai/bagel/actions/workflows/publish.yaml">
-    <img src="https://img.shields.io/github/actions/workflow/status/Extelligence-ai/bagel/publish.yaml?branch=stage&label=publish&style=flat-square">
+    <img src="https://img.shields.io/github/actions/workflow/status/Extelligence-ai/bagel/publish.yaml?branch=main&label=publish&style=flat-square">
   </a>
   <a href="https://discord.gg/QJDwuDGJsH">
     <img src="https://img.shields.io/discord/1392632504908906506?label=Discord&style=flat-square">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ We aim to acknowledge reports within **3 business days**. Please include a worki
 proof of concept and the exact code paths involved; reports without a reproducible
 PoC are hard to act on.
 
-Bagel tracks a single rolling branch (`stage`); fixes land there and in the next
+Bagel tracks a single rolling branch (`main`); fixes land there and in the next
 published Docker images.
 
 ## Threat model (what counts)


### PR DESCRIPTION
Closes #70. Supersedes #144.

## Why now

The default branch was just renamed `stage` -> `main`, which **deletes `stage`**. The workflows still triggered on `stage`, so as of the rename lint/test no longer fire on PRs and publish no longer runs on push. This points them at `main` so CI and image publishing come back to life.

## What

- **Triggers -> `main`**: `lint.yaml` and `test.yaml` PR triggers, and the `publish.yaml` push trigger. `stage` is removed entirely (it no longer exists).
- **Concurrency**: `lint` and `test` now cancel a superseded in-progress run when a new commit lands on the same PR. `publish` deliberately has no concurrency group, so no push is skipped.
- **Docs**: updated the `stage` references in `README.md` (license link + publish status badge), `CONTRIBUTING.md` (PR base branch), and `SECURITY.md` (rolling branch name) to `main`.

## Relationship to #144

This folds in #144's concurrency + `main`-trigger changes and finishes the job by removing the now-dead `stage` triggers and sweeping the docs. #144's PR body also repeated an earlier claim that the Slack notify test "hits a real webhook" that turned out to be wrong (it uses a localhost `ThreadingHTTPServer`), so superseding it also drops that inaccurate note. **#144 can be closed.**

## Verification

- All three workflow files parse as valid YAML; triggers and the concurrency blocks match the intended shape.
- `grep` across the repo confirms no remaining `stage` branch references outside the git-ignored local roadmap file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha3QkkeGnp36jPZBj2ReX3)_