### PR TITLE
Fix Docker images: copy all of src/ and smoke-check imports at build time (fixes #151)

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,48 @@
+name: docker-build
+
+# Build every container on PRs that could affect them. Each Dockerfile ends with
+# an `import server` smoke check, so "the image builds" means "the server boots" —
+# a missing-module regression (issue #151) fails here, in review, not in a
+# user's terminal. publish.yaml then rebuilds and pushes on merge to main.
+
+on:
+  pull_request:
+    paths:
+      - "docker/**"
+      - "src/**"
+      - "server.py"
+      - "run.py"
+      - "settings.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".env"
+      - "compose.yaml"
+      - "data/sample/**"
+      - ".github/workflows/docker-build.yaml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - ros2-kilted
+          - ros2-jazzy
+          - ros2-iron
+          - ros2-humble
+          - ros1-noetic
+          - ros1-noetic-cv
+          - px4
+          - ardupilot
+          - betaflight
+          - iot
+          - apache-arrow
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
+      - name: Build ${{ matrix.service }}
+        run: docker compose build ${{ matrix.service }}

--- a/docker/Dockerfile.ardupilot
+++ b/docker/Dockerfile.ardupilot
@@ -58,33 +58,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -94,14 +69,14 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
 
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
+
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
 # Copy ArduPilot specific source code
-COPY --chown=${USERNAME}:${USERNAME} src/source/ardupilot ./src/source/ardupilot
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ardupilot ./src/topic/ardupilot
-COPY --chown=${USERNAME}:${USERNAME} src/message/ardupilot ./src/message/ardupilot
-COPY --chown=${USERNAME}:${USERNAME} src/logging/ardupilot ./src/logging/ardupilot
 
 # Copy ArduPilot specific test code
 COPY --chown=${USERNAME}:${USERNAME} test/source/ardupilot ./test/source/ardupilot

--- a/docker/Dockerfile.arrow
+++ b/docker/Dockerfile.arrow
@@ -57,33 +57,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -92,6 +67,10 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
+
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
 
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/

--- a/docker/Dockerfile.betaflight
+++ b/docker/Dockerfile.betaflight
@@ -58,33 +58,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -94,14 +69,14 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
 
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
+
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
 # Copy Betaflight specific source code
-COPY --chown=${USERNAME}:${USERNAME} src/source/betaflight ./src/source/betaflight
-COPY --chown=${USERNAME}:${USERNAME} src/topic/betaflight ./src/topic/betaflight
-COPY --chown=${USERNAME}:${USERNAME} src/message/betaflight ./src/message/betaflight
-COPY --chown=${USERNAME}:${USERNAME} src/logging/betaflight ./src/logging/betaflight
 
 # Copy Betaflight specific test code
 COPY --chown=${USERNAME}:${USERNAME} test/source/betaflight ./test/source/betaflight

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -61,35 +61,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/mqtt.py ./src/sink/mqtt.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/sparkplug ./src/sink/sparkplug
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -98,6 +71,10 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
+
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
 
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/

--- a/docker/Dockerfile.px4
+++ b/docker/Dockerfile.px4
@@ -57,33 +57,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -93,14 +68,14 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
 
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
+
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
 # Copy PX4 specific source code
-COPY --chown=${USERNAME}:${USERNAME} src/source/px4 ./src/source/px4
-COPY --chown=${USERNAME}:${USERNAME} src/topic/px4 ./src/topic/px4
-COPY --chown=${USERNAME}:${USERNAME} src/message/px4 ./src/message/px4
-COPY --chown=${USERNAME}:${USERNAME} src/logging/px4 ./src/logging/px4
 
 # Copy PX4 specific test code
 COPY --chown=${USERNAME}:${USERNAME} test/source/px4 ./test/source/px4

--- a/docker/Dockerfile.ros1
+++ b/docker/Dockerfile.ros1
@@ -119,35 +119,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/definition.py ./src/topic/ros2/definition.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/protobuf ./src/topic/ros2/protobuf
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2/ros2msg ./src/topic/ros2/ros2msg
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2/convert.py ./src/message/ros2/convert.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/image/base.py ./src/image/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/image/bagel ./src/image/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -157,16 +130,14 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
 
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
+
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
 # Copy ROS1 specific source code
-COPY --chown=${USERNAME}:${USERNAME} src/sink/ros1 ./src/sink/ros1
-COPY --chown=${USERNAME}:${USERNAME} src/source/ros1 ./src/source/ros1
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros1 ./src/topic/ros1
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros1 ./src/message/ros1
-COPY --chown=${USERNAME}:${USERNAME} src/logging/ros1 ./src/logging/ros1
-COPY --chown=${USERNAME}:${USERNAME} src/image/ros1 ./src/image/ros1
 
 # Copy ROS1 specific test code
 COPY --chown=${USERNAME}:${USERNAME} test/source/ros1 ./test/source/ros1

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -66,29 +66,8 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
-COPY --chown=${USERNAME}:${USERNAME} src/artifacts.py ./src/artifacts.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/base.py ./src/sink/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/buffer.py ./src/sink/buffer.py
-COPY --chown=${USERNAME}:${USERNAME} src/sink/reader.py ./src/sink/reader.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/base.py ./src/source/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/errors.py ./src/source/errors.py
-COPY --chown=${USERNAME}:${USERNAME} src/source/bagel ./src/source/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/source/pyarrow ./src/source/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/topic/base.py ./src/topic/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/bagel ./src/topic/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/topic/pyarrow ./src/topic/pyarrow
-COPY --chown=${USERNAME}:${USERNAME} src/message/base.py ./src/message/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/bagel ./src/message/bagel
-COPY --chown=${USERNAME}:${USERNAME} src/message/pyarrow ./src/message/pyarrow
+COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
-COPY --chown=${USERNAME}:${USERNAME} src/source/mcap.py ./src/source/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/topic/mcap.py ./src/topic/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/message/mcap.py ./src/message/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/mcap.py ./src/logging/mcap.py
-COPY --chown=${USERNAME}:${USERNAME} src/logging/base.py ./src/logging/base.py
-COPY --chown=${USERNAME}:${USERNAME} src/pipeline ./src/pipeline
-COPY --chown=${USERNAME}:${USERNAME} src/di ./src/di
-COPY --chown=${USERNAME}:${USERNAME} src/agent ./src/agent
 
 # Copy common test code
 COPY --chown=${USERNAME}:${USERNAME} test/test_artifacts.py ./test/test_artifacts.py
@@ -98,15 +77,14 @@ COPY --chown=${USERNAME}:${USERNAME} test/source/test_source_base.py ./test/sour
 # Copy configuration file
 COPY --chown=${USERNAME}:${USERNAME} .env ./.env
 
+# Fail the build if the server cannot even import -- catches missing-module
+# regressions (issue #151) at build time instead of at the user's terminal.
+RUN uv run python -c "import server"
+
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
 # Copy ROS2 specific source code
-COPY --chown=${USERNAME}:${USERNAME} src/sink/ros2 ./src/sink/ros2
-COPY --chown=${USERNAME}:${USERNAME} src/source/ros2 ./src/source/ros2
-COPY --chown=${USERNAME}:${USERNAME} src/topic/ros2 ./src/topic/ros2
-COPY --chown=${USERNAME}:${USERNAME} src/message/ros2 ./src/message/ros2
-COPY --chown=${USERNAME}:${USERNAME} src/logging/ros2 ./src/logging/ros2
 
 # Copy ROS2 specific test code
 COPY --chown=${USERNAME}:${USERNAME} test/source/ros2 ./test/source/ros2


### PR DESCRIPTION
Fixes #151 — `docker compose run ros2-jazzy` crashed with `ImportError: cannot import name 'mcp_compat' from 'src'` on freshly-pulled images.

## Root cause
The Dockerfiles keep a **hand-maintained per-file whitelist** of `src/` paths. The 2.0 wave added modules that were never whitelisted — `src/mcp_compat.py` (the crash), `src/sink/startup.py` (the *next* crash, it's imported by server.py), the ROS text-log adapter family, and others. Reproduced by pulling `ghcr.io/…/ros2-jazzy:latest` (built Jul 14): `server.py` references the modules, the image doesn't contain them.

**Why our tests missed it** (answering @arunvenkatadri's comment on the issue): all container verification during development bind-mounted the working repo into the image, which papers over any COPY gap. Only a from-scratch image build — what every user gets — exercises the whitelist.

## Fix, two layers
1. **`COPY src ./src` in all seven Dockerfiles**, replacing ~200 lines of per-file COPYs. The DI layer imports adapters lazily, so modules whose deps a flavor doesn't ship stay inert — the whitelist bought a few hundred KB and rotted silently.
2. **Build-time smoke check** in every image: `RUN uv run python -c "import server"`. A missing-module regression now fails the build — and since `publish.yaml` runs on push to `main`, it can never reach `:latest` again.

## Verification
- Built `Dockerfile.ros2` from scratch with the fix: build passes (smoke check green), container registers **16 MCP tools**, and `src.mcp_compat` / `src.sink.startup` / `src.source.ros.parse` all import cleanly
- Merging this republishes `:latest` automatically (publish triggers on main push), so the issue reporter just re-pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
