### PR TITLE
Harden parsers against malformed input + secrets audit + dep-audit cadence (#134)

### DIFF
--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -1,0 +1,36 @@
+# Non-blocking dependency-vulnerability cadence (issue #134).
+#
+# The current lockfile carries known advisories almost entirely in transitive
+# dependencies pulled in by the jupyter/torch/dev stack (setuptools, starlette,
+# tornado, urllib3, virtualenv, soupsieve, etc.). A hard-fail gate would be red
+# from day one and would likely get disabled rather than fixed. This workflow
+# is intentionally informational: it runs pip-audit on a cadence (every PR to
+# main, plus a weekly schedule) so advisories stay visible, without blocking
+# merges. Once the transitive-advisory baseline has been triaged, the audit
+# step below can be tightened to a blocking gate.
+
+name: dependency-audit
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+      - name: Install dependencies
+        run: uv sync
+      - name: Run pip-audit (non-blocking)
+        continue-on-error: true
+        run: |
+          uv run --with pip-audit pip-audit --format markdown >> "$GITHUB_STEP_SUMMARY" || true
+          uv run --with pip-audit pip-audit

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 import yaml
 
+from src.source.redact import redact_url
+
 
 class DataSource(Enum):
     """Supported data source types."""
@@ -90,7 +92,10 @@ def resolve_file_based_data_source(path: str | pathlib.Path) -> DataSource:  # n
     elif is_csv_file(path) or is_csv_directory(path):
         return DataSource.PYARROW_CSV
     else:
-        raise ValueError(f"Cannot resolve data source type from path: {path}")
+        # `path` may be a malformed/typo'd URL (e.g. a DSN missing the "//" after the
+        # scheme) that fell through from `resolve()`'s URL branch into this
+        # file-based path, so it can still carry credentials -- redact defensively.
+        raise ValueError(f"Cannot resolve data source type from path: {redact_url(str(path))}")
 
 
 def has_magic_bytes(path: pathlib.Path, magic: bytes) -> bool:

--- a/src/di/types/data_source.py
+++ b/src/di/types/data_source.py
@@ -245,7 +245,7 @@ def is_standard_json_file(path: pathlib.Path) -> bool:
     try:
         json.loads(path.read_text())
         return True
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return False
 
 
@@ -254,12 +254,12 @@ def is_json_lines_file(path: pathlib.Path) -> bool:
     if not path.is_file():
         return False
 
-    with open(path, encoding="utf-8") as f:
-        try:
+    try:
+        with open(path, encoding="utf-8") as f:
             json.loads(f.readline().strip())  # only check the first line
             return True
-        except json.JSONDecodeError:
-            return False
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
 
 
 def is_mdf_file(path: pathlib.Path) -> bool:

--- a/src/message/pyarrow/base.py
+++ b/src/message/pyarrow/base.py
@@ -7,6 +7,7 @@ from typing import Any
 import pyarrow as pa
 
 from src.message import base
+from src.source import errors
 from src.source.pyarrow.base import PyArrowDataset
 from src.topic.pyarrow.base import TOPIC_NAME
 
@@ -26,7 +27,21 @@ class MessageDataset(base.MessageDataset):
 
         heap = []
 
-        for tie_breaker, msg in enumerate(data_source.dataset.to_table().to_pylist()):
+        # dataset construction (_build(), src/source/pyarrow/base.py) can succeed
+        # while still holding an unreadable file: e.g. a directory whose schema is
+        # taken from one valid file, alongside a malformed sibling that only fails
+        # once actually scanned. to_table() is where that scan -- and thus the raw
+        # pyarrow.lib.ArrowInvalid/ArrowTypeError (ArrowException) -- happens.
+        try:
+            rows = data_source.dataset.to_table().to_pylist()
+        except pa.ArrowException as exc:
+            files = getattr(data_source.dataset, "files", None)
+            location = ", ".join(files) if files else "the PyArrow dataset"
+            raise errors.InvalidPathError(
+                f"{location} could not be parsed: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        for tie_breaker, msg in enumerate(rows):
             timestamp_seconds = data_source.extract_timestamp_seconds(msg)
             if end_seconds_inclusive is not None and timestamp_seconds > end_seconds_inclusive:
                 continue

--- a/src/pipeline/tasks/notify/slack.py
+++ b/src/pipeline/tasks/notify/slack.py
@@ -48,7 +48,10 @@ class NotifySlack(base.Task):
 
         """
         if not webhook_url.startswith(("https://", "http://")):
-            raise ValueError(f"webhook_url must be http(s), got: {webhook_url}")
+            # The webhook URL *is* the secret (Slack/Mattermost/Rocket.Chat webhook
+            # URLs embed a bearer token in the path) -- never echo it back, even to
+            # say it was rejected.
+            raise ValueError("webhook_url must be http(s) (value withheld).")
         self._webhook_url = webhook_url
         self._message = message
         self._include_context = include_context

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -9,6 +9,7 @@ raw bus capture becomes queryable like any other source. Requires the optional
 import functools
 import logging
 import pathlib
+import struct
 from typing import Any
 
 import can
@@ -31,7 +32,19 @@ class CanLog:
             dbc (str): Path to the DBC database describing the bus.
 
         """
-        self.database = cantools.database.load_file(dbc)
+        try:
+            self.database = cantools.database.load_file(dbc)
+        except (cantools.errors.Error, ValueError) as exc:
+            # Empirically, a malformed/garbage/empty DBC raises
+            # cantools.database.errors.UnsupportedDatabaseFormatError (a
+            # cantools.errors.Error subclass), while a DBC path with an
+            # extension cantools can't map to a format raises a plain
+            # ValueError from cantools' own format-dispatch code. Translate
+            # either into a single clean, typed error instead of letting a
+            # cantools-internal exception escape.
+            raise errors.InvalidPathError(
+                f"{dbc} could not be parsed as a DBC database: {type(exc).__name__}: {exc}"
+            ) from exc
         self._path = path
         self._records: list[tuple[float, str, dict[str, Any]]] | None = None
 
@@ -42,18 +55,57 @@ class CanLog:
             known = {message.frame_id: message.name for message in self.database.messages}
             records = []
             unknown = 0
-            with can.LogReader(self._path) as reader:
-                for frame in reader:
-                    name = known.get(frame.arbitration_id)
-                    if name is None:
-                        unknown += 1
-                        continue
-                    decoded = self.database.decode_message(
-                        frame.arbitration_id, frame.data, decode_choices=False
-                    )
-                    records.append((float(frame.timestamp), name, dict(decoded)))
+            undecodable = 0
+            try:
+                # This region wraps library parse calls over untrusted input
+                # (the capture file itself), so failures here are translated
+                # into a clean, typed error rather than leaking a can/cantools
+                # traceback. It's scoped to STRUCTURAL capture failures only:
+                # the file can't be opened, or frame iteration itself breaks
+                # down (corrupt/truncated container). A single frame that
+                # fails to decode is handled by the inner skip-and-count
+                # below and never reaches this except clause.
+                with can.LogReader(self._path) as reader:
+                    for frame in reader:
+                        name = known.get(frame.arbitration_id)
+                        if name is None:
+                            unknown += 1
+                            continue
+                        try:
+                            decoded = self.database.decode_message(
+                                frame.arbitration_id, frame.data, decode_choices=False
+                            )
+                            records.append((float(frame.timestamp), name, dict(decoded)))
+                        except (cantools.database.errors.DecodeError, ValueError) as exc:
+                            # A single frame with a data length mismatch (or
+                            # other per-frame decode problem) shouldn't nuke
+                            # an otherwise-good capture: skip and count it,
+                            # mirroring the `unknown` handling above.
+                            undecodable += 1
+                            logging.debug(
+                                "Skipping undecodable frame (arbitration_id=%s): %s: %s",
+                                frame.arbitration_id,
+                                type(exc).__name__,
+                                exc,
+                            )
+                            continue
+            except (struct.error, ValueError, cantools.errors.Error) as exc:
+                # Empirically observed across malformed/truncated .blf and
+                # .asc captures: struct.error and ValueError escape
+                # can.LogReader(...) construction (corrupt/inconsistent BLF
+                # headers, unrecognized capture extensions) or frame
+                # iteration (non-hex ASC frame data). These share no common
+                # base narrower than Exception, so translate either of them
+                # into a single clean, typed error instead of letting a
+                # can/cantools-internal exception escape.
+                raise errors.InvalidPathError(
+                    f"{self._path} could not be read as a CAN capture: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
             if unknown:
                 logging.info("Skipped %d frames with IDs not in the DBC", unknown)
+            if undecodable:
+                logging.info("Skipped %d frames that failed to decode", undecodable)
             records.sort(key=lambda record: record[0])
             self._records = records
         return self._records

--- a/src/source/automotive/mf4.py
+++ b/src/source/automotive/mf4.py
@@ -28,7 +28,24 @@ class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
 
         """
         super().__init__(path)
-        self._mdf = MDF(path)
+        try:
+            self._mdf = MDF(path)
+        except Exception as exc:
+            # validate_path() already confirmed the MDF_MAGIC header, so a
+            # file that still fails to parse here has a corrupt or truncated
+            # body. asammdf's block-unpacking code does not raise a single,
+            # library-specific exception for this: depending on exactly
+            # where the corruption falls, it has been observed to raise
+            # struct.error, UnicodeDecodeError, AttributeError, ValueError,
+            # or UnboundLocalError directly from deep inside its parser.
+            # There is no common base among these narrower than Exception,
+            # so translate any parse failure here into a single clean,
+            # typed error instead of letting an asammdf-internal traceback
+            # escape.
+            raise errors.InvalidPathError(
+                f"{self.path} could not be parsed as an ASAM MDF file: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
 
     @property
     def metadata(self) -> dict[str, Any]:

--- a/src/source/influxdb.py
+++ b/src/source/influxdb.py
@@ -22,6 +22,7 @@ from influxdb_client_3 import InfluxDBClient3
 from pydantic import BaseModel
 
 from src.di import module
+from src.source.redact import redact_url, scrub_secrets
 
 DEFAULT_PORT = 8181  # InfluxDB 3 Core
 
@@ -39,13 +40,13 @@ def parse_url(url: str) -> dict[str, str]:
     """
     parsed = urlparse(url)
     if parsed.scheme != "influxdb":
-        raise ValueError(f"Expected an influxdb:// URL, got: {url}")
+        raise ValueError(f"Expected an influxdb:// URL, got: {redact_url(url)}")
     if not parsed.hostname:
-        raise ValueError(f"Missing host in InfluxDB URL: {url}")
+        raise ValueError(f"Missing host in InfluxDB URL: {redact_url(url)}")
     database = parsed.path.lstrip("/")
     if not database:
         raise ValueError(
-            f"Missing database in InfluxDB URL: {url} "
+            f"Missing database in InfluxDB URL: {redact_url(url)} "
             "(expected influxdb://token@host:port/database)"
         )
     port = parsed.port or DEFAULT_PORT
@@ -113,7 +114,13 @@ class SourceFactory:
         try:
             self._database.tables()
         except Exception as error:
-            raise ConnectionError(f"Cannot connect to '{parts['host']}': {error}") from error
+            # `parts["host"]` never carries the token, but scrub the resolved token
+            # (from the URL or the explicit `token` arg) out of the combined message
+            # anyway, in case the underlying client's own error message echoes it.
+            message = scrub_secrets(
+                f"Cannot connect to '{parts['host']}': {error}", self._database.token
+            )
+            raise ConnectionError(message) from error
 
     @property
     def path(self) -> str:

--- a/src/source/postgres.py
+++ b/src/source/postgres.py
@@ -9,13 +9,29 @@ The data source `path` is a standard connection URL, e.g.
 """
 
 import functools
+import re
 import uuid
 from typing import Any
+from urllib.parse import urlsplit
 
 import duckdb
 from pydantic import BaseModel, Field
 
 from src.di import module
+from src.source.redact import REDACTED, redact_url, scrub_secrets
+
+# Matches a `user:password@` fragment embedded anywhere in arbitrary text (e.g. an
+# underlying driver's own error message that re-embeds a raw connection string).
+# Used as a defense-in-depth fallback that doesn't require knowing the password
+# value ahead of time -- unlike `scrub_secrets`, it works even when the DSN is too
+# malformed for `urlsplit` to parse it out.
+_EMBEDDED_USERINFO_RE = re.compile(r"(://[^:@/\s]+:)([^@/\s]+)(@)")
+
+
+def _scrub_embedded_userinfo(text: str) -> str:
+    """Redact any `scheme://user:password@` fragment found within `text`."""
+    return _EMBEDDED_USERINFO_RE.sub(rf"\1{REDACTED}\3", text)
+
 
 EXCLUDED_SCHEMAS = (
     "pg_catalog",
@@ -152,7 +168,39 @@ class SourceFactory:
         try:
             attach(path)
         except duckdb.Error as error:
-            raise ConnectionError(f"Cannot connect to '{path}': {error}") from error
+            # DuckDB's postgres extension embeds the *raw* connection string (password
+            # included) in its own error message, so redacting `path` alone is not
+            # enough -- scrub the actual password out of the combined message too.
+            # `urlsplit` can itself raise `ValueError` on a malformed host (e.g. an
+            # unbalanced IPv6 bracket); if it did we'd be inside this `except` block,
+            # so Python would chain the original `error` -- password and all -- onto
+            # that new ValueError as `__context__`, leaking the password via the
+            # traceback even though this handler never raises `ConnectionError`
+            # normally. Guard the extraction so that can't happen: no password just
+            # means `scrub_secrets` below is a harmless no-op (the regex fallback
+            # below still catches it).
+            try:
+                password = urlsplit(path).password
+            except ValueError:
+                password = None
+            message = _scrub_embedded_userinfo(
+                scrub_secrets(
+                    f"Cannot connect to '{redact_url(path)}': {error}",
+                    password,
+                )
+            )
+            # `raise ... from error` chains the *original*, unmodified `error` into
+            # the traceback too, so scrub its own message in place -- otherwise the
+            # password survives in the "above exception" section of a full
+            # traceback dump regardless of how well `message` above is redacted.
+            if error.args:
+                error.args = tuple(
+                    _scrub_embedded_userinfo(scrub_secrets(arg, password))
+                    if isinstance(arg, str)
+                    else arg
+                    for arg in error.args
+                )
+            raise ConnectionError(message) from error
 
     @property
     def path(self) -> str:
@@ -187,7 +235,7 @@ class SourceFactory:
                     ],
                 }
             )
-        return {"url_host": self._url.split("@")[-1], "tables": tables}
+        return {"url": redact_url(self._url), "tables": tables}
 
 
 def register() -> None:

--- a/src/source/pyarrow/base.py
+++ b/src/source/pyarrow/base.py
@@ -7,10 +7,11 @@ from enum import Enum
 from typing import Any
 
 import pandas as pd
+import pyarrow as pa
 from pyarrow import dataset as ds
 from pydantic import BaseModel, ConfigDict
 
-from src.source import base
+from src.source import base, errors
 
 
 class TimestampUnit(Enum):
@@ -117,14 +118,32 @@ class SourceFactory(base.FileBasedSourceFactory):
         return lambda msg: cast_to_timestamp(_get_value(msg, self._timestamp_access_path))
 
     def _build(self, file_format: str) -> PyArrowDataset:
-        return PyArrowDataset(
-            dataset=ds.dataset(
+        # ds.dataset() is lazy about reading row *data*, but for CSV/JSON it must
+        # still infer a schema immediately, which requires reading (part of) the
+        # file. When exclude_invalid_files=True (the default) PyArrow silently
+        # drops any file that fails this check; but that check is an explicit,
+        # user-settable constructor argument (see csv.SourceFactory /
+        # json.SourceFactory docstrings), and with it disabled a malformed file
+        # raises PyArrow's internal parse error -- pyarrow.lib.ArrowInvalid (or a
+        # sibling ArrowException such as ArrowTypeError) -- directly out of this
+        # call. Translate that into a single clean, typed error instead of
+        # letting a raw PyArrow-internal traceback escape.
+        try:
+            dataset = ds.dataset(
                 str(self.path),
                 format=file_format,
                 partitioning=self._partitioning,
                 partition_base_dir=self._partition_base_dir,
                 exclude_invalid_files=self._exclude_invalid_files,
                 ignore_prefixes=self._ignore_prefixes,
-            ),
+            )
+        except pa.ArrowException as exc:
+            raise errors.InvalidPathError(
+                f"{self.path} could not be parsed as a {file_format} dataset: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+        return PyArrowDataset(
+            dataset=dataset,
             extract_timestamp_seconds=self._extract_timestamp_fn(),
         )

--- a/src/source/redact.py
+++ b/src/source/redact.py
@@ -1,0 +1,123 @@
+"""Redact credentials from URLs/DSNs before they reach errors, logs, or metadata.
+
+Several data sources and sinks (PostgreSQL, InfluxDB, MQTT, Slack webhooks, ...)
+are configured with a URL or connection string that embeds a credential -- a
+password in the userinfo (``user:pass@host``), a token in a query parameter
+(``?token=...``), or the entire URL being the secret (a webhook URL). Those
+raw values must never be echoed back into an exception message, a log line, or
+a tool-facing ``metadata`` dict, since all three can reach an MCP client.
+
+This module provides two small, composable helpers:
+
+- `redact_url`: builds a *display-safe* version of a URL for use in error
+  messages and metadata, keeping the scheme/host/path (useful for diagnosing
+  "which database/host did this fail against") while stripping userinfo and
+  known-sensitive query parameters.
+- `scrub_secrets`: a defense-in-depth net for text that isn't under our
+  control, e.g. an underlying driver's own exception message, which can
+  re-embed the raw secret even after we've redacted our own message.
+"""
+
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+REDACTED = "***"
+
+# Query-parameter names (case-insensitive) whose values are redacted by `redact_url`.
+SENSITIVE_QUERY_PARAMS = frozenset(
+    {
+        "token",
+        "password",
+        "passwd",
+        "pwd",
+        "apikey",
+        "api_key",
+        "key",
+        "secret",
+        "access_key",
+        "secret_key",
+        "sas",
+        "sig",
+        "signature",
+    }
+)
+
+
+def redact_url(value: str) -> str:
+    """Return a display-safe version of a URL/DSN with credentials removed.
+
+    Userinfo is replaced wholesale (``user:pass@host`` -> ``***@host``), and
+    any query parameter whose name matches `SENSITIVE_QUERY_PARAMS` (case
+    insensitive) has its value replaced with `REDACTED`. The scheme, host,
+    port, path, and any non-sensitive query parameters are preserved so the
+    result stays useful for diagnostics (e.g. "which host/db was this?"). Any
+    URL fragment is dropped unconditionally: no current call site uses
+    fragments, and some APIs (e.g. OAuth implicit-grant redirects) stuff
+    credentials there, so there's no safe way to tell a benign fragment from
+    a sensitive one.
+
+    A value with no userinfo, no sensitive query parameters, and no fragment
+    -- including a plain filesystem path with no URL structure at all -- is
+    returned unchanged.
+    """
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # Value isn't parseable as a URL at all (e.g. malformed IPv6 host).
+        # We have no safe way to reconstruct a redacted version of it, and
+        # `value` itself may well be (or contain) the raw credential -- so
+        # fail SAFE and hand back a fixed placeholder, never the input.
+        return REDACTED
+
+    netloc = parts.netloc
+    if "@" in netloc:
+        _, _, host_part = netloc.rpartition("@")
+        netloc = f"{REDACTED}@{host_part}" if host_part else REDACTED
+
+    path = parts.path
+    if parts.scheme and not parts.netloc:
+        # A scheme with no netloc means `urlsplit` couldn't find a `//` authority --
+        # likely a malformed DSN (missing slashes) whose userinfo landed in `.path`.
+        # Split off the actual path/db (after the first `/`) before looking for
+        # userinfo, then anchor on the LAST `@` in what's left -- mirroring the
+        # netloc branch's `rpartition("@")` above -- so a password that itself
+        # contains a literal `@` doesn't leave its tail unredacted.
+        head, sep, tail = path.partition("/")
+        userinfo, at_sign, host_part = head.rpartition("@")
+        if at_sign:
+            path = f"{REDACTED}@{host_part}{sep}{tail}"
+
+    query = parts.query
+    if query:
+        pairs = parse_qsl(query, keep_blank_values=True)
+        query = urlencode(
+            [(k, REDACTED if k.lower() in SENSITIVE_QUERY_PARAMS else v) for k, v in pairs],
+            safe="*",
+        )
+
+    # Fragments aren't used by any current call site, and unlike the path/query
+    # we don't have a safe way to know whether a fragment carries a credential
+    # (some APIs stuff tokens there, e.g. OAuth implicit-grant redirects) --
+    # so drop it unconditionally rather than passing it through unredacted.
+    fragment = ""
+
+    return urlunsplit((parts.scheme, netloc, path, query, fragment))
+
+
+def scrub_secrets(text: str, *secrets: str | None) -> str:
+    """Replace literal occurrences of each secret in `text` with `REDACTED`.
+
+    Defense in depth for text we don't fully control -- most commonly the
+    `str()` of an exception raised by an underlying driver (e.g. DuckDB's
+    postgres extension embeds the *raw* connection string, password
+    included, in its own connection-failure message). Pass the credential(s)
+    actually used to connect (a password, a token, ...) and any verbatim
+    occurrence in `text` is stripped, regardless of where it came from.
+
+    Empty/`None` secrets are ignored (so callers can pass an optional token
+    without an `if` guard).
+    """
+    scrubbed = text
+    for secret in secrets:
+        if secret:
+            scrubbed = scrubbed.replace(secret, REDACTED)
+    return scrubbed

--- a/src/source/ros/parse.py
+++ b/src/source/ros/parse.py
@@ -90,9 +90,16 @@ def parse_line(line: str, fallback_node: str) -> LogRecord | None:
         else:
             # rospy writes local wall-clock time with no timezone; interpret it
             # in the machine's local timezone, mirroring how it was written.
-            timestamp_seconds = datetime.datetime.strptime(
-                groups["datetime"], "%Y-%m-%d %H:%M:%S,%f"
-            ).timestamp()
+            # A regex match doesn't guarantee a valid calendar date/time (e.g.
+            # month 13, hour 25) or a timestamp representable on this
+            # platform (e.g. year 1 underflowing once the local UTC offset is
+            # applied), so treat those as "no match" rather than crashing.
+            try:
+                timestamp_seconds = datetime.datetime.strptime(
+                    groups["datetime"], "%Y-%m-%d %H:%M:%S,%f"
+                ).timestamp()
+            except (ValueError, OverflowError, OSError):
+                continue
         level = groups["level"].upper()
         return LogRecord(
             timestamp_seconds=timestamp_seconds,

--- a/src/topic/mcap.py
+++ b/src/topic/mcap.py
@@ -36,8 +36,23 @@ def _channels_with_schemas(data_source: McapBag) -> dict[str, base.MessageDefini
     return topics
 
 
-def _jsonschema_type(schema: dict) -> pa.DataType:  # noqa: PLR0911 -- one return per JSON type
-    """Map a JSON-Schema type definition to a PyArrow type (utf8 for unknowns)."""
+_MAX_JSONSCHEMA_DEPTH = 100
+
+
+def _jsonschema_type(schema: dict, _depth: int = 0) -> pa.DataType:  # noqa: PLR0911 -- one return per JSON type
+    """Map a JSON-Schema type definition to a PyArrow type (utf8 for unknowns).
+
+    Raises:
+        UnsupportedEncodingError: If the schema is nested deeper than
+            ``_MAX_JSONSCHEMA_DEPTH`` -- a schema nested that deep is pathological,
+            not a legitimate document, and left unguarded would risk a
+            ``RecursionError``.
+
+    """
+    if _depth > _MAX_JSONSCHEMA_DEPTH:
+        raise base.UnsupportedEncodingError(
+            f"jsonschema document nested deeper than {_MAX_JSONSCHEMA_DEPTH} levels"
+        )
     json_type = schema.get("type")
     if isinstance(json_type, list):  # e.g. ["number", "null"] -> nullable number
         json_type = next((t for t in json_type if t != "null"), "string")
@@ -45,10 +60,16 @@ def _jsonschema_type(schema: dict) -> pa.DataType:  # noqa: PLR0911 -- one retur
     match json_type:
         case "object":
             properties = schema.get("properties", {})
-            if not properties:
-                return pa.string()  # schemaless object: keep as JSON text
+            if not isinstance(properties, dict) or not properties:
+                return pa.string()  # schemaless (or malformed) object: keep as JSON text
             return pa.struct(
-                [pa.field(name, _jsonschema_type(sub)) for name, sub in properties.items()]
+                [
+                    pa.field(
+                        name,
+                        _jsonschema_type(sub if isinstance(sub, dict) else {}, _depth + 1),
+                    )
+                    for name, sub in properties.items()
+                ]
             )
         case "number":
             return pa.float64()
@@ -57,7 +78,8 @@ def _jsonschema_type(schema: dict) -> pa.DataType:  # noqa: PLR0911 -- one retur
         case "boolean":
             return pa.bool_()
         case "array":
-            return pa.list_(_jsonschema_type(schema.get("items", {})))
+            items = schema.get("items", {})
+            return pa.list_(_jsonschema_type(items if isinstance(items, dict) else {}, _depth + 1))
         case _:
             return pa.string()
 
@@ -66,13 +88,18 @@ def jsonschema_to_struct(definition: bytes) -> pa.StructType:
     """Convert a JSON-Schema document (top-level object) to a PyArrow StructType.
 
     Raises:
-        UnsupportedEncodingError: If the document is not valid JSON or not an object schema.
+        UnsupportedEncodingError: If the document is not valid (UTF-8) JSON, not
+            an object schema, or nested pathologically deep.
 
     """
     try:
         document = json.loads(definition)
-    except json.JSONDecodeError as error:
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
         raise base.UnsupportedEncodingError(f"invalid jsonschema document: {error}") from error
+    except RecursionError as error:
+        raise base.UnsupportedEncodingError(
+            "jsonschema document is nested too deeply to parse"
+        ) from error
     struct = _jsonschema_type(document if isinstance(document, dict) else {})
     if not isinstance(struct, pa.StructType):
         raise base.UnsupportedEncodingError("jsonschema document is not an object schema")

--- a/test/adversarial/test_can_parse.py
+++ b/test/adversarial/test_can_parse.py
@@ -1,0 +1,256 @@
+"""Adversarial/fuzz tests for the raw CAN log source (issue #134).
+
+``CanLog`` has TWO distinct untrusted-input surfaces:
+
+1. The DBC schema, parsed by ``cantools.database.load_file`` in
+   ``CanLog.__init__``. Characterization showed a malformed/garbage/empty DBC
+   raises ``cantools.database.errors.UnsupportedDatabaseFormatError`` (a
+   ``cantools.errors.Error`` subclass), while a DBC path with an extension
+   cantools doesn't recognize (e.g. ``.txt``) raises a plain ``ValueError``
+   from cantools' own format-dispatch code -- not a domain error either way.
+
+2. The CAN capture (``.blf``/``.asc``), opened and iterated by
+   ``can.LogReader`` and decoded via ``cantools``'s
+   ``Database.decode_message`` in ``CanLog.records``. Characterization
+   showed:
+   - A ``.blf`` with the correct ``LOGG`` magic but a corrupt/truncated body
+     raises ``struct.error`` (on very short files) or ``ValueError``
+     (`"read length must be non-negative or -1"`, on files with an
+     internally-inconsistent header) from deep inside python-can's BLF
+     reader, both at ``can.LogReader(...)`` construction time.
+   - A ``.blf``/``.asc`` path whose extension python-can doesn't recognize
+     raises ``ValueError`` ("No read support for unknown log format ...").
+   - A syntactically-parseable ``.asc`` whose frame line has a non-hex data
+     byte raises ``ValueError`` ("invalid literal for int() with base 16")
+     during frame iteration (not at construction).
+   - A frame whose declared data length doesn't match its DBC message
+     definition raises ``cantools.database.errors.DecodeError`` ("Wrong data
+     size: N instead of M bytes") from ``decode_message``. Unlike the
+     structural failures above, this is a per-frame problem: ``CanLog``
+     skips and counts that one frame (mirroring how unknown-arbitration-id
+     frames are handled) rather than aborting the whole capture.
+
+Structural capture failures (can't open/iterate the container at all) must
+never reach a caller as a raw library traceback -- they come out as a single
+clean, typed error (``errors.InvalidPathError``).
+"""
+
+import pathlib
+
+import pytest
+
+pytest.importorskip("can")
+pytest.importorskip("cantools")
+
+import can
+import cantools
+
+from src.source import errors
+from src.source.automotive import can as can_source
+
+VALID_DBC = """VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: ECU
+
+BO_ 100 EngineData: 8 ECU
+ SG_ Speed : 0|16@1+ (1,0) [0|65535] "" ECU
+"""
+
+
+def _write_valid_dbc(tmp_path: pathlib.Path) -> pathlib.Path:
+    dbc = tmp_path / "valid.dbc"
+    dbc.write_text(VALID_DBC)
+    return dbc
+
+
+def _write_blf(tmp_path: pathlib.Path, name: str, messages: list[can.Message]) -> pathlib.Path:
+    path = tmp_path / name
+    with can.BLFWriter(str(path)) as writer:
+        for msg in messages:
+            writer.on_message_received(msg)
+    return path
+
+
+def _write_valid_blf(tmp_path: pathlib.Path, *, data: bytes = bytes(range(8))) -> pathlib.Path:
+    msg = can.Message(arbitration_id=0x64, data=data, is_extended_id=False, timestamp=1.0)
+    return _write_blf(tmp_path, "valid.blf", [msg])
+
+
+# ---------------------------------------------------------------------------
+# Surface 1: DBC schema parsing (CanLog.__init__ -> cantools.database.load_file)
+# Before hardening: raw cantools.database.errors.UnsupportedDatabaseFormatError
+# or a raw ValueError escape from CanLog.__init__.
+# ---------------------------------------------------------------------------
+
+
+def test_garbage_dbc_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    dbc = tmp_path / "garbage.dbc"
+    dbc.write_bytes(b"this is not a dbc file \x00\x01\x02 garbage {{{ ]] not valid at all\n")
+    blf = _write_valid_blf(tmp_path)
+
+    with pytest.raises(errors.InvalidPathError):
+        can_source.CanLog(path=str(blf), dbc=str(dbc))
+
+
+def test_empty_dbc_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    dbc = tmp_path / "empty.dbc"
+    dbc.write_bytes(b"")
+    blf = _write_valid_blf(tmp_path)
+
+    with pytest.raises(errors.InvalidPathError):
+        can_source.CanLog(path=str(blf), dbc=str(dbc))
+
+
+def test_dbc_with_unrecognized_extension_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """cantools dispatches load format by extension; ``.txt`` raises a raw ValueError."""
+    dbc = tmp_path / "garbage.txt"
+    dbc.write_bytes(b"garbage")
+    blf = _write_valid_blf(tmp_path)
+
+    with pytest.raises(errors.InvalidPathError):
+        can_source.CanLog(path=str(blf), dbc=str(dbc))
+
+
+def test_missing_dbc_raises_file_not_found_already(tmp_path: pathlib.Path) -> None:
+    """Already clean: cantools itself raises a plain FileNotFoundError. Regression guard."""
+    blf = _write_valid_blf(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        can_source.CanLog(path=str(blf), dbc=str(tmp_path / "does_not_exist.dbc"))
+
+
+# ---------------------------------------------------------------------------
+# Surface 2: CAN capture parsing (CanLog.records -> can.LogReader + decode_message)
+# Before hardening: raw struct.error / ValueError from python-can, or a raw
+# cantools.database.errors.DecodeError from decode_message.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_blf_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Before hardening: struct.error escapes can.LogReader(...) construction."""
+    dbc = _write_valid_dbc(tmp_path)
+    blf = tmp_path / "empty.blf"
+    blf.write_bytes(b"")
+
+    log = can_source.CanLog(path=str(blf), dbc=str(dbc))
+    with pytest.raises(errors.InvalidPathError):
+        _ = log.records
+
+
+def test_corrupt_blf_header_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Has the LOGG magic but an internally-inconsistent header.
+
+    Before hardening: ValueError("read length must be non-negative or -1")
+    escapes can.LogReader(...) construction.
+    """
+    dbc = _write_valid_dbc(tmp_path)
+    blf = tmp_path / "corrupt_header.blf"
+    blf.write_bytes(b"LOGG" + b"\x00" * 20 + b"garbage garbage garbage not a real blf structure")
+
+    log = can_source.CanLog(path=str(blf), dbc=str(dbc))
+    with pytest.raises(errors.InvalidPathError):
+        _ = log.records
+
+
+def test_unrecognized_capture_extension_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Before hardening: ValueError("No read support for unknown log format ...")."""
+    dbc = _write_valid_dbc(tmp_path)
+    capture = tmp_path / "capture.weird"
+    capture.write_bytes(b"garbage")
+
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+    with pytest.raises(errors.InvalidPathError):
+        _ = log.records
+
+
+def test_asc_with_non_hex_frame_data_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Syntactically valid ASC header, but a frame data byte isn't valid hex.
+
+    Before hardening: ValueError("invalid literal for int() with base 16:
+    'ZZ'") escapes during frame iteration (not construction).
+    """
+    dbc = _write_valid_dbc(tmp_path)
+    asc = tmp_path / "bad_frame.asc"
+    asc.write_text(
+        "date Mon Jan 1 00:00:00 2024\n"
+        "base hex  timestamps absolute\n"
+        "no internal events logged\n"
+        "\n"
+        "   1.000000 1  100             Rx   d 8 01 02 03 04 05 06 07 ZZ\n"
+    )
+
+    log = can_source.CanLog(path=str(asc), dbc=str(dbc))
+    with pytest.raises(errors.InvalidPathError):
+        _ = log.records
+
+
+def test_frame_data_length_mismatch_is_skipped_not_fatal(tmp_path: pathlib.Path) -> None:
+    """One bad-known-id frame among several good ones must not nuke the capture.
+
+    A frame for a known DBC message whose data is shorter than the message
+    length makes decode_message raise cantools.database.errors.DecodeError
+    ("Wrong data size: 2 instead of 8 bytes"). This is a per-frame problem,
+    not a structural one: CanLog.records should skip and count that single
+    frame (like it already does for unknown arbitration IDs) and still
+    return the good frames, rather than raising for the whole capture.
+    """
+    dbc = _write_valid_dbc(tmp_path)
+    good = [
+        can.Message(arbitration_id=0x64, data=bytes(range(8)), is_extended_id=False, timestamp=t)
+        for t in (1.0, 2.0, 3.0)
+    ]
+    bad = can.Message(arbitration_id=0x64, data=b"\x01\x02", is_extended_id=False, timestamp=4.0)
+    blf = _write_blf(tmp_path, "mixed.blf", [*good, bad])
+
+    log = can_source.CanLog(path=str(blf), dbc=str(dbc))
+    records = log.records
+
+    assert len(records) == len(good)
+    assert all(name == "EngineData" for _, name, _ in records)
+
+
+def test_missing_capture_file_raises_file_not_found_already(tmp_path: pathlib.Path) -> None:
+    """Already clean: python-can itself raises a plain FileNotFoundError. Regression guard."""
+    dbc = _write_valid_dbc(tmp_path)
+    log = can_source.CanLog(path=str(tmp_path / "does_not_exist.blf"), dbc=str(dbc))
+
+    with pytest.raises(FileNotFoundError):
+        _ = log.records
+
+
+def test_asc_with_only_unrecognized_lines_is_already_clean(tmp_path: pathlib.Path) -> None:
+    """python-can's ASC reader is lenient: garbage lines are silently skipped,
+    not raised. Already clean (no exception, just zero records). Kept as a
+    regression guard against accidentally over-tightening the capture guard.
+    """
+    dbc = _write_valid_dbc(tmp_path)
+    asc = tmp_path / "garbage.asc"
+    asc.write_text("this is not an asc file\nrandom garbage\n\x00\x01\x02")
+
+    log = can_source.CanLog(path=str(asc), dbc=str(dbc))
+    assert log.records == []
+
+
+# ---------------------------------------------------------------------------
+# Sanity: genuinely valid DBC + capture still builds and decodes normally --
+# hardening the parse-failure paths must not affect the happy path.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_dbc_and_capture_still_decode_correctly(tmp_path: pathlib.Path) -> None:
+    dbc = _write_valid_dbc(tmp_path)
+    blf = _write_valid_blf(tmp_path)
+
+    log = can_source.CanLog(path=str(blf), dbc=str(dbc))
+    records = log.records
+
+    assert len(records) == 1
+    timestamp, name, signals = records[0]
+    assert isinstance(timestamp, float)
+    assert name == "EngineData"
+    assert signals == {"Speed": 256}
+    assert isinstance(log.database, cantools.database.can.database.Database)

--- a/test/adversarial/test_mcap_jsonschema.py
+++ b/test/adversarial/test_mcap_jsonschema.py
@@ -1,0 +1,123 @@
+"""Malformed jsonschema-encoded MCAP definitions: must never crash uncontrollably.
+
+``jsonschema_to_struct`` (and its helper ``_jsonschema_type``) is the entry point
+production code calls when an MCAP channel's schema encoding is "jsonschema"
+(``TopicRegistry.struct`` / ``describe`` in ``src/topic/mcap.py``). A malformed
+document -- non-UTF-8 bytes, non-JSON text, a non-object top level, type-confused
+``properties``/``items``, or a pathologically deep nesting -- must raise the
+module's clean, typed error (``base.UnsupportedEncodingError``), never a raw
+``UnicodeDecodeError``, ``AttributeError``, ``RecursionError``, or ``TypeError``.
+"""
+
+import json
+
+import pyarrow as pa
+import pytest
+
+from src.topic import base
+from src.topic.mcap import jsonschema_to_struct
+
+
+def _deeply_nested_object_bytes(depth: int) -> bytes:
+    """Build JSON bytes for an object schema nested ``depth`` levels deep.
+
+    Built via plain string concatenation (no Python-level recursion, no
+    ``json.dumps``) so that constructing the *test fixture* itself never trips
+    a ``RecursionError`` -- only feeding it through the parser under test
+    should be able to do that.
+    """
+    prefix = '{"type": "object", "properties": {"child": ' * depth
+    leaf = '{"type": "string"}'
+    suffix = "}}" * depth
+    return (prefix + leaf + suffix).encode()
+
+
+CASES: dict[str, bytes] = {
+    # Raw bytes that are not valid UTF-8 -- json.loads raises UnicodeDecodeError
+    # (not json.JSONDecodeError) before it can even attempt to parse. Note:
+    # b"\xff\xfe..." looks like it should qualify but is actually a UTF-16 LE
+    # BOM that json.loads sniffs and decodes successfully (then fails as
+    # JSONDecodeError, already handled) -- confirmed empirically. A lone
+    # continuation byte with no BOM reliably fails UTF-8 decoding instead.
+    "invalid_utf8": b'{"a": "\x80\x81"}',
+    # Valid UTF-8, but not JSON at all.
+    "non_json_text": b"not json at all {{{",
+    # Valid JSON, but the top-level document is not an object.
+    "valid_json_non_object_int": b"42",
+    "valid_json_non_object_string": b'"just a string"',
+    "valid_json_non_object_array": b"[1, 2, 3]",
+    # Type confusion: "properties" is a str, not a dict -- .items() should not
+    # be called on it.
+    "properties_not_a_dict": json.dumps({"type": "object", "properties": "not-a-dict"}).encode(),
+    # Nested well past any sane schema depth (150 levels), but still shallow
+    # enough that json.loads() parses it fine -- this exercises
+    # _jsonschema_type's own recursion-depth guard.
+    "moderately_nested_exceeds_depth_cap": _deeply_nested_object_bytes(150),
+    # Nested ~2000 levels deep -- deep enough that json.loads() itself hits
+    # CPython's recursion limit while parsing, before _jsonschema_type is ever
+    # called. This is a real, empirically-confirmed vector distinct from
+    # _jsonschema_type's own recursion.
+    "extremely_nested_breaks_json_loads": _deeply_nested_object_bytes(2000),
+}
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_malformed_jsonschema_raises_clean_error(name: str) -> None:
+    """Every malformed jsonschema definition must raise a clean, typed error.
+
+    Specifically ``base.UnsupportedEncodingError`` -- not a raw
+    ``UnicodeDecodeError``, ``AttributeError``, ``RecursionError``, or
+    ``TypeError`` escaping from ``jsonschema_to_struct``.
+    """
+    with pytest.raises(base.UnsupportedEncodingError):
+        jsonschema_to_struct(CASES[name])
+
+
+def test_nested_items_not_a_dict_degrades_gracefully() -> None:
+    """A nested ``"items"`` that is a str, not a dict, must not raise AttributeError.
+
+    Unlike the other type-confusion cases, this one is nested one level below
+    the top-level object, so the malformed ``items`` value doesn't invalidate
+    the whole document -- it only affects the one field. Per the module's
+    existing "schemaless object" convention (see
+    ``test_jsonschema_mapper_edge_cases`` in
+    ``test/pipeline/test_mcap_jsonschema.py``), the field degrades to a plain
+    string (schemaless) rather than raising. This is a deliberate design
+    choice, not an oversight -- this test guards it as a regression check.
+    """
+    definition = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "bad_array": {"type": "array", "items": "not-a-dict"},
+            },
+        }
+    ).encode()
+    struct = jsonschema_to_struct(definition)
+    assert isinstance(struct, pa.StructType)
+    assert struct.field("bad_array").type == pa.list_(pa.string())
+
+
+def test_property_not_a_dict_preserves_field_instead_of_dropping_it() -> None:
+    """A property sub-schema that is a str, not a dict, must not silently vanish.
+
+    Symmetric with ``test_nested_items_not_a_dict_degrades_gracefully``: a
+    malformed ``items`` degrades to a schemaless string, so a malformed
+    property sub-schema must do the same -- the field name is preserved and
+    typed as ``pa.string()`` -- rather than being dropped from the struct with
+    no error and no signal (the original bug this test guards against).
+    """
+    definition = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "a": {"type": "number"},
+                "b": "not-a-dict",
+            },
+        }
+    ).encode()
+    struct = jsonschema_to_struct(definition)
+    assert isinstance(struct, pa.StructType)
+    assert struct.names == ["a", "b"]
+    assert struct.field("a").type == pa.float64()
+    assert struct.field("b").type == pa.string()

--- a/test/adversarial/test_mdf4_parse.py
+++ b/test/adversarial/test_mdf4_parse.py
@@ -1,0 +1,169 @@
+"""Adversarial/fuzz tests for the ASAM MDF4 source (issue #134).
+
+A malformed ``.mf4`` file must produce a CLEAN, typed error from
+``SourceFactory`` -- either ``errors.InvalidPathError`` (or another
+clearly-typed domain error) -- never a raw ``asammdf``-internal traceback
+(``struct.error``, ``UnicodeDecodeError``, ``AttributeError``,
+``UnboundLocalError``, etc.) and never a hang.
+
+Call-flow note: ``SourceFactory.__init__`` calls ``super().__init__(path)``
+first, which (via ``base.FileBasedSourceFactory.__init__``) already invokes
+``validate_path()`` and raises cleanly if the file doesn't exist, isn't a
+file, or lacks the ``MDF_MAGIC`` header. So files with no/wrong magic are
+*already* clean (see the "already clean" section below). The real gap is a
+file that HAS the correct 8-byte magic but a corrupt/truncated body: it
+passes ``validate_path()`` and then ``MDF(path)`` in ``__init__`` explodes
+with whatever low-level exception ``asammdf``'s binary parser happens to hit
+at the point of corruption -- observed, across different truncation points
+of a real minimal MDF4 file, to be any of: ``struct.error``,
+``UnicodeDecodeError``, ``AttributeError``, ``ValueError``,
+``UnboundLocalError``. There is no common asammdf-specific base exception
+across these -- they're raised from deep inside asammdf's block-unpacking
+code as plain Python parsing errors.
+"""
+
+import pathlib
+
+import pytest
+
+pytest.importorskip("asammdf")
+
+from src.source import errors
+from src.source.automotive import mf4
+
+MDF_MAGIC = b"MDF     "
+
+
+# ---------------------------------------------------------------------------
+# Vector 1 (PRIMARY CRASH): valid MDF_MAGIC header, corrupt/garbage body.
+# Before hardening: raises whatever asammdf's parser raises (struct.error /
+# UnicodeDecodeError / AttributeError / ValueError / UnboundLocalError,
+# depending on exactly where the corruption falls) directly out of __init__.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_magic_with_garbage_body_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "corrupt_body.mf4"
+    bad.write_bytes(MDF_MAGIC + b"\x00\xff\x10\x20" * 50)
+
+    with pytest.raises(errors.InvalidPathError):
+        mf4.SourceFactory(str(bad))
+
+
+def test_valid_magic_truncated_right_after_magic_raises_clean_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Only the 8-byte magic is present; the mandatory ID block is truncated.
+
+    Before hardening: ``struct.error: unpack requires a buffer of 64 bytes``
+    escapes from asammdf's ``FileIdentificationBlock`` unpacking.
+    """
+    bad = tmp_path / "truncated_after_magic.mf4"
+    bad.write_bytes(MDF_MAGIC)
+
+    with pytest.raises(errors.InvalidPathError):
+        mf4.SourceFactory(str(bad))
+
+
+def test_real_mdf_file_truncated_at_various_offsets_raises_clean_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Truncate a genuinely valid MDF4 file at many offsets.
+
+    Characterization (against the unhardened code) showed this produces a
+    grab-bag of distinct raw exception types depending on exactly where the
+    cut falls: struct.error, AttributeError, ValueError, UnboundLocalError.
+    After hardening, every one of these must come out as a single clean
+    InvalidPathError instead.
+    """
+    import numpy as np
+    from asammdf import MDF, Signal
+
+    full_path = tmp_path / "real.mf4"
+    working = MDF(version="4.10")
+    signal = Signal(
+        samples=np.array([1.0, 2.0, 3.0]),
+        timestamps=np.array([0.0, 1.0, 2.0]),
+        name="test_channel",
+    )
+    working.append([signal])
+    working.save(str(full_path), overwrite=True)
+    working.close()
+
+    data = full_path.read_bytes()
+    assert len(data) > 100  # sanity: the fixture file isn't trivially tiny
+
+    for offset in (8, 16, 24, 40, 64, 100, 150, 300, 500, len(data) - 1):
+        truncated = tmp_path / f"trunc_{offset}.mf4"
+        truncated.write_bytes(data[:offset])
+
+        with pytest.raises(errors.InvalidPathError):
+            mf4.SourceFactory(str(truncated))
+
+
+# ---------------------------------------------------------------------------
+# Vectors that are ALREADY CLEAN via validate_path() -- kept as regression
+# guards so future refactors of __init__'s ordering can't silently reopen
+# the crash.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    empty = tmp_path / "empty.mf4"
+    empty.write_bytes(b"")
+
+    with pytest.raises(errors.InvalidPathError):
+        mf4.SourceFactory(str(empty))
+
+
+def test_no_mdf_magic_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    not_mdf = tmp_path / "not_mdf.mf4"
+    not_mdf.write_bytes(b"NOTMDF!!" + b"\x00" * 50)
+
+    with pytest.raises(errors.InvalidPathError):
+        mf4.SourceFactory(str(not_mdf))
+
+
+def test_missing_file_raises_file_not_found_already(tmp_path: pathlib.Path) -> None:
+    missing = tmp_path / "does_not_exist.mf4"
+
+    with pytest.raises(FileNotFoundError):
+        mf4.SourceFactory(str(missing))
+
+
+def test_directory_instead_of_file_raises_clean_error_already(
+    tmp_path: pathlib.Path,
+) -> None:
+    directory = tmp_path / "a_directory.mf4"
+    directory.mkdir()
+
+    with pytest.raises(errors.PathNotFileError):
+        mf4.SourceFactory(str(directory))
+
+
+# ---------------------------------------------------------------------------
+# Sanity: a genuinely valid MDF4 file still builds and works normally --
+# hardening the corrupt-body path must not affect the happy path.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_mdf_file_still_builds_correctly(tmp_path: pathlib.Path) -> None:
+    import asammdf
+    import numpy as np
+    from asammdf import Signal
+
+    full_path = tmp_path / "valid.mf4"
+    working = asammdf.MDF(version="4.10")
+    signal = Signal(
+        samples=np.array([1.0, 2.0, 3.0]),
+        timestamps=np.array([0.0, 1.0, 2.0]),
+        name="test_channel",
+    )
+    working.append([signal])
+    working.save(str(full_path), overwrite=True)
+    working.close()
+
+    factory = mf4.SourceFactory(str(full_path))
+
+    assert factory.total_message_count == 3
+    assert isinstance(factory.build(), asammdf.MDF)

--- a/test/adversarial/test_pyarrow_sources.py
+++ b/test/adversarial/test_pyarrow_sources.py
@@ -1,0 +1,318 @@
+"""Adversarial/fuzz tests for the PyArrow CSV/JSON sources (issue #134).
+
+A malformed CSV/JSON input must produce a CLEAN, typed error --
+``errors.InvalidPathError`` (or another clearly-typed domain error) -- never a
+raw ``pyarrow.lib.ArrowInvalid``/``ArrowTypeError`` traceback, an uncontrolled
+crash (e.g. a raw ``UnicodeDecodeError``), or a hang.
+
+Call-flow / boundary characterization (empirically determined against the
+unhardened code):
+
+- ``pyarrow.dataset.dataset(...)`` (the ``ds.dataset()`` call) is LAZY about
+  reading row *data*, but it is NOT lazy about schema inference: for CSV and
+  JSON formats it must read (at least part of) the file immediately to infer
+  a schema. Whether that inference failure surfaces as an exception depends
+  entirely on ``exclude_invalid_files``:
+
+  * ``exclude_invalid_files=True`` (the default): PyArrow performs its own
+    internal per-file validity check during dataset construction, silently
+    EXCLUDES any file that fails it, and the result is simply an empty
+    dataset (0 rows, empty schema) -- no exception at all. This means most
+    single malformed files never crash under default settings; they just
+    silently vanish from the dataset. That's a (separate, pre-existing) data
+    -correctness concern, not a crash, and is out of scope here.
+  * ``exclude_invalid_files=False`` (an explicit, first-class, user-settable
+    constructor argument on both ``csv.SourceFactory`` and
+    ``json.SourceFactory`` -- see their docstrings, which already warn "this
+    will incur IO ... resulting in an error at scan time" when disabled):
+    a single malformed file raises ``pyarrow.lib.ArrowInvalid`` directly out
+    of ``ds.dataset(...)`` inside ``SourceFactory._build()``
+    (``src/source/pyarrow/base.py``). This is the PRIMARY crash boundary.
+  * Also with ``exclude_invalid_files=False``: a DIRECTORY containing one
+    valid file (whose schema is used) and one malformed file that still
+    passes the lightweight Python-side ``is_csv_file``/``is_json_file``
+    sniffer, will construct successfully (schema comes from the first good
+    file) but raises ``pyarrow.lib.ArrowInvalid`` later, at
+    ``data_source.dataset.to_table()`` inside
+    ``src/message/pyarrow/base.py``'s ``MessageDataset._messages()``. This is
+    the SECONDARY crash boundary.
+
+- Separately (not a pyarrow exception at all): binary garbage with a
+  ``.json`` extension was found to raise a raw, un-typed
+  ``UnicodeDecodeError`` straight out of ``SourceFactory.__init__()`` (via
+  ``validate_path()`` -> ``is_json_file()`` -> ``is_json_lines_file()`` /
+  ``is_standard_json_file()`` in ``src/di/types/data_source.py``), because
+  those two helpers only caught ``json.JSONDecodeError`` and not the
+  ``UnicodeDecodeError`` that invalid UTF-8 bytes trigger during
+  ``f.readline()`` / ``path.read_text()``. The sibling ``is_csv_file()`` in
+  the same module already guards against exactly this
+  (``except (csv.Error, UnicodeDecodeError)``), so this was a pre-existing
+  gap in the JSON-specific helpers, now closed to match.
+
+Both `pyarrow.lib.ArrowInvalid` and `pyarrow.lib.ArrowTypeError` (and other
+Arrow-specific exceptions) share the common base `pyarrow.lib.ArrowException`
+(itself unrelated to `ArrowInvalid`'s incidental `ValueError` parentage), so
+that is what the hardening catches.
+"""
+
+import pathlib
+
+import pytest
+
+from src.di.types import data_source as data_source_types
+from src.message.pyarrow.base import MessageDataset
+from src.source import errors
+from src.source.pyarrow import csv as csv_source
+from src.source.pyarrow import json as json_source
+
+# ---------------------------------------------------------------------------
+# Vector 1 (PRIMARY CRASH -- _build() / ds.dataset()): a single malformed
+# file, with exclude_invalid_files=False so PyArrow doesn't silently drop it.
+# ---------------------------------------------------------------------------
+
+
+def test_csv_ragged_rows_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Ragged rows (inconsistent column counts) that survive the CSV sniffer.
+
+    A handful of well-formed rows establishes the dialect for
+    ``csv.Sniffer()``; a single short row later in the same file is enough
+    to make PyArrow's real CSV parser raise, but not necessarily enough to
+    trip the lenient Python sniffer used by ``validate_path()``.
+    """
+    bad = tmp_path / "ragged.csv"
+    rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], "99,100"]
+    bad.write_text("\n".join(rows) + "\n")
+
+    factory = csv_source.SourceFactory(str(bad), exclude_invalid_files=False)
+    with pytest.raises(errors.InvalidPathError):
+        factory.build()
+
+
+def test_csv_unterminated_quote_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "unterminated.csv"
+    rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], '99,"100,200']
+    bad.write_text("\n".join(rows) + "\n")
+
+    factory = csv_source.SourceFactory(str(bad), exclude_invalid_files=False)
+    with pytest.raises(errors.InvalidPathError):
+        factory.build()
+
+
+def test_json_array_instead_of_ndjson_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """PyArrow's JSON reader expects newline-delimited JSON, not a JSON array."""
+    bad = tmp_path / "array.json"
+    bad.write_text('[{"a": 1}, {"a": 2}]')
+
+    factory = json_source.SourceFactory(str(bad), exclude_invalid_files=False)
+    with pytest.raises(errors.InvalidPathError):
+        factory.build()
+
+
+def test_json_type_conflicting_rows_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    """Same key changes type (number -> object) across NDJSON rows."""
+    bad = tmp_path / "mixed_types.json"
+    bad.write_text('{"a": 1}\n{"a": {"b": 2}}\n')
+
+    factory = json_source.SourceFactory(str(bad), exclude_invalid_files=False)
+    with pytest.raises(errors.InvalidPathError):
+        factory.build()
+
+
+def test_json_broken_second_line_raises_clean_error(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "broken_line.json"
+    bad.write_text('{"a": 1}\n{"a": 2\n{"a": 3}\n')
+
+    factory = json_source.SourceFactory(str(bad), exclude_invalid_files=False)
+    with pytest.raises(errors.InvalidPathError):
+        factory.build()
+
+
+# ---------------------------------------------------------------------------
+# Vector 2 (SECONDARY CRASH -- to_table() inside message/pyarrow/base.py):
+# a directory where the dataset schema comes from a valid file, but a
+# malformed sibling file (which still passes the Python-side sniffer) blows
+# up only once the dataset is actually scanned.
+# ---------------------------------------------------------------------------
+
+
+def test_directory_with_malformed_sibling_raises_clean_error_at_to_table(
+    tmp_path: pathlib.Path,
+) -> None:
+    directory = tmp_path / "mixed"
+    directory.mkdir()
+    (directory / "a_good.csv").write_text("a,b,c\n1,2,3\n4,5,6\n")
+    rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], "99,100"]
+    (directory / "z_bad.csv").write_text("\n".join(rows) + "\n")
+
+    factory = csv_source.SourceFactory(str(directory), exclude_invalid_files=False)
+    data_source = factory.build()  # succeeds: schema comes from the good file
+
+    message_dataset = MessageDataset()
+    with pytest.raises(errors.InvalidPathError):
+        list(
+            message_dataset._messages(
+                data_source,
+                topics=["message"],
+                start_seconds_inclusive=None,
+                end_seconds_inclusive=None,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector 3: binary garbage with a .json extension -- not a pyarrow exception
+# at all, but a raw UnicodeDecodeError leaking out of the JSON sniffer
+# helpers in src/di/types/data_source.py, straight out of
+# SourceFactory.__init__() (via validate_path()).
+# ---------------------------------------------------------------------------
+
+
+def test_json_binary_garbage_raises_clean_error_not_unicode_decode_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    bad = tmp_path / "binary.json"
+    bad.write_bytes(bytes(range(256)) * 4)
+
+    with pytest.raises(ValueError):
+        json_source.SourceFactory(str(bad))
+
+
+def test_is_json_lines_file_does_not_raise_on_invalid_utf8(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "binary.json"
+    bad.write_bytes(bytes(range(256)) * 4)
+
+    assert data_source_types.is_json_lines_file(bad) is False
+
+
+def test_is_standard_json_file_does_not_raise_on_invalid_utf8(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "binary.json"
+    bad.write_bytes(bytes(range(256)) * 4)
+
+    assert data_source_types.is_standard_json_file(bad) is False
+
+
+# ---------------------------------------------------------------------------
+# Vectors that are ALREADY CLEAN (or already don't crash) -- kept as
+# regression guards so future refactors can't silently reopen them.
+# ---------------------------------------------------------------------------
+
+
+def test_csv_binary_garbage_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "binary.csv"
+    bad.write_bytes(bytes(range(256)) * 4)
+
+    with pytest.raises(ValueError):
+        csv_source.SourceFactory(str(bad))
+
+
+def test_csv_empty_file_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    empty = tmp_path / "empty.csv"
+    empty.write_bytes(b"")
+
+    with pytest.raises(ValueError):
+        csv_source.SourceFactory(str(empty))
+
+
+def test_json_empty_file_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    empty = tmp_path / "empty.json"
+    empty.write_bytes(b"")
+
+    with pytest.raises(ValueError):
+        json_source.SourceFactory(str(empty))
+
+
+def test_json_invalid_syntax_raises_clean_error_already(tmp_path: pathlib.Path) -> None:
+    bad = tmp_path / "invalid.json"
+    bad.write_text("{not valid json!!!")
+
+    with pytest.raises(ValueError):
+        json_source.SourceFactory(str(bad))
+
+
+def test_csv_header_only_file_does_not_crash_already(tmp_path: pathlib.Path) -> None:
+    """Header-only CSV: builds fine and yields zero rows, no crash."""
+    header_only = tmp_path / "header_only.csv"
+    header_only.write_text("a,b,c\n")
+
+    factory = csv_source.SourceFactory(str(header_only))
+    data_source = factory.build()
+    message_dataset = MessageDataset()
+    messages = list(
+        message_dataset._messages(
+            data_source,
+            topics=["message"],
+            start_seconds_inclusive=None,
+            end_seconds_inclusive=None,
+        )
+    )
+    assert messages == []
+
+
+def test_malformed_file_default_exclude_invalid_files_yields_no_crash_already(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Under the default exclude_invalid_files=True, PyArrow silently drops a
+    malformed single file from the dataset instead of raising -- this is a
+    (separate, pre-existing) silent-data-loss concern, not a crash, and is
+    documented here as out of scope for this hardening pass.
+    """
+    bad = tmp_path / "ragged.csv"
+    rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], "99,100"]
+    bad.write_text("\n".join(rows) + "\n")
+
+    factory = csv_source.SourceFactory(str(bad))  # default exclude_invalid_files=True
+    data_source = factory.build()
+    message_dataset = MessageDataset()
+    messages = list(
+        message_dataset._messages(
+            data_source,
+            topics=["message"],
+            start_seconds_inclusive=None,
+            end_seconds_inclusive=None,
+        )
+    )
+    assert messages == []
+
+
+# ---------------------------------------------------------------------------
+# Sanity: valid CSV/JSON files still build and materialize correctly --
+# hardening the crash boundaries must not affect the happy path.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_csv_file_still_builds_and_materializes_correctly(tmp_path: pathlib.Path) -> None:
+    good = tmp_path / "good.csv"
+    good.write_text("a,b,c\n1,2,3\n4,5,6\n")
+
+    factory = csv_source.SourceFactory(str(good))
+    data_source = factory.build()
+    message_dataset = MessageDataset()
+    messages = list(
+        message_dataset._messages(
+            data_source,
+            topics=["message"],
+            start_seconds_inclusive=None,
+            end_seconds_inclusive=None,
+        )
+    )
+    assert len(messages) == 2
+    assert {msg["a"] for _, _, msg in messages} == {1, 4}
+
+
+def test_valid_json_file_still_builds_and_materializes_correctly(tmp_path: pathlib.Path) -> None:
+    good = tmp_path / "good.json"
+    good.write_text('{"a": 1}\n{"a": 2}\n')
+
+    factory = json_source.SourceFactory(str(good))
+    data_source = factory.build()
+    message_dataset = MessageDataset()
+    messages = list(
+        message_dataset._messages(
+            data_source,
+            topics=["message"],
+            start_seconds_inclusive=None,
+            end_seconds_inclusive=None,
+        )
+    )
+    assert len(messages) == 2
+    assert {msg["a"] for _, _, msg in messages} == {1, 2}

--- a/test/adversarial/test_ros_log_parse.py
+++ b/test/adversarial/test_ros_log_parse.py
@@ -1,0 +1,220 @@
+"""Adversarial/fuzz tests for the ROS text-log parser (issue #134).
+
+A malformed line must produce a CLEAN outcome from ``parse_line`` /
+``parse_file`` -- either a sensible ``LogRecord`` or, for garbage that cannot
+be sensibly parsed, ``None`` (``parse_line``'s documented "no known format"
+contract) / an empty-ish list -- never an uncontrolled crash (``ValueError``,
+``OverflowError``, ``OSError``, ``TypeError``) and never a hang.
+"""
+
+import pathlib
+import time
+
+import pytest
+
+from src.source.ros.parse import LogRecord, parse_file, parse_line
+
+# ---------------------------------------------------------------------------
+# Vector 1: a line that MATCHES the rospy LINE_PATTERNS regex (the only
+# pattern that uses datetime.strptime instead of a raw unix_seconds float)
+# but carries an out-of-range calendar datetime (month 13, hour 25, etc).
+# Before hardening: datetime.strptime(...) raises ValueError, which escapes
+# parse_line uncaught.
+# ---------------------------------------------------------------------------
+
+
+def test_rospy_line_with_invalid_month_and_hour_returns_none() -> None:
+    line = "[rospy.client][INFO] 2020-13-45 25:99:99,000: msg"
+
+    record = parse_line(line, fallback_node="fallback")
+
+    assert record is None
+
+
+def test_rospy_line_with_invalid_day_returns_none() -> None:
+    line = "[rospy.client][ERROR] 2022-02-30 10:00:00,000: Feb 30th does not exist"
+
+    record = parse_line(line, fallback_node="fallback")
+
+    assert record is None
+
+
+# ---------------------------------------------------------------------------
+# Vector 2: a regex-matching rospy datetime that strptime accepts, but whose
+# local-timezone .timestamp() conversion falls outside the platform's
+# representable range (year 1 underflows below datetime.MINYEAR once the
+# local UTC offset is subtracted; observed to raise
+# "ValueError: year 0 is out of range" on this platform, OSError on others).
+# ---------------------------------------------------------------------------
+
+
+def test_rospy_line_with_minimum_year_returns_none_not_crash() -> None:
+    line = "[rospy.client][INFO] 0001-01-01 00:00:00,000: tiny year"
+
+    record = parse_line(line, fallback_node="fallback")
+
+    assert record is None
+
+
+def test_rospy_line_with_maximum_year_stays_a_regression_guard() -> None:
+    """Year 9999 is accepted -- already clean, kept as a regression guard."""
+    line = "[rospy.client][INFO] 9999-12-31 23:59:59,999: huge year"
+
+    record = parse_line(line, fallback_node="fallback")
+
+    assert record is not None
+    assert record.level == "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Vector 3: unix_seconds capture -- the regex only permits \d+(\.\d+)? so
+# float() always succeeds; a very large digit run is exercised here as a
+# regression guard (already clean, no hardening needed).
+# ---------------------------------------------------------------------------
+
+
+def test_huge_unix_seconds_digit_run_parses_cleanly() -> None:
+    line = "[INFO] [" + "9" * 200_000 + ".0] [talker]: msg"
+
+    record = parse_line(line, fallback_node="fallback")
+
+    assert record is not None
+    assert record.timestamp_seconds == float("9" * 200_000 + ".0")
+
+
+# ---------------------------------------------------------------------------
+# Vector 4: ReDoS / catastrophic backtracking. Feed long pathological lines
+# shaped to stress each LINE_PATTERNS entry and confirm parse_line returns
+# quickly rather than hanging. (Characterization found no catastrophic
+# backtracking in any pattern -- these are regression guards.)
+# ---------------------------------------------------------------------------
+
+_REDOS_TIMEOUT_SECONDS = 2.0
+
+_PATHOLOGICAL_LINES = [
+    "[" + "0" * 200_000,
+    "[INFO] [" + "9" * 200_000 + ".0] [talker]: msg",
+    "1" + "0" * 200_000 + " [INFO] [launch]: msg",
+    "[" + " " * 100_000 + "INFO] [1.0] [talker]: msg",
+    "[rospy.client]" * 50_000 + "[INFO] 2022-09-05 12:00:00,100: msg",
+    "[" * 100_000,
+    "]" * 100_000,
+    "[INFO] [1.0] [" + "a" * 200_000,
+]
+
+
+@pytest.mark.parametrize("line", _PATHOLOGICAL_LINES)
+def test_pathological_lines_do_not_hang(line: str) -> None:
+    start = time.monotonic()
+    parse_line(line, fallback_node="fallback")
+    elapsed = time.monotonic() - start
+
+    assert elapsed < _REDOS_TIMEOUT_SECONDS, (
+        f"parse_line took {elapsed:.2f}s on a {len(line)}-char pathological "
+        "line -- possible catastrophic backtracking"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vector 5: parse_file robustness -- binary garbage, empty file, a file of
+# only unmatched lines, and a real log file with one malformed-timestamp
+# line mixed in among otherwise-valid lines.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_file_on_binary_garbage_returns_list_without_raising(
+    tmp_path: pathlib.Path,
+) -> None:
+    garbage = tmp_path / "binary.log"
+    garbage.write_bytes(bytes(range(256)) * 100)
+
+    records = parse_file(garbage)
+
+    assert isinstance(records, list)
+
+
+def test_parse_file_on_empty_file_returns_empty_list(tmp_path: pathlib.Path) -> None:
+    empty = tmp_path / "empty.log"
+    empty.write_text("")
+
+    records = parse_file(empty)
+
+    assert records == []
+
+
+def test_parse_file_with_only_unmatched_lines_returns_empty_list(
+    tmp_path: pathlib.Path,
+) -> None:
+    unmatched = tmp_path / "unmatched.log"
+    unmatched.write_text("random line 1\nrandom line 2\n")
+
+    records = parse_file(unmatched)
+
+    assert records == []
+
+
+def test_parse_file_with_malformed_timestamp_mixed_in_does_not_raise(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A file with a valid line, an invalid-datetime line, then another valid
+    line must parse without raising. The invalid line is not a recognized
+    record, so (per parse_file's documented continuation behavior) it is
+    folded into the previous record's message rather than dropped or
+    crashing the whole file.
+    """
+    log = tmp_path / "mixed.log"
+    log.write_text(
+        "[rospy.client][INFO] 2022-09-05 12:00:00,100: first message\n"
+        "[rospy.client][INFO] 2020-13-45 25:99:99,000: bad datetime\n"
+        "[rospy.client][INFO] 2022-09-05 12:00:05,200: second message\n"
+    )
+
+    records = parse_file(log)
+
+    assert isinstance(records, list)
+    assert [r.message.splitlines()[0] for r in records] == [
+        "first message",
+        "second message",
+    ]
+    # The unparseable line is folded into the preceding record as a
+    # continuation line, matching parse_file's documented behavior for
+    # lines that match no known format.
+    assert records[0].message == (
+        "first message\n[rospy.client][INFO] 2020-13-45 25:99:99,000: bad datetime"
+    )
+
+
+def test_parse_file_with_leading_malformed_timestamp_is_dropped(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A malformed-timestamp line with no preceding record is dropped, same
+    as any other unmatched leading line.
+    """
+    log = tmp_path / "leading_bad.log"
+    log.write_text(
+        "[rospy.client][INFO] 2020-13-45 25:99:99,000: bad datetime\n"
+        "[rospy.client][INFO] 2022-09-05 12:00:00,100: ok message\n"
+    )
+
+    records = parse_file(log)
+
+    assert len(records) == 1
+    assert records[0].message == "ok message"
+
+
+# ---------------------------------------------------------------------------
+# Sanity: valid rospy lines are unaffected by the hardening.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_rospy_line_still_parses_correctly() -> None:
+    record = parse_line(
+        "[rospy.client][WARNING] 2022-09-05 12:00:00,100: shutdown request received",
+        fallback_node="fallback",
+    )
+
+    assert record is not None
+    assert isinstance(record, LogRecord)
+    assert record.level == "WARN"
+    assert record.node == "rospy.client"
+    assert record.message == "shutdown request received"

--- a/test/adversarial/test_secrets_redaction.py
+++ b/test/adversarial/test_secrets_redaction.py
@@ -1,0 +1,296 @@
+"""Secrets-leakage audit for issue #134.
+
+Credentials (DSN passwords, InfluxDB tokens, MQTT broker credentials, Slack
+webhook URLs) must never appear in an exception message, a `metadata` dict, or
+a log line that could reach an MCP client. These tests drive each hardened
+leak point with a secret-bearing input through its VALIDATION/parse-error path
+(never a live server) and assert the secret substring is absent from whatever
+came back, while useful diagnostics (host, database name) are preserved.
+"""
+
+import traceback
+
+import pytest
+
+from src.di.types import data_source
+from src.pipeline.tasks.notify.slack import NotifySlack
+from src.source import postgres
+from src.source.redact import redact_url, scrub_secrets
+
+# -- redact_url: the helper itself ---------------------------------------------------
+
+
+def test_redact_url_strips_userinfo_but_keeps_host_and_db() -> None:
+    safe = redact_url("postgresql://alice:s3cr3t@db.example.com:5432/prod")
+    assert "s3cr3t" not in safe
+    assert "alice" not in safe
+    assert "db.example.com" in safe
+    assert "prod" in safe
+
+
+def test_redact_url_strips_sensitive_query_params() -> None:
+    safe = redact_url("influxdb://influx.local:8181/fleet?token=ABC123")
+    assert "ABC123" not in safe
+    assert "influx.local" in safe
+    assert "fleet" in safe
+
+
+def test_redact_url_preserves_non_sensitive_query_params() -> None:
+    safe = redact_url("https://example.com/path?region=us-east-1&token=ABC123")
+    assert "region=us-east-1" in safe
+    assert "ABC123" not in safe
+
+
+def test_redact_url_passes_through_plain_path_unchanged() -> None:
+    path = "./data/sample/pyarrow/csv/flight.csv"
+    assert redact_url(path) == path
+    assert redact_url("/data/logs/2026") == "/data/logs/2026"
+
+
+def test_redact_url_handles_malformed_dsn_missing_slashes() -> None:
+    # A typo'd DSN (missing "//") parses with the userinfo landing in `.path`
+    # instead of `.netloc` -- the redaction must still catch it.
+    safe = redact_url("postgres:alice:s3cr3t@host/db")
+    assert "s3cr3t" not in safe
+    assert "host" in safe
+
+
+def test_redact_url_empty_string() -> None:
+    assert redact_url("") == ""
+
+
+def test_redact_url_fails_safe_on_malformed_ipv6_host() -> None:
+    # Unbalanced `[` in the host makes `urlsplit` raise `ValueError` outright.
+    # The old behavior handed the raw, unparsed `value` back on that path --
+    # i.e. the password verbatim. Fail SAFE instead: never return the input.
+    result = redact_url("postgres://alice:s3cr3t@[::1/db")
+    assert "s3cr3t" not in result
+
+
+def test_redact_url_fails_safe_on_unbalanced_bracket_in_host_only() -> None:
+    result = redact_url("postgres://alice:s3cr3t@host[oops/db")
+    assert "s3cr3t" not in result
+
+
+def test_redact_url_fails_safe_on_bare_non_url_token() -> None:
+    # Not a URL at all -- must not raise, and (trivially) has no secret to leak.
+    assert redact_url("not-a-url-at-all") == "not-a-url-at-all"
+
+
+def test_redact_url_malformed_dsn_with_bare_token_no_colon() -> None:
+    # A missing-"//" InfluxDB URL typo: the userinfo is a BARE TOKEN with no
+    # ":" in it. The malformed-DSN fallback branch used to only redact
+    # `user:pass@host` forms (guarded on ":" in userinfo), so a bare token
+    # sailed through unredacted. It must be redacted unconditionally on "@",
+    # mirroring the well-formed netloc branch above.
+    safe = redact_url("influxdb:MY-SECRET-TOKEN-abc123@influx.local:8181/fleet")
+    assert "MY-SECRET-TOKEN-abc123" not in safe
+    assert "influx.local" in safe
+
+
+def test_redact_url_malformed_dsn_with_bare_token_no_colon_postgres() -> None:
+    safe = redact_url("postgres:sekrittoken@host/db")
+    assert "sekrittoken" not in safe
+    assert "host" in safe
+
+
+def test_redact_url_malformed_dsn_with_embedded_at_in_password() -> None:
+    # On the malformed-DSN fallback path (missing "//"), a password containing
+    # a literal "@" must be redacted using the LAST "@" before the path
+    # boundary -- consistent with the well-formed netloc branch's
+    # `rpartition("@")` -- not the first "@", which would leave the password's
+    # tail ("evil") sitting unredacted in the output.
+    safe = redact_url("postgres:alice:s3cr3t@evil@host/db")
+    assert "s3cr3t" not in safe
+    assert "evil" not in safe
+    assert "host" in safe
+
+
+def test_scrub_secrets_removes_verbatim_occurrences() -> None:
+    text = "IO Error: could not connect using 'postgresql://alice:s3cr3t@host/db'"
+    assert "s3cr3t" not in scrub_secrets(text, "s3cr3t")
+
+
+def test_scrub_secrets_ignores_empty_or_none_secrets() -> None:
+    text = "unaffected message"
+    assert scrub_secrets(text, None, "") == text
+
+
+# -- postgres: ConnectionError must not leak the DSN's password ---------------------
+
+
+def test_postgres_connect_error_does_not_leak_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    import duckdb
+
+    def _boom(_url: str) -> None:
+        # Mirror DuckDB's real behavior: the postgres extension's own error message
+        # embeds the raw connection string, password included.
+        raise duckdb.IOException(
+            "IO Error: Unable to connect to Postgres at "
+            "postgresql://alice:s3cr3t@bad.invalid:5432/prod: name resolution failed"
+        )
+
+    monkeypatch.setattr(postgres, "attach", _boom)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        postgres.SourceFactory("postgresql://alice:s3cr3t@bad.invalid:5432/prod")
+
+    message = str(excinfo.value)
+    assert "s3cr3t" not in message
+    assert "bad.invalid" in message
+
+
+def test_postgres_metadata_url_does_not_leak_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(postgres, "attach", lambda url: "pg_test")
+
+    factory = postgres.SourceFactory("postgresql://alice:s3cr3t@db.example.com:5432/prod")
+    monkeypatch.setattr(postgres.PostgresDatabase, "tables", lambda self: [])
+
+    metadata = factory.metadata
+
+    assert "s3cr3t" not in str(metadata)
+    assert "db.example.com" in metadata["url"]
+
+
+def test_postgres_metadata_does_not_leak_password_for_malformed_ipv6_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end: a DSN with an unbalanced IPv6 bracket makes `urlsplit` raise
+    # `ValueError` inside `redact_url`. That must fail SAFE, not hand the raw
+    # (credential-bearing) DSN back into tool-facing `metadata`.
+    monkeypatch.setattr(postgres, "attach", lambda url: "pg_test")
+    monkeypatch.setattr(postgres.PostgresDatabase, "tables", lambda self: [])
+
+    factory = postgres.SourceFactory("postgres://alice:s3cr3t@[::1/db")
+
+    assert "s3cr3t" not in str(factory.metadata)
+
+
+def test_postgres_connect_error_does_not_leak_password_for_malformed_ipv6_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A DSN with an unbalanced IPv6 bracket makes the *unguarded*
+    # `urlsplit(path).password` call inside the `except duckdb.Error` handler raise
+    # `ValueError` itself. Python chains the original `duckdb.Error` -- whose message
+    # embeds the raw, credential-bearing connection string -- onto that new
+    # `ValueError` as `__context__`, so the password leaks via the traceback even
+    # though the handler never returns normally. Guard the extraction so this can't
+    # happen, and prove it by inspecting the FULL chained traceback, not just the
+    # raised exception's own message.
+    #
+    # The secret is built from a variable (never spelled out as a literal on the
+    # same line as a `raise`/call statement) so that Python's own traceback
+    # formatter -- which echoes each frame's *source line* verbatim from disk,
+    # regardless of redaction -- can't trivially reintroduce it as a test
+    # artifact unrelated to what postgres.py actually leaks.
+    import duckdb
+
+    secret_password = "s3cr3t"  # noqa: S105
+    dsn = f"postgres://alice:{secret_password}@[::1/db"
+    driver_message = f"IO Error: Unable to connect to Postgres at {dsn}: name resolution failed"
+
+    def _boom(_url: str) -> None:
+        raise duckdb.IOException(driver_message)
+
+    monkeypatch.setattr(postgres, "attach", _boom)
+
+    with pytest.raises(Exception) as excinfo:  # ValueError pre-fix, ConnectionError post-fix
+        postgres.SourceFactory(dsn)
+
+    full = "".join(traceback.format_exception(excinfo.value))
+    assert secret_password not in full
+
+
+# -- influxdb: parse/connection errors must not leak the token ----------------------
+
+
+def test_influxdb_bad_scheme_error_does_not_leak_token() -> None:
+    pytest.importorskip("influxdb_client_3")
+    from src.source import influxdb
+
+    with pytest.raises(ValueError) as excinfo:
+        influxdb.parse_url("mysql://s3cr3ttoken@influx.local:8181/fleet")
+
+    assert "s3cr3ttoken" not in str(excinfo.value)
+
+
+def test_influxdb_missing_database_error_does_not_leak_token() -> None:
+    pytest.importorskip("influxdb_client_3")
+    from src.source import influxdb
+
+    with pytest.raises(ValueError) as excinfo:
+        influxdb.parse_url("influxdb://s3cr3ttoken@influx.local:8181")
+
+    message = str(excinfo.value)
+    assert "s3cr3ttoken" not in message
+    assert "influx.local" in message
+
+
+def test_influxdb_connect_error_does_not_leak_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("influxdb_client_3")
+    from src.source import influxdb
+
+    def _boom(self: object) -> None:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(influxdb.InfluxDatabase, "tables", _boom)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        influxdb.SourceFactory("influxdb://s3cr3ttoken@influx.local:8181/fleet")
+
+    message = str(excinfo.value)
+    assert "s3cr3ttoken" not in message
+    assert "influx.local" in message
+
+
+# -- slack: the webhook URL is itself the secret -- never echo it -------------------
+
+
+def test_slack_rejects_non_http_webhook_without_echoing_it() -> None:
+    secret_looking_value = (
+        "ftp://hooks.example.com/services/T00/B00/s3cr3twebhooktoken"  # noqa: S105
+    )
+
+    with pytest.raises(ValueError, match="http") as excinfo:
+        NotifySlack(webhook_url=secret_looking_value, message="x")
+
+    assert "s3cr3twebhooktoken" not in str(excinfo.value)
+    assert secret_looking_value not in str(excinfo.value)
+
+
+# -- mqtt: broker credentials never appear in logs -----------------------------------
+#
+# `src/sink/mqtt.py` was audited and found NOT to leak: every `logging.*` call there
+# is parameterized with a topic name, count, or duration -- never `username`/
+# `password` -- and `TopicSink.metadata` (inherited from `src/sink/base.py`) only
+# includes `host`/`port`/`available_topics`/`magic`. A full end-to-end regression
+# test (constructing a real sink with credentials via the fake-paho-client fixture,
+# then asserting the secrets are absent from both logs and metadata) lives in
+# `test/sink/test_mqtt.py::test_broker_credentials_never_appear_in_logs_or_metadata`,
+# since it needs that suite's `make_sink` fixture (not available to this directory).
+
+
+# -- data_source.resolve: a malformed/typo'd DSN must not leak its credentials ------
+
+
+def test_resolve_malformed_dsn_does_not_leak_credentials() -> None:
+    # Missing "//" after the scheme: falls through to the file-based resolver,
+    # which used to raise with the raw (credential-bearing) string verbatim.
+    with pytest.raises(ValueError) as excinfo:
+        data_source.resolve("postgres:alice:s3cr3t@host/db")
+
+    message = str(excinfo.value)
+    assert "s3cr3t" not in message
+    assert "host" in message
+
+
+def test_resolve_malformed_dsn_with_bare_token_does_not_leak_credentials() -> None:
+    # Same missing-"//" fallthrough, but with a BARE TOKEN (no ":") as
+    # userinfo -- a realistic InfluxDB URL typo. This is the end-to-end path
+    # for the bare-token redact_url fix above: resolve() raises ValueError
+    # (the string doesn't look like any supported file type), and that
+    # ValueError's message must not contain the raw token.
+    with pytest.raises(ValueError) as excinfo:
+        data_source.resolve("influxdb:MY-SECRET-TOKEN-abc123@influx.local:8181/fleet")
+
+    assert "MY-SECRET-TOKEN-abc123" not in str(excinfo.value)

--- a/test/sink/test_mqtt.py
+++ b/test/sink/test_mqtt.py
@@ -1,6 +1,7 @@
 """Tests for the MQTT topic sink, using a fake paho client (no broker needed)."""
 
 import json
+import logging
 import pathlib
 from unittest.mock import MagicMock
 
@@ -271,3 +272,34 @@ def test_wildcard_with_pipeline_requires_single_match(make_sink: MakeSink) -> No
     sink.subscribe("freezer/1/+", pipeline=pipeline, extract_timestamp=lambda m: m["t"])
     sink._fake.deliver("freezer/1/status", json.dumps({"temp": -12.0, "t": 1.0}).encode())
     assert [call.args[0] for call in pipeline.run_at.call_args_list] == [1.0]
+
+
+# -- secrets leakage (issue #134) --------------------------------------------------
+
+
+def test_broker_credentials_never_appear_in_logs_or_metadata(
+    make_sink: MakeSink, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Username/password must never reach a log line or the sink's metadata dict.
+
+    Drives the full init -> discovery -> wildcard-subscribe -> unseen-topic-timeout
+    path (the only places this sink logs anything) with real-looking credentials, and
+    asserts neither value appears in any log record or in `sink.metadata`.
+    """
+    caplog.set_level(logging.DEBUG)
+    sink = make_sink(
+        retained={"freezer/1/status": [b'{"temp": -18.5}']},
+        username="mqtt_admin",
+        password="hunter2",  # noqa: S106 -- fixture value, not a real credential
+        schema_timeout_seconds=0.05,
+    )
+
+    sink.subscribe("freezer/#")  # logs "Wildcard '...' expanded to N topic(s)"
+    sink._struct("garage/unseen")  # unseen topic times out -> logs a warning
+
+    for record in caplog.records:
+        text = record.getMessage()
+        assert "hunter2" not in text
+        assert "mqtt_admin" not in text
+    assert "hunter2" not in str(sink.metadata)
+    assert "mqtt_admin" not in str(sink.metadata)


### PR DESCRIPTION
## Harden the parsers + secrets audit + dependency-audit cadence (#134)

Second slice of issue #134. Every remaining file parser is now fuzzed against malformed input and hardened so a bad file yields a **clean, typed error** instead of a raw library traceback, crash, or hang — plus a credential-leakage audit and a dependency-audit CI cadence.

**Stacked on #153** (the adversarial/e2e test harness it builds upon). Base is `test/aggressive-campaign`; this will retarget to `main` once #153 merges.

### Parser hardening (fuzz → harden, TDD)
- **MCAP jsonschema** — clean errors for invalid UTF-8, non-dict `properties`/`items` (degrade to string, no silent field-drop), and pathological nesting (recursion cap); zstd path exercised.
- **ROS text logs** — a regex-matching but invalid/out-of-range timestamp (month 13, year 0001) no longer crashes `strptime`/`.timestamp()`; it returns the documented no-match. No ReDoS in the line patterns.
- **MDF4** — a corrupt `.mf4` raises `InvalidPathError` instead of a deep asammdf `struct.error`/`UnboundLocalError`.
- **CAN (DBC/BLF/ASC)** — malformed DBC or capture raises a clean error; **a single undecodable frame is now skipped-and-counted, not fatal to the whole capture** (mirroring the existing unknown-ID handling).
- **PyArrow CSV/JSON** — malformed input raises a clean error at both the `_build()` and `.to_table()` boundaries; also closed a `UnicodeDecodeError` gap in the JSON detection sniffers.

### Secrets-leakage audit + redaction
- New `src/source/redact.py` (`redact_url` / `scrub_secrets`): strips userinfo (incl. bare tokens and embedded-`@` passwords), redacts sensitive query params (case-insensitive), drops URL fragments, and **fails safe** (returns `***`) on unparseable input.
- Fixed 6 real leak points where a DSN password / API token / webhook URL reached an exception message, `metadata` dict, or the malformed-DSN fallthrough in `resolve()` (on the first line of every tool call). Includes the chained-traceback leak on the postgres connect path for malformed-IPv6 DSNs.
- Audited and confirmed clean: MQTT broker creds, S3/GCS/Azure upload endpoints, email task.

### CI
- New **non-blocking** `dependency-audit.yaml` (pip-audit, weekly + per-PR). Intentionally informational: the current lock carries dozens of transitive advisories (torch/jupyter stack), so a hard gate would be red on day one; it provides the cadence #134 asks for and can be tightened once the baseline is triaged.

### Verification
Every parser change is TDD (malformed corpus → assert clean typed error), each individually reviewed; the secrets work went through 4 adversarial review rounds that each caught a distinct real leak (fail-open on malformed input, first-vs-last `@`, bare-token bypass, chained-traceback). Full host suite: 249 passed, only the pre-existing ROS-dependency collection errors; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
