### PR TITLE
ci: make ros1 deadsnakes/apt build step resilient to transient network flakes

### DIFF
--- a/docker/Dockerfile.ros1
+++ b/docker/Dockerfile.ros1
@@ -58,13 +58,24 @@ RUN echo "source /opt/ros/noetic/setup.bash" >> /etc/bash.bashrc
 
 # Install new version Python
 ARG PYTHON_VERSION=3.10
+# This step reaches two flaky external services in one layer -- the Launchpad
+# PPA API (add-apt-repository) and the Ubuntu package mirrors (apt fetch). Any
+# transient hiccup in either used to fail the whole build (observed both as
+# Launchpad's "'~deadsnakes' user or team does not exist" and as mirror
+# "Connection failed" fetch errors). Retry both: Acquire::Retries covers the
+# apt fetches, and the loop covers add-apt-repository, which does not self-retry.
 # hadolint ignore=DL3008
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa && \
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+    software-properties-common && \
+    for i in $(seq 1 5); do \
+        add-apt-repository -y ppa:deadsnakes/ppa && break; \
+        if [ "$i" = 5 ]; then echo "add-apt-repository failed after 5 attempts" >&2; exit 1; fi; \
+        echo "add-apt-repository attempt $i failed; retrying in 10s..." && sleep 10; \
+    done && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --fix-missing \
     python${PYTHON_VERSION} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Make the ros1 deadsnakes/apt build step resilient to transient network flakes

The Python-install layer in `docker/Dockerfile.ros1` reaches **two** flaky external services in a single `RUN`:
- the **Launchpad PPA API** via `add-apt-repository ppa:deadsnakes/ppa`, and
- the **Ubuntu package mirrors** via `apt-get install`.

A transient hiccup in *either* failed the entire build. Observed both ways:
- In CI: `Cannot add PPA: 'ppa:~deadsnakes/ubuntu/ppa' / '~deadsnakes' user or team does not exist` (Launchpad API flake) — reddened three separate PRs.
- Locally: `E: Failed to fetch http://ports.ubuntu.com/.../libqt5quick5_..._arm64.deb  Connection failed` (mirror fetch flake).

Neither is a code problem — it's an un-retried layer that depends on multiple external networks at once.

### Fix
- `Acquire::Retries "5"` so apt retries transient package fetches instead of aborting the layer.
- A bounded retry loop (5 attempts, 10s backoff) around `add-apt-repository`, which does not self-retry; fails cleanly if all attempts are exhausted.
- `--fix-missing` on the Python install as belt-and-suspenders for partial-fetch cases.

One file covers both affected images: `ros1-noetic` (`CV_MODE=false`) and `ros1-noetic-cv` (`CV_MODE=true`) both build from `docker/Dockerfile.ros1`.

### Verification
Built `ros1-noetic` locally with the fix → `BUILD_EXIT=0`, and the in-container suite passes **132 passed, 7 skipped**. (`ros2-humble` and `px4` were also re-verified green as part of the same local CI reproduction.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
