### PR TITLE
Resource limits: streaming readers, PyArrow drop visibility, cache eviction, buffer admission control (#134)

### DIFF
--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -8,6 +8,9 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `MCP_SERVER_HOST` | `0.0.0.0` | In-container listen address; host-side exposure is governed by the compose port mapping - see SECURITY.md before sharing the endpoint beyond the machine |
 | `MCP_TRANSPORT` | `sse` | MCP transport the server runs |
 | `JSONL_BUFFER_SIZE_PER_TOPIC_BYTES` | 1 GB | Rolling live buffer per subscribed topic |
+| `SINK_TOTAL_BUFFER_BYTES` | 0 (unbounded) | Total live-buffer budget per sink; when set, subscribe() refuses topics that would exceed it (`BufferCapacityExceededError` names both knobs to adjust) |
+| `CACHE_MAX_BYTES` | 20 GB | LRU cap on the arrow query cache; 0 disables eviction. Never touches sink buffers or artifacts |
+| `MAX_ARROW_RECORD_BATCH_SIZE_COUNT` | 100000 | Row ceiling per arrow batch; bounds peak memory when converting large topics |
 | `ARTIFACT_DIRECTORY` | `~/.bagel/artifacts` | User deliverables (snippets, GIFs, exports). Never cleaned up automatically |
 | `CACHE_DIRECTORY` | `~/.cache/bagel` | Intermediate artifact cache |
 | `STARTUP_PIPELINES_FILE` | unset | YAML manifest of subscriptions/pipelines re-established on boot |

--- a/server.py
+++ b/server.py
@@ -970,7 +970,7 @@ if __name__ == "__main__":
     # cache self-evicts (CACHE_MAX_BYTES), but ARTIFACT_DIRECTORY holds user
     # deliverables and is never auto-deleted -- its datestr= partition layout
     # supports external rotation (e.g. find -mtime +N).
-    logging.info(
+    logging.warning(
         "Disk usage: cache %s = %d bytes, artifacts %s = %d bytes",
         settings.CACHE_DIRECTORY,
         artifacts.directory_size_bytes(settings.CACHE_DIRECTORY),

--- a/server.py
+++ b/server.py
@@ -87,11 +87,14 @@ def describe_data_source(path: str, args: dict[str, Any] | None = None) -> list[
         f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
+    # Build BEFORE reading metadata: _build() populates excluded_file_count,
+    # and dict values evaluate in order (Codex review on #156).
+    data_source = factory.build()
     return poml(
         "./src/agent/describe/data_source.poml",
         context={
             "metadata": factory.metadata,
-            "topics": registry.available_topics(factory.build()),
+            "topics": registry.available_topics(data_source),
         },
     )
 

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 """Entry point for the Bagel MCP server."""
 
+import logging
 import pathlib
 from typing import Any
 
@@ -8,7 +9,7 @@ import yaml
 from poml import poml
 
 from settings import settings
-from src import mcp_compat
+from src import artifacts, mcp_compat
 from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
@@ -565,9 +566,7 @@ def preview_pipeline(  # noqa: PLR0913
         "run later with `run.py`. Returns the path to the written file."
     ),
 )
-def save_pipeline(
-    config: dict[str, Any], name: str, directory: str = "pipelines"
-) -> str:
+def save_pipeline(config: dict[str, Any], name: str, directory: str = "pipelines") -> str:
     """Write a pipeline configuration to a YAML file.
 
     Args:
@@ -726,7 +725,8 @@ def export_for_plotjuggler(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -795,7 +795,8 @@ def export_for_rerun(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -864,7 +865,8 @@ def export_for_lichtblick(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -937,7 +939,8 @@ def export_for_lerobot(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -963,6 +966,17 @@ if __name__ == "__main__":
         # Standing pipelines: re-establish subscriptions (and their attached pipelines)
         # on boot, so they survive container restarts.
         startup.start(settings.STARTUP_PIPELINES_FILE)
+    # Disk-usage visibility for unattended deployments (#134): the arrow query
+    # cache self-evicts (CACHE_MAX_BYTES), but ARTIFACT_DIRECTORY holds user
+    # deliverables and is never auto-deleted -- its datestr= partition layout
+    # supports external rotation (e.g. find -mtime +N).
+    logging.info(
+        "Disk usage: cache %s = %d bytes, artifacts %s = %d bytes",
+        settings.CACHE_DIRECTORY,
+        artifacts.directory_size_bytes(settings.CACHE_DIRECTORY),
+        settings.ARTIFACT_DIRECTORY,
+        artifacts.directory_size_bytes(settings.ARTIFACT_DIRECTORY),
+    )
     mcp_compat.run_server(
         server,
         transport=settings.MCP_TRANSPORT,

--- a/settings.py
+++ b/settings.py
@@ -40,6 +40,12 @@ class Settings(BaseSettings):
     # Bytes per record batch in arrow files. Not always respected
     ARROW_RECORD_BATCH_SIZE_BYTES: int = 1 * GB
 
+    # Hard row-count ceiling per record batch. The byte target above is
+    # measured in Arrow bytes, but rows accumulate as Python objects (10-20x
+    # overhead) until a batch flushes; with small rows the byte target alone
+    # resolves to millions of buffered rows and can OOM the server (#134).
+    MAX_ARROW_RECORD_BATCH_SIZE_COUNT: int = 100_000
+
     # Bytes per topic buffer in a topic sink. Always respected
     JSONL_BUFFER_SIZE_PER_TOPIC_BYTES: int = 1 * GB
 

--- a/settings.py
+++ b/settings.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     # are never touched by eviction.
     CACHE_MAX_BYTES: int = 20 * GB
 
+    # Max total nominal buffer bytes across all subscribed topics of one live
+    # sink. 0 = unbounded (the historical behavior). When set, subscribe()
+    # refuses new topics that would exceed it with BufferCapacityExceededError
+    # instead of silently growing; note on-disk usage can transiently reach 2x
+    # nominal because a rotated overflow file is retained until the next
+    # rotation.
+    SINK_TOTAL_BUFFER_BYTES: int = 0
+
     # Number of messages to buffer in rosbridge before sending over the WebSocket
     ROSBRIDGE_QUEUE_LENGTH: int = 1000
 

--- a/settings.py
+++ b/settings.py
@@ -43,6 +43,14 @@ class Settings(BaseSettings):
     # Bytes per topic buffer in a topic sink. Always respected
     JSONL_BUFFER_SIZE_PER_TOPIC_BYTES: int = 1 * GB
 
+    # Max total bytes of cached .arrow query results under
+    # <CACHE_DIRECTORY>/data/source_id=*/ . When a new cache file is about to
+    # be written and the total exceeds this, the oldest-by-access files are
+    # deleted first (cache entries are derived data and rebuild on demand).
+    # 0 disables eviction. Live sink buffers, repos, and ARTIFACT_DIRECTORY
+    # are never touched by eviction.
+    CACHE_MAX_BYTES: int = 20 * GB
+
     # Number of messages to buffer in rosbridge before sending over the WebSocket
     ROSBRIDGE_QUEUE_LENGTH: int = 1000
 

--- a/src/artifacts.py
+++ b/src/artifacts.py
@@ -3,6 +3,7 @@
 import base64
 import hashlib
 import json
+import logging
 import pathlib
 import re
 import uuid
@@ -64,6 +65,48 @@ def arrow_file(source_uuid: str, seeds: list[str], prefix: str) -> pathlib.Path:
         / f"source_id={source_uuid}"
         / f"{stem}.arrow"
     )
+
+
+def cached_arrow_files() -> list[pathlib.Path]:
+    """All cached .arrow query results (never sink buffers, repos, or artifacts)."""
+    data_directory = pathlib.Path(settings.CACHE_DIRECTORY) / "data"
+    return [file for file in data_directory.glob("source_id=*/**/*.arrow") if file.is_file()]
+
+
+def evict_arrow_cache() -> int:
+    """Delete oldest-by-access cached .arrow files until under CACHE_MAX_BYTES.
+
+    Cache entries are derived data keyed by (source, topics, window, ffill) and
+    rebuild on demand, so deletion is always safe. Called before each new cache
+    write; the incoming file may overshoot the cap until the next write evicts.
+    Returns the number of files deleted; no-op when CACHE_MAX_BYTES is 0.
+    """
+    limit_bytes = settings.CACHE_MAX_BYTES
+    if not limit_bytes:
+        return 0
+    entries = []
+    for file in cached_arrow_files():
+        try:
+            stat = file.stat()
+        except OSError:
+            continue  # deleted by a concurrent process; nothing to account
+        entries.append((max(stat.st_atime, stat.st_mtime), stat.st_size, file))
+    total = sum(size for _, size, _ in entries)
+    deleted = 0
+    for _, size, file in sorted(entries):
+        if total <= limit_bytes:
+            break
+        file.unlink(missing_ok=True)
+        total -= size
+        deleted += 1
+    if deleted:
+        logging.warning(
+            "Evicted %d cached arrow file(s) to keep the query cache under %d bytes "
+            "(CACHE_MAX_BYTES; 0 disables eviction)",
+            deleted,
+            limit_bytes,
+        )
+    return deleted
 
 
 def sink_directory(sink_uuid: str) -> pathlib.Path:

--- a/src/artifacts.py
+++ b/src/artifacts.py
@@ -161,3 +161,11 @@ def artifact_s3_key(path: pathlib.Path) -> str:
     relative_path = path.relative_to(settings.ARTIFACT_DIRECTORY)
     s3_key = pathlib.Path(settings.ARTIFACT_DIRNAME) / relative_path
     return s3_key.as_posix()
+
+
+def directory_size_bytes(directory: str | pathlib.Path) -> int:
+    """Total size of all files under a directory; 0 if it does not exist."""
+    root = pathlib.Path(directory)
+    if not root.exists():
+        return 0
+    return sum(file.stat().st_size for file in root.glob("**/*") if file.is_file())

--- a/src/artifacts.py
+++ b/src/artifacts.py
@@ -168,4 +168,12 @@ def directory_size_bytes(directory: str | pathlib.Path) -> int:
     root = pathlib.Path(directory)
     if not root.exists():
         return 0
-    return sum(file.stat().st_size for file in root.glob("**/*") if file.is_file())
+    total = 0
+    for file in root.glob("**/*"):
+        if not file.is_file():
+            continue
+        try:
+            total += file.stat().st_size
+        except OSError:
+            continue  # deleted between glob and stat; nothing to account
+    return total

--- a/src/di/types/topic_sink.py
+++ b/src/di/types/topic_sink.py
@@ -18,7 +18,7 @@ def guess_host(type_: TopicSink) -> str:
     match type_:
         case TopicSink.ROS1_BRIDGE:
             return "0.0.0.0"  # noqa: S104
-        case (TopicSink.ROS2_BRIDGE | TopicSink.MQTT) if settings.CONTAINER_MODE:
+        case TopicSink.ROS2_BRIDGE | TopicSink.MQTT if settings.CONTAINER_MODE:
             return "host.docker.internal"
         case TopicSink.ROS2_BRIDGE | TopicSink.MQTT:
             return "localhost"

--- a/src/message/automotive/can.py
+++ b/src/message/automotive/can.py
@@ -25,12 +25,10 @@ class MessageDataset(base.MessageDataset):
         end_seconds_inclusive: float | None,
     ) -> Iterator[tuple[str, float, dict[str, Any]]]:
         wanted = set(topics)
-        for timestamp, name, decoded in data_source.records:
+        for timestamp, name, decoded in data_source.records(
+            start_seconds_inclusive, end_seconds_inclusive
+        ):
             if name not in wanted:
-                continue
-            if start_seconds_inclusive is not None and timestamp < start_seconds_inclusive:
-                continue
-            if end_seconds_inclusive is not None and timestamp > end_seconds_inclusive:
                 continue
             yield (name, timestamp, {key: float(value) for key, value in decoded.items()})
 

--- a/src/message/automotive/can.py
+++ b/src/message/automotive/can.py
@@ -25,7 +25,7 @@ class MessageDataset(base.MessageDataset):
         end_seconds_inclusive: float | None,
     ) -> Iterator[tuple[str, float, dict[str, Any]]]:
         wanted = set(topics)
-        for timestamp, name, decoded in data_source.records(
+        for timestamp, name, decoded in data_source.iter_records(
             start_seconds_inclusive, end_seconds_inclusive
         ):
             if name not in wanted:

--- a/src/message/automotive/mf4.py
+++ b/src/message/automotive/mf4.py
@@ -4,6 +4,7 @@ import heapq
 from collections.abc import Iterator
 from typing import Any
 
+import numpy as np
 import pyarrow as pa
 from asammdf import MDF
 
@@ -33,19 +34,28 @@ class MessageDataset(base.MessageDataset):
         def stream(topic: str) -> Iterator[tuple[float, int, str, dict[str, Any]]]:
             index = names[topic]
             master = data_source.get_master(index)
+            lo, hi = 0, len(master)
+            if start_seconds_inclusive is not None:
+                lo = int(
+                    np.searchsorted(master, start_seconds_inclusive - start_epoch, side="left")
+                )
+            if end_seconds_inclusive is not None:
+                hi = int(np.searchsorted(master, end_seconds_inclusive - start_epoch, side="right"))
+            if lo >= hi:
+                return
+            # Load only the window's slice of each channel; .tolist() on the
+            # slice keeps element types identical to the previous full
+            # materialization while bounding memory by the query window (#134).
             columns = {
-                name: data_source.get(name, group=index, raw=False).samples.tolist()
+                name: data_source.get(
+                    name, group=index, raw=False, record_offset=lo, record_count=hi - lo
+                ).samples.tolist()
                 for name in _channels(data_source, index)
             }
-            for position, relative in enumerate(master.tolist()):
-                timestamp = start_epoch + relative
-                if start_seconds_inclusive is not None and timestamp < start_seconds_inclusive:
-                    continue
-                if end_seconds_inclusive is not None and timestamp > end_seconds_inclusive:
-                    continue
+            for position in range(hi - lo):
                 yield (
-                    timestamp,
-                    position,
+                    start_epoch + float(master[lo + position]),
+                    lo + position,
                     topic,
                     {name: values[position] for name, values in columns.items()},
                 )

--- a/src/message/base.py
+++ b/src/message/base.py
@@ -240,7 +240,13 @@ class MessageDataset(abc.ABC):
                     (settings.ARROW_RECORD_BATCH_SIZE_BYTES / record_batch.nbytes)
                     * record_batch.num_rows
                 )
-                batch_size = max(estimate, settings.MIN_ARROW_RECORD_BATCH_SIZE_COUNT)
+                # Clamp: the estimate targets Arrow bytes, but rows buffer as
+                # Python objects until the flush; small rows would otherwise
+                # resolve to millions of buffered rows and OOM (#134).
+                batch_size = min(
+                    max(estimate, settings.MIN_ARROW_RECORD_BATCH_SIZE_COUNT),
+                    settings.MAX_ARROW_RECORD_BATCH_SIZE_COUNT,
+                )
                 batch = {column: [] for column in schema.names}
                 yield record_batch
 

--- a/src/message/base.py
+++ b/src/message/base.py
@@ -1,6 +1,7 @@
 """An abstract base class for topic message datasets."""
 
 import abc
+import os
 from collections.abc import Iterator
 from typing import Any
 
@@ -153,10 +154,17 @@ class MessageDataset(abc.ABC):
         seeds = [*(topics or [str(None)]), str(start_seconds), str(end_seconds), str(ffill)]
         arrow_file = artifacts.arrow_file(factory.uuid, seeds, "topics")
         if arrow_file.exists() and self._use_cache:
+            try:
+                # Mark the entry as recently used so LRU eviction prefers
+                # colder files (#134).
+                os.utime(arrow_file)
+            except OSError:
+                pass  # a read-only cache mount must not break reads
             dataset = ds.dataset(arrow_file, format="arrow")
             return duckdb.from_arrow(dataset)
         arrow_file.unlink(missing_ok=True)
         arrow_file.parent.mkdir(parents=True, exist_ok=True)
+        artifacts.evict_arrow_cache()
 
         data_source = factory.build()
         topics = topics or registry.available_topics(data_source)

--- a/src/message/influxdb.py
+++ b/src/message/influxdb.py
@@ -93,9 +93,7 @@ class MessageDataset(base.MessageDataset):
             select = f'SELECT * FROM "{alias}"'  # noqa: S608
             combined = select if combined is None else f"{combined} UNION ALL BY NAME {select}"
 
-        return duckdb.sql(
-            f'{combined} ORDER BY "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}"'
-        )
+        return duckdb.sql(f'{combined} ORDER BY "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}"')
 
     def _messages(
         self,

--- a/src/message/mcap.py
+++ b/src/message/mcap.py
@@ -46,8 +46,7 @@ def decoder_for(schema: Schema | None, channel: Channel) -> Callable[[bytes], ob
         if decoder is not None:
             return decoder
     raise UnsupportedEncodingError(
-        f"No decoder for message encoding '{channel.message_encoding}' "
-        f"on topic '{channel.topic}'"
+        f"No decoder for message encoding '{channel.message_encoding}' on topic '{channel.topic}'"
     )
 
 

--- a/src/message/postgres.py
+++ b/src/message/postgres.py
@@ -77,9 +77,7 @@ class MessageDataset(base.MessageDataset):
         ]
         # UNION ALL BY NAME lines up shared columns and fills missing structs with NULL.
         query = " UNION ALL BY NAME ".join(f"({select})" for select in selects)
-        return duckdb.sql(
-            f'{query} ORDER BY "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}"'
-        )
+        return duckdb.sql(f'{query} ORDER BY "{settings.TIMESTAMP_SECONDS_COLUMN_NAME}"')
 
     def _messages(
         self,

--- a/src/pipeline/plotjuggler.py
+++ b/src/pipeline/plotjuggler.py
@@ -25,8 +25,20 @@ PALETTE = ("#1f77b4", "#d62728", "#1ac938", "#ff7f0e", "#f14cc1", "#9467bd", "#1
 
 MAX_CURVES = 8
 
-_NUMERIC_PREFIXES = ("TINYINT", "SMALLINT", "INTEGER", "BIGINT", "HUGEINT", "UTINYINT",
-                     "USMALLINT", "UINTEGER", "UBIGINT", "FLOAT", "DOUBLE", "DECIMAL")
+_NUMERIC_PREFIXES = (
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "FLOAT",
+    "DOUBLE",
+    "DECIMAL",
+)
 
 
 def _numeric_columns(relation: duckdb.DuckDBPyRelation) -> list[str]:

--- a/src/pipeline/tasks/cloudini/decode_pointcloud.py
+++ b/src/pipeline/tasks/cloudini/decode_pointcloud.py
@@ -140,9 +140,7 @@ class DecodePointCloudTask(base.Task):
         ):
             start_seconds = asof_seconds - lookback.to_seconds()
 
-        messages = self._dataset._messages(
-            data_source, self._topics, start_seconds, asof_seconds
-        )
+        messages = self._dataset._messages(data_source, self._topics, start_seconds, asof_seconds)
 
         digest = short_digest([*self._topics, str(lookback)])
         output_dir = self._output_directory / f"timestamp_seconds={asof_seconds}" / digest

--- a/src/pipeline/tasks/cloudini/vendor/cloudini_decoder.py
+++ b/src/pipeline/tasks/cloudini/vendor/cloudini_decoder.py
@@ -25,7 +25,7 @@ class CloudiniDecoder:
         """
         # Load the WASM module
         print(f"Loading WASM module from {wasm_path}")
-        with open(wasm_path, 'rb') as f:
+        with open(wasm_path, "rb") as f:
             wasm_bytes = f.read()
 
         # Create wasmtime engine with exception handling enabled
@@ -65,10 +65,11 @@ class CloudiniDecoder:
                         if len(func_type.results) > 0:
                             # Return appropriate default based on result type
                             result_type = str(func_type.results[0])
-                            if 'f32' in result_type or 'f64' in result_type:
+                            if "f32" in result_type or "f64" in result_type:
                                 return 0.0  # Float
                             return 0  # Integer
                         return None
+
                     return stub
 
                 stub_func = make_stub(func_type)
@@ -92,6 +93,7 @@ class CloudiniDecoder:
         if not self.memory:
             # Find memory by type
             from wasmtime import Memory as MemoryType
+
             for name, obj in exports.items():
                 if isinstance(obj, MemoryType):
                     self.memory = obj
@@ -99,15 +101,17 @@ class CloudiniDecoder:
                     break
 
         if not self.memory:
-            raise RuntimeError(f"Could not find memory export. Available: {list(export_info.keys())}")
+            raise RuntimeError(
+                f"Could not find memory export. Available: {list(export_info.keys())}"
+            )
 
         # Get malloc/free (may not exist in all modules)
         self.malloc = exports.get("malloc")
         self.free = exports.get("free")
 
         # Get the cloudini functions
-        self.decode_compressed_msg = exports.get('cldn_DecodeCompressedMessage')
-        self.get_header_as_yaml = exports.get('cldn_GetHeaderAsYAMLFromDDS')
+        self.decode_compressed_msg = exports.get("cldn_DecodeCompressedMessage")
+        self.get_header_as_yaml = exports.get("cldn_GetHeaderAsYAMLFromDDS")
 
         if not all([self.decode_compressed_msg, self.get_header_as_yaml]):
             raise RuntimeError("Could not find required Cloudini functions in WASM module")
@@ -120,7 +124,9 @@ class CloudiniDecoder:
         # Simple allocator offset (start at 2MB to avoid stack/heap)
         self.alloc_offset = 2 * 1024 * 1024
 
-        self.output_ptr = self.allocate(32 * 1024 * 1024) # allocate 32 megabytes as worst case scenario
+        self.output_ptr = self.allocate(
+            32 * 1024 * 1024
+        )  # allocate 32 megabytes as worst case scenario
 
         print("WASM module loaded successfully!")
 
@@ -147,7 +153,9 @@ class CloudiniDecoder:
         """Read bytes from WASM memory."""
         return self.memory.read(self.store, ptr, ptr + size)
 
-    def decode_message(self, compressed_msg: bytes, verbose: bool = True) -> tuple[np.ndarray, dict]:
+    def decode_message(
+        self, compressed_msg: bytes, verbose: bool = True
+    ) -> tuple[np.ndarray, dict]:
         """
         Decode a compressed DDS message to raw point cloud data.
 
@@ -167,9 +175,10 @@ class CloudiniDecoder:
             # Write compressed message to WASM memory
             self.write_bytes(input_ptr, compressed_msg)
 
-
             # Convert compressed message to PointCloud2 message
-            actual_size = self.decode_compressed_msg(self.store, input_ptr, len(compressed_msg), self.output_ptr)
+            actual_size = self.decode_compressed_msg(
+                self.store, input_ptr, len(compressed_msg), self.output_ptr
+            )
 
             if actual_size == 0:
                 raise RuntimeError("Failed to convert compressed message to PointCloud2")
@@ -184,8 +193,10 @@ class CloudiniDecoder:
             except Exception as e:
                 raise RuntimeError(f"Failed to extract header info from compressed message: {e}")
 
-            if not header_info or 'width' not in header_info:
-                raise RuntimeError("Header info extraction returned incomplete data (missing 'width')")
+            if not header_info or "width" not in header_info:
+                raise RuntimeError(
+                    "Header info extraction returned incomplete data (missing 'width')"
+                )
 
             # Parse the PointCloud2 message to extract the point cloud data
             # The PointCloud2 message contains the data field with raw point cloud bytes
@@ -199,7 +210,7 @@ class CloudiniDecoder:
     @staticmethod
     def _parse_yaml_value(value: str):
         """Convert a YAML scalar string to int, float, None, or str."""
-        if value == 'null' or value == 'None':
+        if value == "null" or value == "None":
             return None
         try:
             return int(value)
@@ -230,13 +241,15 @@ class CloudiniDecoder:
             self.write_bytes(input_ptr, compressed_msg)
 
             # Get header as YAML
-            yaml_size = self.get_header_as_yaml(self.store, input_ptr, len(compressed_msg), yaml_ptr)
+            yaml_size = self.get_header_as_yaml(
+                self.store, input_ptr, len(compressed_msg), yaml_ptr
+            )
             if yaml_size == 0:
                 return {}
 
-            yaml_str = self.read_bytes(yaml_ptr, yaml_size).decode('utf-8')
+            yaml_str = self.read_bytes(yaml_ptr, yaml_size).decode("utf-8")
 
-            #print(f"Extracted YAML header:\n{yaml_str}")
+            # print(f"Extracted YAML header:\n{yaml_str}")
 
             # Parse YAML (handles nested fields structure)
             header = {}
@@ -244,23 +257,23 @@ class CloudiniDecoder:
             current_field = None
             in_fields_section = False
 
-            for line in yaml_str.split('\n'):
+            for line in yaml_str.split("\n"):
                 stripped = line.strip()
 
                 # Check if we're in the fields section
-                if stripped.startswith('fields:'):
+                if stripped.startswith("fields:"):
                     in_fields_section = True
                     continue
 
                 if in_fields_section:
                     # New field starts with '- name:'
-                    if stripped.startswith('- name:'):
+                    if stripped.startswith("- name:"):
                         if current_field:
                             fields.append(current_field)
-                        current_field = {'name': stripped.split(':', 1)[1].strip()}
-                    elif stripped and ':' in stripped and not stripped.startswith('-'):
+                        current_field = {"name": stripped.split(":", 1)[1].strip()}
+                    elif stripped and ":" in stripped and not stripped.startswith("-"):
                         # Field property
-                        key, value = stripped.split(':', 1)
+                        key, value = stripped.split(":", 1)
                         key = key.strip()
                         value = value.strip()
 
@@ -268,8 +281,8 @@ class CloudiniDecoder:
                             current_field[key] = self._parse_yaml_value(value)
                 else:
                     # Top-level properties
-                    if ':' in stripped:
-                        key, value = stripped.split(':', 1)
+                    if ":" in stripped:
+                        key, value = stripped.split(":", 1)
                         key = key.strip()
                         value = value.strip()
 
@@ -279,7 +292,7 @@ class CloudiniDecoder:
             if current_field:
                 fields.append(current_field)
 
-            header['fields'] = fields
+            header["fields"] = fields
             return header
 
         finally:
@@ -299,9 +312,9 @@ class CloudiniDecoder:
         """
         # For now, we'll use a simplified approach and extract based on expected size
         # A full CDR deserializer would be needed for proper parsing
-        width = header_info.get('width', 0)
-        height = header_info.get('height', 0)
-        point_step = header_info.get('point_step', 0)
+        width = header_info.get("width", 0)
+        height = header_info.get("height", 0)
+        point_step = header_info.get("point_step", 0)
 
         expected_data_size = width * height * point_step
 
@@ -312,7 +325,9 @@ class CloudiniDecoder:
             data_bytes = pc2_msg[-expected_data_size:]
             return self.bytes_to_numpy(data_bytes, header_info)
         else:
-            print(f"Warning: PC2 message size {len(pc2_msg)} < expected data size {expected_data_size}")
+            print(
+                f"Warning: PC2 message size {len(pc2_msg)} < expected data size {expected_data_size}"
+            )
             return self.bytes_to_numpy(pc2_msg, header_info)
 
     def bytes_to_numpy(self, data: bytes, header_info: dict) -> np.ndarray:
@@ -326,40 +341,44 @@ class CloudiniDecoder:
         Returns:
             Structured numpy array with named fields
         """
-        width = header_info.get('width', 0)
-        height = header_info.get('height', 0)
-        point_step = header_info.get('point_step', 0)
-        fields = header_info.get('fields', [])
+        width = header_info.get("width", 0)
+        height = header_info.get("height", 0)
+        point_step = header_info.get("point_step", 0)
+        fields = header_info.get("fields", [])
 
         num_points = width * height
 
         if len(data) != num_points * point_step:
-            print(f"Warning: Data size mismatch. Expected {num_points * point_step}, got {len(data)}")
+            print(
+                f"Warning: Data size mismatch. Expected {num_points * point_step}, got {len(data)}"
+            )
 
         # Map Cloudini types to numpy dtypes
         type_map = {
-            'FLOAT32': np.float32,
-            'FLOAT64': np.float64,
-            'UINT8': np.uint8,
-            'UINT16': np.uint16,
-            'UINT32': np.uint32,
-            'INT8': np.int8,
-            'INT16': np.int16,
-            'INT32': np.int32,
+            "FLOAT32": np.float32,
+            "FLOAT64": np.float64,
+            "UINT8": np.uint8,
+            "UINT16": np.uint16,
+            "UINT32": np.uint32,
+            "INT8": np.int8,
+            "INT16": np.int16,
+            "INT32": np.int32,
         }
 
         # Create structured dtype from fields
         if fields:
             try:
                 # Sort fields by offset to ensure correct order
-                sorted_fields = sorted(fields, key=lambda f: f.get('offset', 0))
+                sorted_fields = sorted(fields, key=lambda f: f.get("offset", 0))
 
                 # Build dtype specification with explicit offsets
                 dtype_spec = {
-                    'names': [f.get('name', f'field_{i}') for i, f in enumerate(sorted_fields)],
-                    'formats': [type_map.get(f.get('type', 'UINT8'), np.uint8) for f in sorted_fields],
-                    'offsets': [f.get('offset', 0) for f in sorted_fields],
-                    'itemsize': point_step
+                    "names": [f.get("name", f"field_{i}") for i, f in enumerate(sorted_fields)],
+                    "formats": [
+                        type_map.get(f.get("type", "UINT8"), np.uint8) for f in sorted_fields
+                    ],
+                    "offsets": [f.get("offset", 0) for f in sorted_fields],
+                    "itemsize": point_step,
                 }
 
                 dtype = np.dtype(dtype_spec)

--- a/src/pipeline/tasks/snippet/mcap.py
+++ b/src/pipeline/tasks/snippet/mcap.py
@@ -71,9 +71,7 @@ class SnipMcap(base.ArtifactMixin, messages.TopicMessageMixin, base.Task):
             case base.Lookback(last=_, unit=_):
                 start_ns = int((asof_seconds - lookback.to_seconds()) * SECOND)
                 records = (
-                    record
-                    for record in raw_messages
-                    if start_ns <= record[2].log_time <= end_ns
+                    record for record in raw_messages if start_ns <= record[2].log_time <= end_ns
                 )
             case _:
                 records = (record for record in raw_messages if record[2].log_time <= end_ns)

--- a/src/pipeline/windows.py
+++ b/src/pipeline/windows.py
@@ -9,9 +9,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 
-def rising_edges(
-    samples: Iterable[tuple[float, Any]], min_gap_seconds: float = 0.0
-) -> list[float]:
+def rising_edges(samples: Iterable[tuple[float, Any]], min_gap_seconds: float = 0.0) -> list[float]:
     """Return timestamps where a boolean predicate transitions False -> True.
 
     A condition that stays true across consecutive samples produces a single edge

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -176,6 +176,52 @@ class TopicSink(abc.ABC):
             "magic": "BAGEL_SINK",  # Magic keyword to identify Bagel sink directories
         }
 
+    @property
+    def subscribed_topics(self) -> list[str]:
+        """Topics currently subscribed on this sink, in insertion order."""
+        return list(self._buffers)
+
+    def ensure_capacity(
+        self,
+        topics: list[str],
+        overwrite: bool = False,
+        buffer_size_bytes: int | None = settings.JSONL_BUFFER_SIZE_PER_TOPIC_BYTES,
+    ) -> None:
+        """Raise if subscribing all ``topics`` would exceed SINK_TOTAL_BUFFER_BYTES.
+
+        Batch admission is checked up front so a refusal happens before any
+        topic is subscribed: a mid-batch failure would otherwise leave a
+        partial subscription set behind (Codex review on #156). No-op when
+        the budget is 0 (unbounded).
+        """
+        total_limit = settings.SINK_TOTAL_BUFFER_BYTES
+        if not total_limit:
+            return
+        if buffer_size_bytes is None:
+            raise BufferCapacityExceededError(
+                f"Cannot batch-subscribe {len(topics)} topic(s) with unbounded "
+                f"buffers while SINK_TOTAL_BUFFER_BYTES={total_limit}: unbounded "
+                "topics cannot be accounted. Pass an explicit buffer_size_bytes "
+                "or set SINK_TOTAL_BUFFER_BYTES=0."
+            )
+        new_topics = [topic for topic in topics if overwrite or topic not in self._buffers]
+        existing_total = sum(
+            writer.buffer_size_bytes or 0
+            for existing_topic, writer in self._buffers.items()
+            if not (overwrite and existing_topic in topics)
+        )
+        projected = existing_total + len(new_topics) * buffer_size_bytes
+        if projected > total_limit:
+            raise BufferCapacityExceededError(
+                f"Subscribing {len(new_topics)} topic(s) at "
+                f"buffer_size_bytes={buffer_size_bytes} each would bring this "
+                f"sink's total to {projected} bytes, exceeding "
+                f"SINK_TOTAL_BUFFER_BYTES={total_limit}. Lower buffer_size_bytes "
+                "(default JSONL_BUFFER_SIZE_PER_TOPIC_BYTES) or raise "
+                "SINK_TOTAL_BUFFER_BYTES; no topics from this request were "
+                "subscribed."
+            )
+
     def subscribe(
         self,
         topic: str,

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -30,6 +30,10 @@ class TopicAlreadySubscribedError(Exception):
     """Raised when topic is already subscribed."""
 
 
+class BufferCapacityExceededError(Exception):
+    """Raised when a subscription would exceed SINK_TOTAL_BUFFER_BYTES."""
+
+
 class TopicSink(abc.ABC):
     """Abstract base class for topic sinks.
 
@@ -198,6 +202,8 @@ class TopicSink(abc.ABC):
 
         Raises:
             TopicNotFoundError: If any requested topic is unavailable.
+            BufferCapacityExceededError: If SINK_TOTAL_BUFFER_BYTES is set and this
+                subscription would exceed it.
 
         """
         if topic not in self.available_topics:
@@ -205,6 +211,30 @@ class TopicSink(abc.ABC):
 
         if topic in self._buffers and not overwrite:
             raise TopicAlreadySubscribedError(topic)
+
+        total_limit = settings.SINK_TOTAL_BUFFER_BYTES
+        if total_limit:
+            if buffer_size_bytes is None:
+                raise BufferCapacityExceededError(
+                    f"Cannot subscribe to {topic} with an unbounded buffer while "
+                    f"SINK_TOTAL_BUFFER_BYTES={total_limit}: an unbounded topic cannot be "
+                    "accounted. Pass an explicit buffer_size_bytes or set "
+                    "SINK_TOTAL_BUFFER_BYTES=0."
+                )
+            existing_total = sum(
+                writer.buffer_size_bytes or 0
+                for existing_topic, writer in self._buffers.items()
+                if existing_topic != topic  # overwrite replaces its own budget
+            )
+            if existing_total + buffer_size_bytes > total_limit:
+                raise BufferCapacityExceededError(
+                    f"Subscribing to {topic} with buffer_size_bytes={buffer_size_bytes} "
+                    f"would bring this sink's total to {existing_total + buffer_size_bytes} "
+                    f"bytes, exceeding SINK_TOTAL_BUFFER_BYTES={total_limit}. Lower "
+                    "buffer_size_bytes (default JSONL_BUFFER_SIZE_PER_TOPIC_BYTES) or "
+                    "raise SINK_TOTAL_BUFFER_BYTES; on-disk usage can transiently reach "
+                    "2x nominal during overflow rotation."
+                )
 
         self._buffers[topic] = TopicBufferWriter(
             self.directory,

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -136,6 +136,11 @@ class TopicBufferWriter:
             )
 
     @property
+    def buffer_size_bytes(self) -> int | None:
+        """The configured maximum buffer size in bytes; None means unbounded."""
+        return self._buffer_size_bytes
+
+    @property
     def topic(self) -> str:
         """Topic name for the messages held by this buffer."""
         return self._topic

--- a/src/sink/mqtt.py
+++ b/src/sink/mqtt.py
@@ -277,6 +277,8 @@ class TopicSink(base.TopicSink):
             TopicNotFoundError: If a wildcard matches no discovered topic.
             ValueError: If a pipeline is attached to a wildcard matching several topics
                 (a pipeline's cadence is defined over exactly one topic).
+            BufferCapacityExceededError: If SINK_TOTAL_BUFFER_BYTES is set and this
+                subscription would exceed it.
 
         """
         if extract_timestamp is None and self._timestamp_field is not None:

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -78,6 +78,10 @@ def subscribe_with_pipeline(
                 f"subscribed topics: {topics}"
             )
 
+    # All-or-nothing admission: refuse the whole batch up front rather than
+    # subscribing a prefix and failing mid-loop (Codex review on #156).
+    sink.ensure_capacity(list(topics), overwrite=overwrite)
+
     for topic in topics:
         sink.subscribe(
             topic,

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -146,20 +146,10 @@ def start(manifest_file: str | pathlib.Path) -> list[dict[str, Any]]:
                     **(entry.get("args") or {}),
                 },
             )
-            topics = subscribe_with_pipeline(
-                sink, entry.get("topics"), entry.get("pipeline")
-            )
-            reports.append(
-                {"sink": sink_type.value, "status": "subscribed", "topics": topics}
-            )
-            logging.info(
-                "Startup subscription active: %s -> %s", sink_type.value, topics
-            )
+            topics = subscribe_with_pipeline(sink, entry.get("topics"), entry.get("pipeline"))
+            reports.append({"sink": sink_type.value, "status": "subscribed", "topics": topics})
+            logging.info("Startup subscription active: %s -> %s", sink_type.value, topics)
         except Exception as error:
-            logging.error(
-                "Startup subscription failed for sink '%s': %s", sink_type.value, error
-            )
-            reports.append(
-                {"sink": sink_type.value, "status": "failed", "error": str(error)}
-            )
+            logging.error("Startup subscription failed for sink '%s': %s", sink_type.value, error)
+            reports.append({"sink": sink_type.value, "status": "failed", "error": str(error)})
     return reports

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -8,8 +8,10 @@ raw bus capture becomes queryable like any other source. Requires the optional
 
 import functools
 import logging
+import math
 import pathlib
 import struct
+from collections.abc import Iterator
 from typing import Any
 
 import can
@@ -46,69 +48,97 @@ class CanLog:
                 f"{dbc} could not be parsed as a DBC database: {type(exc).__name__}: {exc}"
             ) from exc
         self._path = path
-        self._records: list[tuple[float, str, dict[str, Any]]] | None = None
 
-    @property
-    def records(self) -> list[tuple[float, str, dict[str, Any]]]:
-        """(timestamp, message_name, decoded_signals) tuples, sorted by time."""
-        if self._records is None:
-            known = {message.frame_id: message.name for message in self.database.messages}
-            records = []
-            unknown = 0
-            undecodable = 0
-            try:
-                # This region wraps library parse calls over untrusted input
-                # (the capture file itself), so failures here are translated
-                # into a clean, typed error rather than leaking a can/cantools
-                # traceback. It's scoped to STRUCTURAL capture failures only:
-                # the file can't be opened, or frame iteration itself breaks
-                # down (corrupt/truncated container). A single frame that
-                # fails to decode is handled by the inner skip-and-count
-                # below and never reaches this except clause.
-                with can.LogReader(self._path) as reader:
-                    for frame in reader:
-                        name = known.get(frame.arbitration_id)
-                        if name is None:
-                            unknown += 1
-                            continue
-                        try:
-                            decoded = self.database.decode_message(
-                                frame.arbitration_id, frame.data, decode_choices=False
-                            )
-                            records.append((float(frame.timestamp), name, dict(decoded)))
-                        except (cantools.database.errors.DecodeError, ValueError) as exc:
-                            # A single frame with a data length mismatch (or
-                            # other per-frame decode problem) shouldn't nuke
-                            # an otherwise-good capture: skip and count it,
-                            # mirroring the `unknown` handling above.
-                            undecodable += 1
-                            logging.debug(
-                                "Skipping undecodable frame (arbitration_id=%s): %s: %s",
-                                frame.arbitration_id,
-                                type(exc).__name__,
-                                exc,
-                            )
-                            continue
-            except (struct.error, ValueError, cantools.errors.Error) as exc:
-                # Empirically observed across malformed/truncated .blf and
-                # .asc captures: struct.error and ValueError escape
-                # can.LogReader(...) construction (corrupt/inconsistent BLF
-                # headers, unrecognized capture extensions) or frame
-                # iteration (non-hex ASC frame data). These share no common
-                # base narrower than Exception, so translate either of them
-                # into a single clean, typed error instead of letting a
-                # can/cantools-internal exception escape.
-                raise errors.InvalidPathError(
-                    f"{self._path} could not be read as a CAN capture: "
-                    f"{type(exc).__name__}: {exc}"
-                ) from exc
-            if unknown:
-                logging.info("Skipped %d frames with IDs not in the DBC", unknown)
-            if undecodable:
-                logging.info("Skipped %d frames that failed to decode", undecodable)
-            records.sort(key=lambda record: record[0])
-            self._records = records
-        return self._records
+    def _decoded_frames(self) -> Iterator[tuple[float, str, dict[str, Any]]]:
+        """Stream (timestamp, message_name, decoded_signals) without storing them."""
+        known = {message.frame_id: message.name for message in self.database.messages}
+        unknown = 0
+        undecodable = 0
+        try:
+            # This region wraps library parse calls over untrusted input
+            # (the capture file itself), so failures here are translated
+            # into a clean, typed error rather than leaking a can/cantools
+            # traceback. It's scoped to STRUCTURAL capture failures only:
+            # the file can't be opened, or frame iteration itself breaks
+            # down (corrupt/truncated container). A single frame that
+            # fails to decode is handled by the inner skip-and-count
+            # below and never reaches this except clause.
+            with can.LogReader(self._path) as reader:
+                for frame in reader:
+                    name = known.get(frame.arbitration_id)
+                    if name is None:
+                        unknown += 1
+                        continue
+                    try:
+                        decoded = self.database.decode_message(
+                            frame.arbitration_id, frame.data, decode_choices=False
+                        )
+                    except (cantools.database.errors.DecodeError, ValueError) as exc:
+                        # A single frame with a data length mismatch (or
+                        # other per-frame decode problem) shouldn't nuke
+                        # an otherwise-good capture: skip and count it,
+                        # mirroring the `unknown` handling above.
+                        undecodable += 1
+                        logging.debug(
+                            "Skipping undecodable frame (arbitration_id=%s): %s: %s",
+                            frame.arbitration_id,
+                            type(exc).__name__,
+                            exc,
+                        )
+                        continue
+                    yield (float(frame.timestamp), name, dict(decoded))
+        except (struct.error, ValueError, cantools.errors.Error) as exc:
+            # Empirically observed across malformed/truncated .blf and
+            # .asc captures: struct.error and ValueError escape
+            # can.LogReader(...) construction (corrupt/inconsistent BLF
+            # headers, unrecognized capture extensions) or frame
+            # iteration (non-hex ASC frame data). These share no common
+            # base narrower than Exception, so translate either of them
+            # into a single clean, typed error instead of letting a
+            # can/cantools-internal exception escape.
+            raise errors.InvalidPathError(
+                f"{self._path} could not be read as a CAN capture: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        if unknown:
+            logging.info("Skipped %d frames with IDs not in the DBC", unknown)
+        if undecodable:
+            logging.info("Skipped %d frames that failed to decode", undecodable)
+
+    @functools.cached_property
+    def stats(self) -> tuple[int, float, float]:
+        """(decodable frame count, first timestamp, last timestamp), one pass, O(1) memory.
+
+        Decode is still attempted per frame so the count matches records()
+        exactly; the decoded values are discarded immediately (#134).
+        """
+        count = 0
+        start = math.inf
+        end = -math.inf
+        for timestamp, _, _ in self._decoded_frames():
+            count += 1
+            start = min(start, timestamp)
+            end = max(end, timestamp)
+        if not count:
+            return (0, 0.0, 0.0)
+        return (count, start, end)
+
+    def records(
+        self, start_seconds: float | None = None, end_seconds: float | None = None
+    ) -> list[tuple[float, str, dict[str, Any]]]:
+        """(timestamp, message_name, decoded_signals) in the window, sorted by time.
+
+        Decoded per call and NOT cached on the object: repeated-query
+        performance comes from the on-disk Arrow cache in to_duckdb (#134).
+        """
+        records = [
+            record
+            for record in self._decoded_frames()
+            if (start_seconds is None or record[0] >= start_seconds)
+            and (end_seconds is None or record[0] <= end_seconds)
+        ]
+        records.sort(key=lambda record: record[0])
+        return records
 
 
 class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
@@ -140,19 +170,17 @@ class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
     @property
     def total_message_count(self) -> int:
         """Return the number of decodable frames."""
-        return len(self._log.records)
+        return self._log.stats[0]
 
     @functools.cached_property
     def start_seconds(self) -> float:
         """Return the first frame's timestamp in seconds."""
-        records = self._log.records
-        return records[0][0] if records else 0.0
+        return self._log.stats[1]
 
     @functools.cached_property
     def end_seconds(self) -> float:
         """Return the last frame's timestamp in seconds."""
-        records = self._log.records
-        return records[-1][0] if records else 0.0
+        return self._log.stats[2]
 
     def build(self) -> CanLog:
         """Return the decoded log."""

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -97,8 +97,7 @@ class CanLog:
             # into a single clean, typed error instead of letting a
             # can/cantools-internal exception escape.
             raise errors.InvalidPathError(
-                f"{self._path} could not be read as a CAN capture: "
-                f"{type(exc).__name__}: {exc}"
+                f"{self._path} could not be read as a CAN capture: {type(exc).__name__}: {exc}"
             ) from exc
         if unknown:
             logging.info("Skipped %d frames with IDs not in the DBC", unknown)

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -7,6 +7,7 @@ raw bus capture becomes queryable like any other source. Requires the optional
 """
 
 import functools
+import heapq
 import logging
 import math
 import pathlib
@@ -140,6 +141,35 @@ class CanLog:
     def topic_message_counts(self) -> dict[str, int]:
         """Decoded frame count per DBC message name, from the same pass as `stats` (#134)."""
         return self._frame_stats[3]
+
+    def iter_records(
+        self,
+        start_seconds: float | None = None,
+        end_seconds: float | None = None,
+        reorder_buffer: int = 10_000,
+    ) -> Iterator[tuple[float, str, dict[str, Any]]]:
+        """Stream windowed records in timestamp order with bounded memory.
+
+        CAN captures are written (near-)chronologically; a bounded min-heap
+        absorbs local interleave across channels. A frame more than
+        ``reorder_buffer`` positions out of order would be yielded late, but
+        captures that disordered are not produced by known tooling. Peak
+        memory is the heap, not the capture (Codex review on #156).
+        """
+        heap: list[tuple[float, int, tuple[float, str, dict[str, Any]]]] = []
+        counter = 0
+        for record in self._decoded_frames():
+            timestamp = record[0]
+            if start_seconds is not None and timestamp < start_seconds:
+                continue
+            if end_seconds is not None and timestamp > end_seconds:
+                continue
+            heapq.heappush(heap, (timestamp, counter, record))
+            counter += 1
+            if len(heap) > reorder_buffer:
+                yield heapq.heappop(heap)[2]
+        while heap:
+            yield heapq.heappop(heap)[2]
 
     def records(
         self, start_seconds: float | None = None, end_seconds: float | None = None

--- a/src/source/automotive/can.py
+++ b/src/source/automotive/can.py
@@ -106,22 +106,41 @@ class CanLog:
             logging.info("Skipped %d frames that failed to decode", undecodable)
 
     @functools.cached_property
+    def _frame_stats(self) -> tuple[int, float, float, dict[str, int]]:
+        """One decode pass: (count, first timestamp, last timestamp, per-topic counts).
+
+        Backs both `stats` and `topic_message_counts` so enumerating N topics
+        costs one decode pass total, not N (#134). Memory for the per-topic
+        dict is bounded by the number of distinct DBC message names, not file
+        size, so it stays within the streaming design.
+        """
+        count = 0
+        start = math.inf
+        end = -math.inf
+        topic_counts: dict[str, int] = {}
+        for timestamp, name, _ in self._decoded_frames():
+            count += 1
+            start = min(start, timestamp)
+            end = max(end, timestamp)
+            topic_counts[name] = topic_counts.get(name, 0) + 1
+        if not count:
+            return (0, 0.0, 0.0, {})
+        return (count, start, end, topic_counts)
+
+    @functools.cached_property
     def stats(self) -> tuple[int, float, float]:
         """(decodable frame count, first timestamp, last timestamp), one pass, O(1) memory.
 
         Decode is still attempted per frame so the count matches records()
         exactly; the decoded values are discarded immediately (#134).
         """
-        count = 0
-        start = math.inf
-        end = -math.inf
-        for timestamp, _, _ in self._decoded_frames():
-            count += 1
-            start = min(start, timestamp)
-            end = max(end, timestamp)
-        if not count:
-            return (0, 0.0, 0.0)
+        count, start, end, _ = self._frame_stats
         return (count, start, end)
+
+    @functools.cached_property
+    def topic_message_counts(self) -> dict[str, int]:
+        """Decoded frame count per DBC message name, from the same pass as `stats` (#134)."""
+        return self._frame_stats[3]
 
     def records(
         self, start_seconds: float | None = None, end_seconds: float | None = None

--- a/src/source/automotive/mf4.py
+++ b/src/source/automotive/mf4.py
@@ -43,8 +43,7 @@ class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
             # typed error instead of letting an asammdf-internal traceback
             # escape.
             raise errors.InvalidPathError(
-                f"{self.path} could not be parsed as an ASAM MDF file: "
-                f"{type(exc).__name__}: {exc}"
+                f"{self.path} could not be parsed as an ASAM MDF file: {type(exc).__name__}: {exc}"
             ) from exc
 
     @property
@@ -79,8 +78,13 @@ class SourceFactory(base.BoundedSourceFactory, base.FileBasedSourceFactory):
     def end_seconds(self) -> float:
         """Return the epoch seconds of the last sample in any channel group."""
         last = 0.0
-        for index in range(len(self._mdf.groups)):
-            master = self._mdf.get_master(index)
+        for index, group in enumerate(self._mdf.groups):
+            cycles = group.channel_group.cycles_nr
+            if not cycles:
+                continue
+            # Read only the final master sample instead of the whole time
+            # array per group (#134).
+            master = self._mdf.get_master(index, record_offset=cycles - 1, record_count=1)
             if len(master):
                 last = max(last, float(master[-1]))
         return self.start_seconds + last

--- a/src/source/mcap.py
+++ b/src/source/mcap.py
@@ -36,9 +36,7 @@ def decompress(file: pathlib.Path) -> pathlib.Path:
     re-decompressed while repeat reads are free. The source file is never modified.
     """
     stat = file.stat()
-    key = str(
-        uuid.uuid5(uuid.NAMESPACE_OID, f"{file.resolve()}_{stat.st_size}_{stat.st_mtime_ns}")
-    )
+    key = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{file.resolve()}_{stat.st_size}_{stat.st_mtime_ns}"))
     output = pathlib.Path(settings.CACHE_DIRECTORY) / "decompressed" / key / file.stem
     if output.exists():
         return output
@@ -64,8 +62,7 @@ class McapBag(BaseModel):
         else:
             candidates = sorted([*self.path.glob("*.mcap"), *self.path.glob("*.mcap.zstd")])
         return [
-            decompress(file) if file.name.endswith(".mcap.zstd") else file
-            for file in candidates
+            decompress(file) if file.name.endswith(".mcap.zstd") else file for file in candidates
         ]
 
     def __hash__(self) -> int:

--- a/src/source/postgres.py
+++ b/src/source/postgres.py
@@ -71,9 +71,7 @@ def attach(url: str) -> str:
     duckdb.load_extension("postgres")
     name = attach_name(url)
     safe_url = url.replace("'", "''")
-    duckdb.execute(
-        f"ATTACH IF NOT EXISTS '{safe_url}' AS {name} (TYPE postgres, READ_ONLY)"
-    )
+    duckdb.execute(f"ATTACH IF NOT EXISTS '{safe_url}' AS {name} (TYPE postgres, READ_ONLY)")
     return name
 
 

--- a/src/source/pyarrow/base.py
+++ b/src/source/pyarrow/base.py
@@ -1,5 +1,7 @@
 """Base class for PyArrow dataset source factories."""
 
+import logging
+import pathlib
 import time
 from collections.abc import Callable
 from datetime import datetime
@@ -69,6 +71,9 @@ class SourceFactory(base.FileBasedSourceFactory):
         self._exclude_invalid_files = exclude_invalid_files
         self._ignore_prefixes = ignore_prefixes or []
 
+        # Populated by _build(): files PyArrow silently excluded as invalid (#134).
+        self._excluded_file_count = 0
+
         # Timestamp parsing
         self._timestamp_access_path = timestamp_access_path
         self._timestamp_format = timestamp_format
@@ -84,6 +89,7 @@ class SourceFactory(base.FileBasedSourceFactory):
             "ignore_prefixes": self._ignore_prefixes,
             "timestamp_access_path": self._timestamp_access_path,
             "timestamp_format": self._timestamp_format,
+            "excluded_file_count": self._excluded_file_count,
         }
 
     def _extract_timestamp_fn(self) -> Callable[[dict[str, Any]], float]:
@@ -143,7 +149,40 @@ class SourceFactory(base.FileBasedSourceFactory):
                 f"{type(exc).__name__}: {exc}"
             ) from exc
 
+        # exclude_invalid_files=True silently drops files that fail the format
+        # check. Silent-empty is indistinguishable from "no events found" to a
+        # caller, so: zero readable files is an error; a partial drop keeps the
+        # good files but is logged and counted in metadata (#134).
+        discovered = getattr(dataset, "files", None)
+        if self._exclude_invalid_files and discovered is not None:
+            if not discovered:
+                raise errors.InvalidPathError(
+                    f"{self.path} contains no readable {file_format} files: "
+                    "every candidate file was excluded as invalid"
+                )
+            self._excluded_file_count = max(0, self._candidate_file_count() - len(discovered))
+            if self._excluded_file_count:
+                logging.warning(
+                    "%d file(s) under %s were excluded as invalid %s and are absent "
+                    "from query results (see excluded_file_count in source metadata)",
+                    self._excluded_file_count,
+                    self.path,
+                    file_format,
+                )
+
         return PyArrowDataset(
             dataset=dataset,
             extract_timestamp_seconds=self._extract_timestamp_fn(),
         )
+
+    def _candidate_file_count(self) -> int:
+        """Count files the dataset discovery would have considered."""
+        if self.path.is_file():
+            return 1
+        ignored = tuple(self._ignore_prefixes)
+
+        def _is_ignored(file: pathlib.Path) -> bool:
+            parts = file.relative_to(self.path).parts
+            return bool(ignored) and any(part.startswith(ignored) for part in parts)
+
+        return sum(1 for file in self.path.rglob("*") if file.is_file() and not _is_ignored(file))

--- a/src/source/ros/parse.py
+++ b/src/source/ros/parse.py
@@ -116,20 +116,22 @@ def parse_file(path: str | pathlib.Path) -> list[LogRecord]:
 
     Unmatched lines are appended to the previous record's message (multi-line
     messages such as tracebacks); unmatched lines before the first record are
-    dropped.
+    dropped. The file is streamed line-by-line so peak memory is the records
+    themselves, not multiples of the file size (#134).
     """
     path = pathlib.Path(path)
     records: list[LogRecord] = []
-    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        line = raw_line.rstrip()
-        if not line:
-            continue
-        record = parse_line(line, fallback_node=path.stem)
-        if record is not None:
-            record.file = path.name
-            records.append(record)
-        elif records:
-            records[-1].message += "\n" + line
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for raw_line in f:
+            line = raw_line.rstrip()
+            if not line:
+                continue
+            record = parse_line(line, fallback_node=path.stem)
+            if record is not None:
+                record.file = path.name
+                records.append(record)
+            elif records:
+                records[-1].message += "\n" + line
     return records
 
 

--- a/src/topic/automotive/can.py
+++ b/src/topic/automotive/can.py
@@ -14,7 +14,7 @@ class TopicRegistry(base.TopicRegistry):
 
     def available_topics(self, data_source: CanLog) -> list[str]:
         """Return the DBC message names observed in the capture."""
-        return sorted({name for _, name, _ in data_source.records})
+        return sorted({name for _, name, _ in data_source.records()})
 
     def native_type_name(self, topic: str, data_source: CanLog) -> str:
         """Return the native type name for the given topic."""
@@ -24,7 +24,7 @@ class TopicRegistry(base.TopicRegistry):
     def message_count(self, topic: str, data_source: CanLog) -> int | None:
         """Return the number of decoded frames for the message."""
         self._message(topic, data_source)
-        return sum(1 for _, name, _ in data_source.records if name == topic)
+        return sum(1 for _, name, _ in data_source.records() if name == topic)
 
     def struct(self, topic: str, data_source: CanLog) -> pa.StructType:
         """Return one float field per DBC signal, with units attached as metadata."""

--- a/src/topic/automotive/can.py
+++ b/src/topic/automotive/can.py
@@ -14,7 +14,7 @@ class TopicRegistry(base.TopicRegistry):
 
     def available_topics(self, data_source: CanLog) -> list[str]:
         """Return the DBC message names observed in the capture."""
-        return sorted({name for _, name, _ in data_source.records()})
+        return sorted(data_source.topic_message_counts)
 
     def native_type_name(self, topic: str, data_source: CanLog) -> str:
         """Return the native type name for the given topic."""
@@ -24,7 +24,7 @@ class TopicRegistry(base.TopicRegistry):
     def message_count(self, topic: str, data_source: CanLog) -> int | None:
         """Return the number of decoded frames for the message."""
         self._message(topic, data_source)
-        return sum(1 for _, name, _ in data_source.records() if name == topic)
+        return data_source.topic_message_counts.get(topic, 0)
 
     def struct(self, topic: str, data_source: CanLog) -> pa.StructType:
         """Return one float field per DBC signal, with units attached as metadata."""

--- a/src/topic/automotive/mf4.py
+++ b/src/topic/automotive/mf4.py
@@ -68,7 +68,9 @@ class TopicRegistry(base.TopicRegistry):
         index = self._group_index(topic, data_source)
         fields = []
         for name in _channels(data_source, index):
-            signal = data_source.get(name, group=index, raw=False)
+            # One sample is enough for dtype/unit/comment; loading the full
+            # channel here made schema inference O(file) in memory (#134).
+            signal = data_source.get(name, group=index, raw=False, record_offset=0, record_count=1)
             fields.append(
                 pa.field(
                     name,

--- a/src/topic/mcap.py
+++ b/src/topic/mcap.py
@@ -174,9 +174,7 @@ class TopicRegistry(base.TopicRegistry):
                 )
                 for file_descriptor in file_descriptor_set.file:
                     pool.Add(file_descriptor)
-                descriptor = pool.FindMessageTypeByName(
-                    self.native_type_name(topic, data_source)
-                )
+                descriptor = pool.FindMessageTypeByName(self.native_type_name(topic, data_source))
                 return protobuf_schema.to_pa_struct(descriptor)
 
             case "jsonschema":

--- a/src/topic/postgres.py
+++ b/src/topic/postgres.py
@@ -17,9 +17,7 @@ class TopicRegistry(base.TopicRegistry):
 
     def available_topics(self, data_source: PostgresDatabase) -> list[str]:
         """Return a list of available topic (table) names."""
-        return [
-            data_source.topic_of(schema, table) for schema, table in data_source.tables()
-        ]
+        return [data_source.topic_of(schema, table) for schema, table in data_source.tables()]
 
     def _require_topic(self, topic: str, data_source: PostgresDatabase) -> None:
         if topic not in self.available_topics(data_source):
@@ -51,9 +49,7 @@ class TopicRegistry(base.TopicRegistry):
         self._require_topic(topic, data_source)
         timestamp_column = data_source.timestamp_column(topic)
         lines = [f"table {topic} (timestamp column: {timestamp_column})"]
-        lines += [
-            f"  {name}: {type_}" for name, type_ in data_source.columns(topic)
-        ]
+        lines += [f"  {name}: {type_}" for name, type_ in data_source.columns(topic)]
         return "\n".join(lines)
 
 

--- a/test/adversarial/test_can_parse.py
+++ b/test/adversarial/test_can_parse.py
@@ -138,7 +138,7 @@ def test_empty_blf_raises_clean_error(tmp_path: pathlib.Path) -> None:
 
     log = can_source.CanLog(path=str(blf), dbc=str(dbc))
     with pytest.raises(errors.InvalidPathError):
-        _ = log.records
+        _ = log.records()
 
 
 def test_corrupt_blf_header_raises_clean_error(tmp_path: pathlib.Path) -> None:
@@ -153,7 +153,7 @@ def test_corrupt_blf_header_raises_clean_error(tmp_path: pathlib.Path) -> None:
 
     log = can_source.CanLog(path=str(blf), dbc=str(dbc))
     with pytest.raises(errors.InvalidPathError):
-        _ = log.records
+        _ = log.records()
 
 
 def test_unrecognized_capture_extension_raises_clean_error(tmp_path: pathlib.Path) -> None:
@@ -164,7 +164,7 @@ def test_unrecognized_capture_extension_raises_clean_error(tmp_path: pathlib.Pat
 
     log = can_source.CanLog(path=str(capture), dbc=str(dbc))
     with pytest.raises(errors.InvalidPathError):
-        _ = log.records
+        _ = log.records()
 
 
 def test_asc_with_non_hex_frame_data_raises_clean_error(tmp_path: pathlib.Path) -> None:
@@ -185,7 +185,7 @@ def test_asc_with_non_hex_frame_data_raises_clean_error(tmp_path: pathlib.Path) 
 
     log = can_source.CanLog(path=str(asc), dbc=str(dbc))
     with pytest.raises(errors.InvalidPathError):
-        _ = log.records
+        _ = log.records()
 
 
 def test_frame_data_length_mismatch_is_skipped_not_fatal(tmp_path: pathlib.Path) -> None:
@@ -207,7 +207,7 @@ def test_frame_data_length_mismatch_is_skipped_not_fatal(tmp_path: pathlib.Path)
     blf = _write_blf(tmp_path, "mixed.blf", [*good, bad])
 
     log = can_source.CanLog(path=str(blf), dbc=str(dbc))
-    records = log.records
+    records = log.records()
 
     assert len(records) == len(good)
     assert all(name == "EngineData" for _, name, _ in records)
@@ -219,7 +219,7 @@ def test_missing_capture_file_raises_file_not_found_already(tmp_path: pathlib.Pa
     log = can_source.CanLog(path=str(tmp_path / "does_not_exist.blf"), dbc=str(dbc))
 
     with pytest.raises(FileNotFoundError):
-        _ = log.records
+        _ = log.records()
 
 
 def test_asc_with_only_unrecognized_lines_is_already_clean(tmp_path: pathlib.Path) -> None:
@@ -232,7 +232,7 @@ def test_asc_with_only_unrecognized_lines_is_already_clean(tmp_path: pathlib.Pat
     asc.write_text("this is not an asc file\nrandom garbage\n\x00\x01\x02")
 
     log = can_source.CanLog(path=str(asc), dbc=str(dbc))
-    assert log.records == []
+    assert log.records() == []
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +246,7 @@ def test_valid_dbc_and_capture_still_decode_correctly(tmp_path: pathlib.Path) ->
     blf = _write_valid_blf(tmp_path)
 
     log = can_source.CanLog(path=str(blf), dbc=str(dbc))
-    records = log.records
+    records = log.records()
 
     assert len(records) == 1
     timestamp, name, signals = records[0]

--- a/test/adversarial/test_mcp_surface.py
+++ b/test/adversarial/test_mcp_surface.py
@@ -24,6 +24,7 @@ def test_describe_data_source_empty_path_raises() -> None:
 def test_query_messages_bad_sql() -> None:
     # Use a real sample so the failure is in SQL handling, not path resolution.
     import pathlib
+
     sample = pathlib.Path("data/sample/ros2/mcap")
     if not sample.exists():
         pytest.skip("ros2 sample not present")
@@ -33,6 +34,7 @@ def test_query_messages_bad_sql() -> None:
 
 def test_read_loggings_inverted_window() -> None:
     import pathlib
+
     sample = pathlib.Path("data/sample/ros2/mcap")
     if not sample.exists():
         pytest.skip("ros2 sample not present")

--- a/test/adversarial/test_pyarrow_sources.py
+++ b/test/adversarial/test_pyarrow_sources.py
@@ -15,12 +15,17 @@ unhardened code):
   entirely on ``exclude_invalid_files``:
 
   * ``exclude_invalid_files=True`` (the default): PyArrow performs its own
-    internal per-file validity check during dataset construction, silently
-    EXCLUDES any file that fails it, and the result is simply an empty
-    dataset (0 rows, empty schema) -- no exception at all. This means most
-    single malformed files never crash under default settings; they just
-    silently vanish from the dataset. That's a (separate, pre-existing) data
-    -correctness concern, not a crash, and is out of scope here.
+    internal per-file validity check during dataset construction and
+    silently EXCLUDES any file that fails it. ``SourceFactory._build()``
+    (``src/source/pyarrow/base.py``) now closes that silent-data-loss gap
+    (#134): if EVERY candidate file was excluded, the resulting dataset
+    would be indistinguishable from "path legitimately has no matching
+    events", so ``_build()`` raises a typed ``errors.InvalidPathError``
+    instead of returning an empty dataset. If only SOME files under a
+    directory were excluded, the good files still build normally, but the
+    drop is surfaced via a ``logging.warning`` call and recorded as
+    ``excluded_file_count`` in ``SourceFactory.metadata`` so it isn't
+    silently invisible to a caller.
   * ``exclude_invalid_files=False`` (an explicit, first-class, user-settable
     constructor argument on both ``csv.SourceFactory`` and
     ``json.SourceFactory`` -- see their docstrings, which already warn "this
@@ -55,6 +60,7 @@ Arrow-specific exceptions) share the common base `pyarrow.lib.ArrowException`
 that is what the hardening catches.
 """
 
+import logging
 import pathlib
 
 import pytest
@@ -248,30 +254,45 @@ def test_csv_header_only_file_does_not_crash_already(tmp_path: pathlib.Path) -> 
     assert messages == []
 
 
-def test_malformed_file_default_exclude_invalid_files_yields_no_crash_already(
+def test_malformed_single_file_raises_instead_of_silently_dropping(
     tmp_path: pathlib.Path,
 ) -> None:
-    """Under the default exclude_invalid_files=True, PyArrow silently drops a
-    malformed single file from the dataset instead of raising -- this is a
-    (separate, pre-existing) silent-data-loss concern, not a crash, and is
-    documented here as out of scope for this hardening pass.
+    """#134: a source whose every file is excluded is an error, not 0 rows.
+
+    Uses the same ragged-rows fixture as ``test_csv_ragged_rows_raises_clean_error``:
+    it passes the lightweight Python-side ``is_csv_file`` sniffer (so
+    ``SourceFactory.__init__`` accepts the path) but PyArrow's own internal
+    validity check excludes it during ``ds.dataset()`` discovery under the
+    default ``exclude_invalid_files=True``.
     """
     bad = tmp_path / "ragged.csv"
     rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], "99,100"]
     bad.write_text("\n".join(rows) + "\n")
 
     factory = csv_source.SourceFactory(str(bad))  # default exclude_invalid_files=True
-    data_source = factory.build()
-    message_dataset = MessageDataset()
-    messages = list(
-        message_dataset._messages(
-            data_source,
-            topics=["message"],
-            start_seconds_inclusive=None,
-            end_seconds_inclusive=None,
-        )
-    )
-    assert messages == []
+    with pytest.raises(errors.InvalidPathError, match="excluded as invalid"):
+        factory.build()
+
+
+def test_directory_with_one_bad_file_warns_and_counts(
+    tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#134: partial drops keep working but leave a warning and metadata count."""
+    (tmp_path / "good.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    rows = ["a,b,c", *[f"{i},{i + 1},{i + 2}" for i in range(20)], "99,100"]
+    (tmp_path / "ragged.csv").write_text("\n".join(rows) + "\n")
+    factory = csv_source.SourceFactory(str(tmp_path))
+    with caplog.at_level(logging.WARNING):
+        built = factory.build()
+    assert built.dataset.count_rows() == 1
+    assert factory.metadata["excluded_file_count"] == 1
+    assert any("excluded" in record.message for record in caplog.records)
+
+
+def test_metadata_excluded_count_defaults_to_zero(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "good.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    factory = csv_source.SourceFactory(str(tmp_path))
+    assert factory.metadata["excluded_file_count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/test/adversarial/test_pyarrow_sources.py
+++ b/test/adversarial/test_pyarrow_sources.py
@@ -337,3 +337,22 @@ def test_valid_json_file_still_builds_and_materializes_correctly(tmp_path: pathl
     )
     assert len(messages) == 2
     assert {msg["a"] for _, _, msg in messages} == {1, 2}
+
+
+def test_describe_surfaces_excluded_file_count(tmp_path: pathlib.Path) -> None:
+    """Codex review on #156: describe_data_source must report exclusions.
+
+    server.py evaluated factory.metadata before factory.build(), so the
+    excluded_file_count the triage workflow tells agents to check was
+    always 0 in the describe response.
+    """
+    import server
+
+    (tmp_path / "good.csv").write_text("t,a\n1.0,2\n", encoding="utf-8")
+    # the first 4 KiB is valid CSV so the cheap sniff (is_csv_file reads 4096
+    # bytes) passes; the binary tail beyond it fails PyArrow's deeper file
+    # inspection, so the file is excluded at build
+    (tmp_path / "bad.csv").write_bytes(b"t,a\n" + b"1,2\n" * 5000 + b"\x00\xff" * 200)
+    rendered = server.describe_data_source(str(tmp_path))
+    joined = " ".join(str(message) for message in rendered)
+    assert '"excluded_file_count": 1' in joined  # metadata renders as JSON

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -210,3 +210,28 @@ def test_mf4_window_loads_only_the_slice(
     for kwargs in calls:
         assert kwargs.get("record_count") is not None
         assert kwargs["record_count"] < 20, "full-channel load defeats window slicing"
+
+
+def test_mf4_struct_and_end_seconds_read_one_sample(
+    small_mf4: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src.source.automotive.mf4 import SourceFactory
+    from src.topic.automotive.mf4 import TopicRegistry
+
+    factory = SourceFactory(str(small_mf4))
+    mdf = factory.build()
+
+    get_counts = []
+    original_get = mdf.get
+
+    def spying_get(*args: object, **kwargs: object) -> object:
+        get_counts.append(kwargs.get("record_count"))
+        return original_get(*args, **kwargs)
+
+    monkeypatch.setattr(mdf, "get", spying_get)
+    struct = TopicRegistry().struct("Engine", mdf)
+    assert struct.field("speed").type is not None
+    assert all(count == 1 for count in get_counts), "struct() must load one sample per channel"
+
+    end = factory.end_seconds
+    assert end == factory.start_seconds + 9.5  # last timestamp in the fixture

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -18,6 +18,7 @@ pytest.importorskip("can")
 pytest.importorskip("cantools")
 
 from src.source.automotive import can as can_source
+from src.topic.automotive.can import TopicRegistry
 from test.adversarial.test_can_parse import _write_valid_dbc
 
 
@@ -107,3 +108,31 @@ def test_can_records_window_filters_before_sort(
     mid = everything[len(everything) // 2][0]
     windowed = log.records(start_seconds=mid)
     assert windowed == [r for r in everything if r[0] >= mid]
+
+
+def test_can_topic_counts_come_from_one_pass_not_records(
+    valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Enumerating topics/counts must not re-decode via records() per topic (#134)."""
+    capture, dbc = valid_asc_and_dbc
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+
+    # Ground truth, independently derived from a full decode.
+    expected_counts: dict[str, int] = {}
+    for _, name, _ in log.records():
+        expected_counts[name] = expected_counts.get(name, 0) + 1
+
+    topic_counts = log.topic_message_counts
+    assert topic_counts == expected_counts
+    assert sum(topic_counts.values()) == log.stats[0]
+
+    registry = TopicRegistry()
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("records() must not be called by topic enumeration")
+
+    monkeypatch.setattr(log, "records", _boom)
+
+    assert sorted(registry.available_topics(log)) == sorted(expected_counts)
+    for name, count in expected_counts.items():
+        assert registry.message_count(name, log) == count

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -241,3 +241,40 @@ def test_mf4_struct_and_end_seconds_read_one_sample(
 
     end = factory.end_seconds
     assert end == factory.start_seconds + 9.5  # last timestamp in the fixture
+
+
+def test_record_batches_row_count_is_clamped() -> None:
+    """#134 addendum: the byte-target batch estimate must be clamped by row count.
+
+    Small rows (e.g. IMU) make the 1 GB Arrow-byte target resolve to millions of
+    rows per batch, which accumulate as Python objects at 10-20x overhead before
+    each flush: a 416 MB / 1.2M-message bag OOM-killed an 8 GB server (matrix,
+    2026-08-14). Batches must flush at MAX_ARROW_RECORD_BATCH_SIZE_COUNT rows
+    regardless of the byte estimate.
+    """
+    import pyarrow as pa
+
+    from settings import settings
+    from src.message.base import MessageDataset
+
+    class _Dataset(MessageDataset):
+        def _messages(self, *args, **kwargs):  # pragma: no cover - unused
+            raise NotImplementedError
+
+        def _to_json(self, message, struct):
+            return message
+
+    schema = pa.schema(
+        [
+            pa.field(settings.TIMESTAMP_SECONDS_COLUMN_NAME, pa.float64()),
+            pa.field("/imu", pa.struct([pa.field("x", pa.float64())])),
+        ]
+    )
+    total = 300_000
+    messages = (("/imu", float(i), {"x": 1.0}) for i in range(total))
+    batches = list(_Dataset()._record_batches(messages, schema, ffill=False))
+
+    assert sum(batch.num_rows for batch in batches) == total
+    cap = settings.MAX_ARROW_RECORD_BATCH_SIZE_COUNT
+    oversized = [batch.num_rows for batch in batches if batch.num_rows > cap]
+    assert not oversized, f"batches exceed the row cap ({cap}): {oversized}"

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -9,6 +9,7 @@ new one ~1.2x, so a 2x threshold cleanly separates them.
 
 import pathlib
 import tracemalloc
+from typing import NoReturn
 from typing import Any
 
 import numpy as np
@@ -258,10 +259,10 @@ def test_record_batches_row_count_is_clamped() -> None:
     from src.message.base import MessageDataset
 
     class _Dataset(MessageDataset):
-        def _messages(self, *args, **kwargs):  # pragma: no cover - unused
+        def _messages(self, *args: object, **kwargs: object) -> NoReturn:  # pragma: no cover
             raise NotImplementedError
 
-        def _to_json(self, message, struct):
+        def _to_json(self, message: object, struct: object) -> object:
             return message
 
     schema = pa.schema(

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -16,13 +16,6 @@ import pytest
 
 from src.source.ros.parse import parse_file
 
-pytest.importorskip("can")
-pytest.importorskip("cantools")
-
-from src.source.automotive import can as can_source
-from src.topic.automotive.can import TopicRegistry
-from test.adversarial.test_can_parse import _write_valid_dbc
-
 
 def test_parse_file_streams_instead_of_slurping(tmp_path: pathlib.Path) -> None:
     message = "x" * 10_000
@@ -59,6 +52,10 @@ def test_parse_file_streams_instead_of_slurping(tmp_path: pathlib.Path) -> None:
 
 @pytest.fixture
 def valid_asc_and_dbc(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    pytest.importorskip("can")
+    pytest.importorskip("cantools")
+    from test.adversarial.test_can_parse import _write_valid_dbc
+
     dbc = _write_valid_dbc(tmp_path)
     asc = tmp_path / "valid.asc"
     lines = [
@@ -76,6 +73,8 @@ def valid_asc_and_dbc(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Pat
 
 def test_can_stats_matches_records(valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path]) -> None:
     """stats must equal what a full decode reports, without storing frames."""
+    from src.source.automotive import can as can_source
+
     capture, dbc = valid_asc_and_dbc
     log = can_source.CanLog(path=str(capture), dbc=str(dbc))
     records = log.records()
@@ -89,6 +88,8 @@ def test_can_metadata_does_not_materialize_records(
     valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """describe-path properties must never build the full decoded list."""
+    from src.source.automotive import can as can_source
+
     capture, dbc = valid_asc_and_dbc
     factory = can_source.SourceFactory(path=str(capture), dbc=str(dbc))
 
@@ -104,6 +105,8 @@ def test_can_metadata_does_not_materialize_records(
 def test_can_records_window_filters_before_sort(
     valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path],
 ) -> None:
+    from src.source.automotive import can as can_source
+
     capture, dbc = valid_asc_and_dbc
     log = can_source.CanLog(path=str(capture), dbc=str(dbc))
     everything = log.records()
@@ -116,6 +119,9 @@ def test_can_topic_counts_come_from_one_pass_not_records(
     valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Enumerating topics/counts must not re-decode via records() per topic (#134)."""
+    from src.source.automotive import can as can_source
+    from src.topic.automotive.can import TopicRegistry
+
     capture, dbc = valid_asc_and_dbc
     log = can_source.CanLog(path=str(capture), dbc=str(dbc))
 

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -10,7 +10,15 @@ new one ~1.2x, so a 2x threshold cleanly separates them.
 import pathlib
 import tracemalloc
 
+import pytest
+
 from src.source.ros.parse import parse_file
+
+pytest.importorskip("can")
+pytest.importorskip("cantools")
+
+from src.source.automotive import can as can_source
+from test.adversarial.test_can_parse import _write_valid_dbc
 
 
 def test_parse_file_streams_instead_of_slurping(tmp_path: pathlib.Path) -> None:
@@ -30,3 +38,72 @@ def test_parse_file_streams_instead_of_slurping(tmp_path: pathlib.Path) -> None:
     assert len(records) == 2_000
     assert records[0].message == message
     assert peak < 2 * size, f"peak {peak} vs file {size}: parse_file is not streaming"
+
+
+# ---------------------------------------------------------------------------
+# CAN: one-pass metadata stats and windowed, uncached records (#134).
+#
+# ``valid_asc_and_dbc`` reuses ``_write_valid_dbc`` from test_can_parse.py
+# (a module-level function, imported directly). test_can_parse.py has no
+# reusable *valid* ASC-writing helper (only inline garbage/malformed ASC text
+# for its failure-path tests), so the ASC body here is written locally,
+# following the same frame-line format used there
+# (test_asc_with_non_hex_frame_data_raises_clean_error): hex-base timestamps,
+# arbitration id "64" (hex) = 100 (decimal) to match the DBC's ``BO_ 100
+# EngineData``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_asc_and_dbc(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    dbc = _write_valid_dbc(tmp_path)
+    asc = tmp_path / "valid.asc"
+    lines = [
+        "date Mon Jan 1 00:00:00 2024",
+        "base hex  timestamps absolute",
+        "no internal events logged",
+        "",
+    ]
+    for index, timestamp in enumerate((1.0, 2.0, 3.0, 4.0, 5.0)):
+        data = " ".join(f"{(byte + index) % 256:02X}" for byte in range(8))
+        lines.append(f"   {timestamp:.6f} 1  64             Rx   d 8 {data}")
+    asc.write_text("\n".join(lines) + "\n")
+    return asc, dbc
+
+
+def test_can_stats_matches_records(valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path]) -> None:
+    """stats must equal what a full decode reports, without storing frames."""
+    capture, dbc = valid_asc_and_dbc
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+    records = log.records()
+    count, start, end = log.stats
+    assert count == len(records)
+    assert start == records[0][0]
+    assert end == records[-1][0]
+
+
+def test_can_metadata_does_not_materialize_records(
+    valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """describe-path properties must never build the full decoded list."""
+    capture, dbc = valid_asc_and_dbc
+    factory = can_source.SourceFactory(path=str(capture), dbc=str(dbc))
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("records() must not be called by metadata paths")
+
+    monkeypatch.setattr(factory._log, "records", _boom)
+    assert factory.total_message_count > 0
+    assert factory.start_seconds <= factory.end_seconds
+    assert "dbc_messages" in factory.metadata
+
+
+def test_can_records_window_filters_before_sort(
+    valid_asc_and_dbc: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    capture, dbc = valid_asc_and_dbc
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+    everything = log.records()
+    mid = everything[len(everything) // 2][0]
+    windowed = log.records(start_seconds=mid)
+    assert windowed == [r for r in everything if r[0] >= mid]

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -278,3 +278,42 @@ def test_record_batches_row_count_is_clamped() -> None:
     cap = settings.MAX_ARROW_RECORD_BATCH_SIZE_COUNT
     oversized = [batch.num_rows for batch in batches if batch.num_rows > cap]
     assert not oversized, f"batches exceed the row cap ({cap}): {oversized}"
+
+
+def test_can_iter_records_streams_in_order(valid_asc_and_dbc: tuple) -> None:
+    """Codex review on #156: the CAN path must stream into Arrow batching.
+
+    records() materializes the full decoded list, so the record-batch row
+    clamp cannot bound CAN captures. iter_records() streams with a bounded
+    reorder heap instead; on (near-)chronological captures its output equals
+    the fully sorted list.
+    """
+    import inspect
+
+    from src.source.automotive import can as can_source
+
+    capture, dbc = valid_asc_and_dbc
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+    assert inspect.isgenerator(log.iter_records())
+    assert list(log.iter_records()) == log.records()
+    everything = log.records()
+    mid = everything[len(everything) // 2][0]
+    assert list(log.iter_records(start_seconds=mid)) == log.records(start_seconds=mid)
+
+
+def test_can_message_layer_streams_not_materializes(
+    valid_asc_and_dbc: tuple, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_messages must consume the streaming iterator, never the full list."""
+    from src.message.automotive.can import MessageDataset as CanMessages
+    from src.source.automotive import can as can_source
+
+    capture, dbc = valid_asc_and_dbc
+    log = can_source.CanLog(path=str(capture), dbc=str(dbc))
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("_messages must not materialize via records()")
+
+    monkeypatch.setattr(log, "records", _boom)
+    messages = list(CanMessages()._messages(log, ["EngineData"], None, None))
+    assert messages, "expected streamed messages"

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -9,8 +9,7 @@ new one ~1.2x, so a 2x threshold cleanly separates them.
 
 import pathlib
 import tracemalloc
-from typing import NoReturn
-from typing import Any
+from typing import Any, NoReturn
 
 import numpy as np
 import pytest

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -9,7 +9,9 @@ new one ~1.2x, so a 2x threshold cleanly separates them.
 
 import pathlib
 import tracemalloc
+from typing import Any
 
+import numpy as np
 import pytest
 
 from src.source.ros.parse import parse_file
@@ -136,3 +138,75 @@ def test_can_topic_counts_come_from_one_pass_not_records(
     assert sorted(registry.available_topics(log)) == sorted(expected_counts)
     for name, count in expected_counts.items():
         assert registry.message_count(name, log) == count
+
+
+# ---------------------------------------------------------------------------
+# MDF4: window-first channel slicing in the message stream (#134).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def small_mf4(tmp_path: pathlib.Path) -> pathlib.Path:
+    asammdf = pytest.importorskip("asammdf")
+    timestamps = np.arange(0.0, 10.0, 0.5)  # 20 samples, relative seconds
+    signal = asammdf.Signal(
+        samples=np.arange(len(timestamps), dtype=np.float64),
+        timestamps=timestamps,
+        name="speed",
+    )
+    mdf = asammdf.MDF()
+    mdf.append([signal], acq_name="Engine")
+    path = tmp_path / "small.mf4"
+    mdf.save(path, overwrite=True)
+    mdf.close()
+    return path
+
+
+def _mf4_messages(
+    path: pathlib.Path, start: float | None = None, end: float | None = None
+) -> list[tuple[str, float, dict[str, Any]]]:
+    from asammdf import MDF
+
+    from src.message.automotive.mf4 import MessageDataset
+
+    mdf = MDF(str(path))
+    try:
+        return list(MessageDataset()._messages(mdf, ["Engine"], start, end))
+    finally:
+        mdf.close()
+
+
+def test_mf4_window_equals_filtered_full_read(small_mf4: pathlib.Path) -> None:
+    from asammdf import MDF
+
+    start_epoch = MDF(str(small_mf4)).header.start_time.timestamp()
+    everything = _mf4_messages(small_mf4)
+    windowed = _mf4_messages(small_mf4, start_epoch + 2.0, start_epoch + 7.0)
+    assert windowed == [m for m in everything if start_epoch + 2.0 <= m[1] <= start_epoch + 7.0]
+    assert 0 < len(windowed) < len(everything)
+
+
+def test_mf4_window_loads_only_the_slice(
+    small_mf4: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Channel loads must pass record_offset/record_count for the window."""
+    from asammdf import MDF
+
+    mdf = MDF(str(small_mf4))
+    start_epoch = mdf.header.start_time.timestamp()
+    calls: list[dict[str, Any]] = []
+    original_get = mdf.get
+
+    def spying_get(*args: object, **kwargs: object) -> object:
+        calls.append(kwargs)
+        return original_get(*args, **kwargs)
+
+    monkeypatch.setattr(mdf, "get", spying_get)
+    from src.message.automotive.mf4 import MessageDataset
+
+    list(MessageDataset()._messages(mdf, ["Engine"], start_epoch + 2.0, start_epoch + 7.0))
+    mdf.close()
+    assert calls, "expected channel loads"
+    for kwargs in calls:
+        assert kwargs.get("record_count") is not None
+        assert kwargs["record_count"] < 20, "full-channel load defeats window slicing"

--- a/test/adversarial/test_resource_limits.py
+++ b/test/adversarial/test_resource_limits.py
@@ -1,0 +1,32 @@
+"""Resource-limit behavior (#134): memory scales with the query, not the file.
+
+Before hardening, parse_file() slurped the whole log via read_text().splitlines()
+(~3x file size peak: raw string + line list + records). After: it iterates the
+open handle, so peak is ~the records themselves plus one line. The test uses
+long messages so records ≈ file size; the old implementation peaks ≥3x and the
+new one ~1.2x, so a 2x threshold cleanly separates them.
+"""
+
+import pathlib
+import tracemalloc
+
+from src.source.ros.parse import parse_file
+
+
+def test_parse_file_streams_instead_of_slurping(tmp_path: pathlib.Path) -> None:
+    message = "x" * 10_000
+    line = f"[INFO] [1662400000.100000000] [talker]: {message}\n"
+    log = tmp_path / "big.log"
+    with open(log, "w", encoding="utf-8") as f:
+        for _ in range(2_000):
+            f.write(line)
+    size = log.stat().st_size  # ~20 MB
+
+    tracemalloc.start()
+    records = parse_file(log)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert len(records) == 2_000
+    assert records[0].message == message
+    assert peak < 2 * size, f"peak {peak} vs file {size}: parse_file is not streaming"

--- a/test/adversarial/test_secrets_redaction.py
+++ b/test/adversarial/test_secrets_redaction.py
@@ -247,9 +247,7 @@ def test_influxdb_connect_error_does_not_leak_token(monkeypatch: pytest.MonkeyPa
 
 
 def test_slack_rejects_non_http_webhook_without_echoing_it() -> None:
-    secret_looking_value = (
-        "ftp://hooks.example.com/services/T00/B00/s3cr3twebhooktoken"  # noqa: S105
-    )
+    secret_looking_value = "ftp://hooks.example.com/services/T00/B00/s3cr3twebhooktoken"  # noqa: S105
 
     with pytest.raises(ValueError, match="http") as excinfo:
         NotifySlack(webhook_url=secret_looking_value, message="x")

--- a/test/e2e/test_large_file_smoke.py
+++ b/test/e2e/test_large_file_smoke.py
@@ -41,9 +41,7 @@ def test_describe_and_windowed_query_on_large_file() -> None:
             )
         args["dbc"] = str(dbc_path)
 
-    factory = module.provide(
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", args
-    )
+    factory = module.provide(f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", args)
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
     # describe must complete without materializing the file

--- a/test/e2e/test_large_file_smoke.py
+++ b/test/e2e/test_large_file_smoke.py
@@ -1,0 +1,38 @@
+"""Optional local-only smoke test (#134): a real multi-GB log can be described
+and window-queried without exhausting memory. Skips unless the external
+fixture is present; never a CI gate.
+
+Point BAGEL_LARGE_FIXTURE at any real large capture (.blf/.asc with a .dbc
+beside it, .mf4, or a ros .log directory) to run it.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+LARGE_FIXTURE = os.environ.get("BAGEL_LARGE_FIXTURE")
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not LARGE_FIXTURE, reason="BAGEL_LARGE_FIXTURE not set")
+def test_describe_and_windowed_query_on_large_file() -> None:
+    from src.di import module
+    from src.di.types.base_module import BaseModule
+    from src.di.types.data_source import resolve
+
+    path = pathlib.Path(LARGE_FIXTURE)
+    assert path.exists()
+    ds_type = resolve(str(path))
+    factory = module.provide(
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": str(path)}
+    )
+    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
+    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+    # describe must complete without materializing the file
+    assert factory.metadata
+    start = factory.start_seconds
+    # a 1-second window near the start must be cheap
+    relation = dataset.to_duckdb(factory, registry, start_seconds=start, end_seconds=start + 1.0)
+    relation.df()

--- a/test/e2e/test_large_file_smoke.py
+++ b/test/e2e/test_large_file_smoke.py
@@ -2,8 +2,10 @@
 and window-queried without exhausting memory. Skips unless the external
 fixture is present; never a CI gate.
 
-Point BAGEL_LARGE_FIXTURE at any real large capture (.blf/.asc with a .dbc
-beside it, .mf4, or a ros .log directory) to run it.
+Point BAGEL_LARGE_FIXTURE at any real large capture:
+  - CAN: .blf or .asc file with a sibling .dbc file (same basename, .dbc extension)
+  - MDF: .mf4 file
+  - ROS: .log file or .log directory
 """
 
 import os
@@ -25,8 +27,22 @@ def test_describe_and_windowed_query_on_large_file() -> None:
     path = pathlib.Path(LARGE_FIXTURE)
     assert path.exists()
     ds_type = resolve(str(path))
+
+    # Construct args dict based on data source type
+    args = {"path": str(path)}
+
+    # CAN sources (.blf/.asc) require a sibling .dbc file
+    if path.suffix.lower() in {".blf", ".asc"}:
+        dbc_path = path.with_suffix(".dbc")
+        if not dbc_path.exists():
+            pytest.skip(
+                f"CAN fixture requires a sibling .dbc file next to the capture "
+                f"(expected: {dbc_path})"
+            )
+        args["dbc"] = str(dbc_path)
+
     factory = module.provide(
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": str(path)}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", args
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})

--- a/test/message/automotive/test_message_mf4.py
+++ b/test/message/automotive/test_message_mf4.py
@@ -5,9 +5,7 @@ import pathlib
 import duckdb
 import pytest
 
-asammdf = pytest.importorskip(
-    "asammdf", reason="asammdf is optional (uv sync --group automotive)"
-)
+asammdf = pytest.importorskip("asammdf", reason="asammdf is optional (uv sync --group automotive)")
 import numpy as np  # noqa: E402
 from asammdf import MDF, Signal  # noqa: E402
 
@@ -89,7 +87,7 @@ def test_sql_over_channel_group(mf4_file: pathlib.Path) -> None:
     relation = dataset.to_duckdb(factory, registry, ["EngineData"])
     duckdb.register("engine", relation)
     row = duckdb.sql(
-        'SELECT COUNT(*) AS n, MIN("EngineData"[\'EngineSpeed\']) AS low FROM engine'
+        "SELECT COUNT(*) AS n, MIN(\"EngineData\"['EngineSpeed']) AS low FROM engine"
     ).fetchone()
     assert row == (20, 3000.0 - 100 * 9.5)
 

--- a/test/pipeline/integration/test_ros2_write_paths.py
+++ b/test/pipeline/integration/test_ros2_write_paths.py
@@ -31,9 +31,7 @@ POST_SECONDS = 1.0
 
 # Ground truth from synth: events at EPOCH+4 and EPOCH+8 -> kept windows [3,6] and [7,9.75].
 EXPECTED_EVENTS = synth.event_onsets()
-EXPECTED_WINDOWS = [
-    (start - PRE_SECONDS, end + POST_SECONDS) for start, end, _ in synth.EVENTS
-]
+EXPECTED_WINDOWS = [(start - PRE_SECONDS, end + POST_SECONDS) for start, end, _ in synth.EVENTS]
 
 
 def _read_messages(bag_dir: pathlib.Path, storage_id: str) -> list[tuple[str, float]]:
@@ -85,9 +83,7 @@ def _isolated_artifacts(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch)
 def test_reduce_db3_keeps_only_event_windows(tmp_path: pathlib.Path) -> None:
     bag = synth.write_imu_bag(tmp_path / "source_bag", "sqlite3")
 
-    pipeline = base.Pipeline.build(
-        _reduce_config(bag, "src.pipeline.tasks.reduce.ros2.db3")
-    )
+    pipeline = base.Pipeline.build(_reduce_config(bag, "src.pipeline.tasks.reduce.ros2.db3"))
     produced = pipeline.run_all()
 
     assert len(produced) == 1

--- a/test/pipeline/tasks/cloudini/test_decode_pointcloud.py
+++ b/test/pipeline/tasks/cloudini/test_decode_pointcloud.py
@@ -17,8 +17,8 @@ def test_empty_topics_raises() -> None:
     with pytest.raises(ValueError, match="at least one"):
         DecodePointCloudTask(
             topics=[],
-            output_directory="/tmp/out",
-            wasm_path=WASM_PATH,  # noqa: S108
+            output_directory="/tmp/out",  # noqa: S108
+            wasm_path=WASM_PATH,
         )
 
 
@@ -55,8 +55,8 @@ def test_global_flag_enabled(mock_settings: MagicMock) -> None:
 def test_extract_raw_data_from_dict() -> None:
     task = DecodePointCloudTask(
         topics=["/lidar"],
-        output_directory="/tmp/out",
-        wasm_path=WASM_PATH,  # noqa: S108
+        output_directory="/tmp/out",  # noqa: S108
+        wasm_path=WASM_PATH,
     )
     assert task._extract_raw_data({"data": b"\x01\x02"}) == b"\x01\x02"
     assert task._extract_raw_data({"other": 1}) is None
@@ -65,8 +65,8 @@ def test_extract_raw_data_from_dict() -> None:
 def test_extract_raw_data_from_object() -> None:
     task = DecodePointCloudTask(
         topics=["/lidar"],
-        output_directory="/tmp/out",
-        wasm_path=WASM_PATH,  # noqa: S108
+        output_directory="/tmp/out",  # noqa: S108
+        wasm_path=WASM_PATH,
     )
     msg = MagicMock()
     msg.data = b"\x03\x04"
@@ -76,8 +76,8 @@ def test_extract_raw_data_from_object() -> None:
 def test_extract_raw_data_from_list() -> None:
     task = DecodePointCloudTask(
         topics=["/lidar"],
-        output_directory="/tmp/out",
-        wasm_path=WASM_PATH,  # noqa: S108
+        output_directory="/tmp/out",  # noqa: S108
+        wasm_path=WASM_PATH,
     )
     msg = MagicMock()
     msg.data = [1, 2, 3]

--- a/test/pipeline/tasks/cloudini/test_decode_pointcloud.py
+++ b/test/pipeline/tasks/cloudini/test_decode_pointcloud.py
@@ -16,7 +16,9 @@ WASM_PATH = "/tmp/cloudini.wasm"  # noqa: S108
 def test_empty_topics_raises() -> None:
     with pytest.raises(ValueError, match="at least one"):
         DecodePointCloudTask(
-            topics=[], output_directory="/tmp/out", wasm_path=WASM_PATH  # noqa: S108
+            topics=[],
+            output_directory="/tmp/out",
+            wasm_path=WASM_PATH,  # noqa: S108
         )
 
 
@@ -52,7 +54,9 @@ def test_global_flag_enabled(mock_settings: MagicMock) -> None:
 
 def test_extract_raw_data_from_dict() -> None:
     task = DecodePointCloudTask(
-        topics=["/lidar"], output_directory="/tmp/out", wasm_path=WASM_PATH  # noqa: S108
+        topics=["/lidar"],
+        output_directory="/tmp/out",
+        wasm_path=WASM_PATH,  # noqa: S108
     )
     assert task._extract_raw_data({"data": b"\x01\x02"}) == b"\x01\x02"
     assert task._extract_raw_data({"other": 1}) is None
@@ -60,7 +64,9 @@ def test_extract_raw_data_from_dict() -> None:
 
 def test_extract_raw_data_from_object() -> None:
     task = DecodePointCloudTask(
-        topics=["/lidar"], output_directory="/tmp/out", wasm_path=WASM_PATH  # noqa: S108
+        topics=["/lidar"],
+        output_directory="/tmp/out",
+        wasm_path=WASM_PATH,  # noqa: S108
     )
     msg = MagicMock()
     msg.data = b"\x03\x04"
@@ -69,7 +75,9 @@ def test_extract_raw_data_from_object() -> None:
 
 def test_extract_raw_data_from_list() -> None:
     task = DecodePointCloudTask(
-        topics=["/lidar"], output_directory="/tmp/out", wasm_path=WASM_PATH  # noqa: S108
+        topics=["/lidar"],
+        output_directory="/tmp/out",
+        wasm_path=WASM_PATH,  # noqa: S108
     )
     msg = MagicMock()
     msg.data = [1, 2, 3]
@@ -100,9 +108,11 @@ def test_execute_decodes_and_writes_npz(
     )
 
     mock_dataset = MagicMock()
-    mock_dataset._messages.return_value = iter([
-        ("/lidar/points", 1.0, {"data": b"\x00\x01"}),
-    ])
+    mock_dataset._messages.return_value = iter(
+        [
+            ("/lidar/points", 1.0, {"data": b"\x00\x01"}),
+        ]
+    )
     task._factory = MagicMock()
     task._registry = MagicMock()
     task._dataset = mock_dataset
@@ -138,9 +148,11 @@ def test_execute_decodes_and_writes_csv(
     )
 
     mock_dataset = MagicMock()
-    mock_dataset._messages.return_value = iter([
-        ("/lidar/points", 0.5, MagicMock(data=b"\xAB\xCD")),
-    ])
+    mock_dataset._messages.return_value = iter(
+        [
+            ("/lidar/points", 0.5, MagicMock(data=b"\xab\xcd")),
+        ]
+    )
     task._factory = MagicMock()
     task._registry = MagicMock()
     task._dataset = mock_dataset

--- a/test/pipeline/test_flatten.py
+++ b/test/pipeline/test_flatten.py
@@ -120,7 +120,5 @@ def test_end_to_end_flattened_parquet(
     (artifact,) = result["artifacts"]
     table = duckdb.sql(f"SELECT * FROM '{artifact}'")
     assert "message/accel_x" in table.columns
-    (minimum,) = duckdb.sql(
-        f'SELECT MIN("message/accel_x") FROM \'{artifact}\''
-    ).fetchone()
+    (minimum,) = duckdb.sql(f"SELECT MIN(\"message/accel_x\") FROM '{artifact}'").fetchone()
     assert minimum == -13.0

--- a/test/pipeline/test_live_buffer_wiring.py
+++ b/test/pipeline/test_live_buffer_wiring.py
@@ -50,9 +50,7 @@ def test_on_event_fires_once_per_rising_edge(tmp_path: pathlib.Path) -> None:
 def test_forward_window_delays_firing_until_post_data_arrived(
     tmp_path: pathlib.Path,
 ) -> None:
-    when = OnEvent(
-        predicate="imu['ax'] < -10", forward=Lookback(last=2, unit=Unit.SECOND)
-    )
+    when = OnEvent(predicate="imu['ax'] < -10", forward=Lookback(last=2, unit=Unit.SECOND))
     writer, pipeline = _writer(tmp_path, when)
 
     _feed(writer, [(0.0, -0.5), (1.0, -12.0), (2.0, -0.5)])
@@ -63,9 +61,7 @@ def test_forward_window_delays_firing_until_post_data_arrived(
 
 
 def test_flush_fires_events_still_awaiting_forward_window(tmp_path: pathlib.Path) -> None:
-    when = OnEvent(
-        predicate="imu['ax'] < -10", forward=Lookback(last=10, unit=Unit.SECOND)
-    )
+    when = OnEvent(predicate="imu['ax'] < -10", forward=Lookback(last=10, unit=Unit.SECOND))
     writer, pipeline = _writer(tmp_path, when)
 
     _feed(writer, [(0.0, -0.5), (5.0, -13.0), (6.0, -0.5)])

--- a/test/pipeline/test_on_event_cadence.py
+++ b/test/pipeline/test_on_event_cadence.py
@@ -57,9 +57,12 @@ def test_predicate_never_true_yields_nothing() -> None:
 
 def test_min_gap_seconds_defaults_to_zero() -> None:
     assert OnEvent(predicate="accel_x < -10").min_gap_seconds() == 0.0
-    assert OnEvent(
-        predicate="accel_x < -10", debounce=Lookback(last=3, unit=Unit.SECOND)
-    ).min_gap_seconds() == 3.0
+    assert (
+        OnEvent(
+            predicate="accel_x < -10", debounce=Lookback(last=3, unit=Unit.SECOND)
+        ).min_gap_seconds()
+        == 3.0
+    )
 
 
 def test_cadence_build_parses_on_event() -> None:
@@ -80,9 +83,7 @@ def test_cadence_build_parses_on_event() -> None:
 
 
 def test_cadence_build_on_event_without_debounce() -> None:
-    cadence = Cadence.build(
-        {"topic": "/imu", "when": {"on_event": {"predicate": "accel_x < -10"}}}
-    )
+    cadence = Cadence.build({"topic": "/imu", "when": {"on_event": {"predicate": "accel_x < -10"}}})
     assert isinstance(cadence.when, OnEvent)
     assert cadence.when.debounce is None
 

--- a/test/pipeline/test_plotjuggler_export.py
+++ b/test/pipeline/test_plotjuggler_export.py
@@ -92,7 +92,7 @@ def test_signals_filter_and_unknown_signal_error() -> None:
 
 def test_non_numeric_signal_rejected_cleanly() -> None:
     relation = duckdb.sql(
-        f'SELECT 1.0 AS "{TS}", struct_pack(temp := 20.0, mode := \'auto\') AS sensor'
+        f"SELECT 1.0 AS \"{TS}\", struct_pack(temp := 20.0, mode := 'auto') AS sensor"
     )
     # "sensor/mode" exists after flattening but is a string -- it must fail with a
     # clean ValueError, not a TypeError from the y-range computation.
@@ -109,7 +109,5 @@ def test_non_numeric_signal_rejected_cleanly() -> None:
 def test_curve_cap_applies_without_explicit_signals() -> None:
     columns = ", ".join(f"s{i:02d} := {float(i)}" for i in range(12))
     relation = duckdb.sql(f'SELECT 1.0 AS "{TS}", struct_pack({columns}) AS wide')
-    result = plotjuggler.export_window(
-        relation, name="wide", start_seconds=0.0, end_seconds=2.0
-    )
+    result = plotjuggler.export_window(relation, name="wide", start_seconds=0.0, end_seconds=2.0)
     assert len(result["curves"]) == plotjuggler.MAX_CURVES

--- a/test/pipeline/test_upload_s3.py
+++ b/test/pipeline/test_upload_s3.py
@@ -121,9 +121,7 @@ def test_filter_modified_at_uploads_only_files_in_window(tmp_path: pathlib.Path)
     task = UploadFilesToS3(bucket="bkt", source=str(tmp_path), filter_modified_at=True)
     client = _client()
     with patch("src.pipeline.tasks.upload.s3.boto3.client", return_value=client):
-        task.execute(
-            asof_seconds=1000.0, lookback=base.Lookback(last=60, unit=base.Unit.SECOND)
-        )
+        task.execute(asof_seconds=1000.0, lookback=base.Lookback(last=60, unit=base.Unit.SECOND))
 
     assert _uploaded_keys(client) == ["fresh.csv"]
 
@@ -148,9 +146,7 @@ def test_registry_discovers_upload_task() -> None:
     from src.pipeline import capabilities
 
     entries = capabilities.list_capabilities()
-    upload = next(
-        (e for e in entries if e["module"] == "src.pipeline.tasks.upload.s3"), None
-    )
+    upload = next((e for e in entries if e["module"] == "src.pipeline.tasks.upload.s3"), None)
     assert upload is not None
     assert upload["kind"] == "task"
     param_names = {p["name"] for p in upload["parameters"]}

--- a/test/sink/test_admission.py
+++ b/test/sink/test_admission.py
@@ -1,0 +1,82 @@
+"""Admission control for live-buffer disk usage (#134).
+
+Before hardening, N subscribed topics could claim N x buffer_size_bytes (x2
+transiently) with no global bound. SINK_TOTAL_BUFFER_BYTES=0 preserves that
+behavior; when set, subscribe() refuses topics that would exceed the total.
+"""
+
+import itertools
+import pathlib
+
+import pyarrow as pa
+import pytest
+
+from settings import settings
+from src.sink import base
+from src.sink.buffer import TopicBufferWriter
+
+_port_counter = itertools.count(19000)
+
+
+class _FakeSink(base.TopicSink):
+    def _connect(self) -> None:
+        pass
+
+    def _disconnect(self) -> None:
+        pass
+
+    def _available_topics(self) -> list[str]:
+        return ["/a", "/b", "/c"]
+
+    def _type_name(self, topic: str) -> str:
+        return "test/type"
+
+    def _definition(self, topic: str) -> str:
+        return "float64 x"
+
+    def _struct(self, topic: str) -> pa.StructType:
+        return pa.struct([pa.field("x", pa.float64())])
+
+    def _subscribe(self, writer: TopicBufferWriter) -> None:
+        pass
+
+    def _unsubscribe(self, writer: TopicBufferWriter) -> None:
+        pass
+
+
+@pytest.fixture
+def sink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> _FakeSink:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+    # unique port per test: TopicSink is a (host, port)-keyed singleton
+    return _FakeSink("localhost", next(_port_counter))
+
+
+def test_default_zero_admits_unbounded(sink: _FakeSink, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", 0)
+    sink.subscribe("/a", buffer_size_bytes=None)
+    sink.subscribe("/b", buffer_size_bytes=10**12)
+
+
+def test_cap_admits_until_exceeded(sink: _FakeSink, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", 2_000)
+    sink.subscribe("/a", buffer_size_bytes=1_000)
+    sink.subscribe("/b", buffer_size_bytes=1_000)
+    with pytest.raises(base.BufferCapacityExceededError) as excinfo:
+        sink.subscribe("/c", buffer_size_bytes=1_000)
+    message = str(excinfo.value)
+    assert "SINK_TOTAL_BUFFER_BYTES" in message
+    assert "buffer_size_bytes" in message
+
+
+def test_cap_rejects_unbounded_topic(sink: _FakeSink, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", 2_000)
+    with pytest.raises(base.BufferCapacityExceededError):
+        sink.subscribe("/a", buffer_size_bytes=None)
+
+
+def test_overwrite_replaces_rather_than_adds(
+    sink: _FakeSink, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", 2_000)
+    sink.subscribe("/a", buffer_size_bytes=1_500)
+    sink.subscribe("/a", buffer_size_bytes=1_800, overwrite=True)  # replaces, still fits

--- a/test/sink/test_admission.py
+++ b/test/sink/test_admission.py
@@ -80,3 +80,17 @@ def test_overwrite_replaces_rather_than_adds(
     monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", 2_000)
     sink.subscribe("/a", buffer_size_bytes=1_500)
     sink.subscribe("/a", buffer_size_bytes=1_800, overwrite=True)  # replaces, still fits
+
+
+def test_batch_subscribe_is_all_or_nothing(
+    sink: _FakeSink, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex review on #156: admission failure mid-batch must not leave a
+    partial subscription set behind."""
+    from src.sink import startup
+
+    per_topic = settings.JSONL_BUFFER_SIZE_PER_TOPIC_BYTES
+    monkeypatch.setattr(settings, "SINK_TOTAL_BUFFER_BYTES", int(per_topic * 2.5))
+    with pytest.raises(base.BufferCapacityExceededError):
+        startup.subscribe_with_pipeline(sink, ["/a", "/b", "/c"], None)
+    assert sink.subscribed_topics == []

--- a/test/sink/test_mqtt.py
+++ b/test/sink/test_mqtt.py
@@ -116,9 +116,7 @@ def test_on_event_pipeline_fires_on_live_messages(make_sink: MakeSink) -> None:
     )
 
     for t, temp in ((1.0, -18.0), (2.0, -12.0), (3.0, -11.5), (4.0, -18.0)):
-        sink._fake.deliver(
-            "freezer/1/status", json.dumps({"temp": temp, "t": t}).encode()
-        )
+        sink._fake.deliver("freezer/1/status", json.dumps({"temp": temp, "t": t}).encode())
 
     # One rising edge at t=2.0 (sustained warm reading counts once).
     assert [call.args[0] for call in pipeline.run_at.call_args_list] == [2.0]
@@ -153,8 +151,12 @@ def test_websockets_transport_and_tls_configure_paho(
     captured: dict[str, object] = {}
 
     class RecordingFake(FakePahoClient):
-        def __init__(self, callback_api_version: object = None, client_id: str | None = None,
-                     transport: str = "tcp") -> None:
+        def __init__(
+            self,
+            callback_api_version: object = None,
+            client_id: str | None = None,
+            transport: str = "tcp",
+        ) -> None:
             super().__init__(callback_api_version, client_id)
             captured["transport"] = transport
             self.tls_args: dict[str, object] | None = None

--- a/test/sink/test_sparkplug.py
+++ b/test/sink/test_sparkplug.py
@@ -99,9 +99,7 @@ def test_sink_decodes_sparkplug_topics_end_to_end(make_sink) -> None:  # noqa: A
 
 
 def test_sparkplug_disabled_falls_back_to_raw(make_sink) -> None:  # noqa: ANN001
-    sink = make_sink(
-        retained={SP_TOPIC: [_payload(temperature=85.0)]}, sparkplug_b=False
-    )
+    sink = make_sink(retained={SP_TOPIC: [_payload(temperature=85.0)]}, sparkplug_b=False)
     assert sink._type_name(SP_TOPIC) == "mqtt/json"
     struct = sink._struct(SP_TOPIC)
     assert "payload" in struct.names  # binary protobuf treated as opaque text

--- a/test/sink/test_startup.py
+++ b/test/sink/test_startup.py
@@ -49,9 +49,7 @@ def test_standing_pipeline_fires_and_writes_artifact(make_sink) -> None:  # noqa
 
     # Cruise, then an excursion: the rising edge fires the standing pipeline.
     for t, temp in ((101.0, -18.0), (102.0, -12.0)):
-        sink._fake.deliver(
-            "freezer/1/status", json.dumps({"temp": temp, "t": t}).encode()
-        )
+        sink._fake.deliver("freezer/1/status", json.dumps({"temp": temp, "t": t}).encode())
 
     artifacts = list(pathlib.Path(settings.ARTIFACT_DIRECTORY).rglob("*.csv"))
     assert len(artifacts) == 1, "the excursion must produce exactly one snapshot"
@@ -92,9 +90,7 @@ def test_manifest_startup_end_to_end(
     manifest_file.write_text(yaml.safe_dump(manifest))
 
     reports = startup.start(manifest_file)
-    assert reports == [
-        {"sink": "mqtt", "status": "subscribed", "topics": ["freezer/1/status"]}
-    ]
+    assert reports == [{"sink": "mqtt", "status": "subscribed", "topics": ["freezer/1/status"]}]
 
     # The subscription is live: an excursion fires the pipeline from the manifest.
     fake.deliver("freezer/1/status", json.dumps({"temp": -12.0, "t": 101.0}).encode())

--- a/test/source/test_influxdb.py
+++ b/test/source/test_influxdb.py
@@ -29,10 +29,7 @@ requires_db = pytest.mark.skipif(
 
 
 def test_influxdb_urls_resolve() -> None:
-    assert (
-        data_source.resolve("influxdb://tok@h:8181/telemetry")
-        == data_source.DataSource.INFLUXDB
-    )
+    assert data_source.resolve("influxdb://tok@h:8181/telemetry") == data_source.DataSource.INFLUXDB
 
 
 def test_parse_url_with_token_and_port() -> None:

--- a/test/test_artifacts.py
+++ b/test/test_artifacts.py
@@ -136,3 +136,11 @@ def test_to_duckdb_rebuilds_after_cache_file_deleted(
     cached[0].unlink()
     relation_again = dataset.to_duckdb(factory, registry)
     assert relation_again.df().shape[0] == rows
+
+
+def test_directory_size_bytes(tmp_path: pathlib.Path) -> None:
+    assert artifacts.directory_size_bytes(tmp_path / "missing") == 0
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.bin").write_bytes(b"x" * 100)
+    (tmp_path / "sub" / "b.bin").write_bytes(b"y" * 50)
+    assert artifacts.directory_size_bytes(tmp_path) == 150

--- a/test/test_artifacts.py
+++ b/test/test_artifacts.py
@@ -1,4 +1,6 @@
+import os
 import pathlib
+import time
 
 import pytest
 
@@ -41,3 +43,96 @@ def test_should_return_git_clone_directory() -> None:
 
     # THEN
     assert str(result) == str(pathlib.Path(settings.CACHE_DIRECTORY) / "repos")
+
+
+@pytest.fixture
+def fake_cache(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> list[pathlib.Path]:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+    source_dir = tmp_path / "data" / "source_id=abc"
+    source_dir.mkdir(parents=True)
+    files = []
+    for index in range(4):
+        file = source_dir / f"topics_{index:08d}.arrow"
+        file.write_bytes(b"x" * 1000)
+        stamp = 1_700_000_000 + index * 1000  # file 0 oldest, file 3 newest
+        os.utime(file, (stamp, stamp))
+        files.append(file)
+    (tmp_path / "data" / "sink=deadbeef").mkdir(parents=True)
+    (tmp_path / "data" / "sink=deadbeef" / "current.jsonl").write_bytes(b"y" * 5000)
+    return files
+
+
+def test_evict_noop_under_cap(
+    fake_cache: list[pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "CACHE_MAX_BYTES", 10_000)
+    assert artifacts.evict_arrow_cache() == 0
+    assert all(file.exists() for file in fake_cache)
+
+
+def test_evict_deletes_oldest_first_until_under_cap(
+    fake_cache: list[pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "CACHE_MAX_BYTES", 2_500)
+    assert artifacts.evict_arrow_cache() == 2
+    assert not fake_cache[0].exists() and not fake_cache[1].exists()
+    assert fake_cache[2].exists() and fake_cache[3].exists()
+
+
+def test_evict_zero_disables(
+    fake_cache: list[pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "CACHE_MAX_BYTES", 0)
+    assert artifacts.evict_arrow_cache() == 0
+
+
+def test_evict_never_touches_sink_trees(
+    fake_cache: list[pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "CACHE_MAX_BYTES", 1)
+    artifacts.evict_arrow_cache()
+    sink_file = pathlib.Path(settings.CACHE_DIRECTORY) / "data" / "sink=deadbeef" / "current.jsonl"
+    assert sink_file.exists()
+
+
+def test_fresh_utime_survives_eviction(
+    fake_cache: list[pathlib.Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#134: a hot (just-read) file is newest and outlives older entries."""
+    monkeypatch.setattr(settings, "CACHE_MAX_BYTES", 1_500)
+    now = time.time()
+    os.utime(fake_cache[0], (now, now))  # oldest file becomes hot
+    artifacts.evict_arrow_cache()
+    assert fake_cache[0].exists()
+    assert not fake_cache[1].exists()
+
+
+def test_to_duckdb_rebuilds_after_cache_file_deleted(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#134: losing a cache file (eviction race) degrades to a miss, not an error.
+
+    Note: `src.di.types.data_source.resolve()` returns a `DataSource` enum member,
+    not a bundle of factory/registry/dataset objects, so this mirrors the direct
+    construction pattern used by e.g. `test/message/px4/test_message_ulg.py`
+    (and the timestamp args from `test/pipeline/test_preview_pipeline.py`) rather
+    than calling `resolve()` directly.
+    """
+    from src.message.pyarrow.csv import MessageDataset
+    from src.source.pyarrow.csv import SourceFactory
+    from src.topic.pyarrow.csv import TopicRegistry
+
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+    factory = SourceFactory(
+        "data/sample/pyarrow/csv/flight.csv", timestamp_column="t", timestamp_format="seconds"
+    )
+    registry = TopicRegistry()
+    dataset = MessageDataset()
+
+    relation = dataset.to_duckdb(factory, registry)
+    rows = relation.df().shape[0]
+    cached = list((tmp_path / "data").glob("source_id=*/**/*.arrow"))
+    assert len(cached) == 1
+    cached[0].unlink()
+    relation_again = dataset.to_duckdb(factory, registry)
+    assert relation_again.df().shape[0] == rows


### PR DESCRIPTION
> [!NOTE]
> Updated 2026-08-16: recovered, rebased onto current main, re-verified, and extended with the big-bag OOM fix. Original description superseded by the below.

Implements the resource-limits plan end to end, plus the fix for the OOM found by the launch-readiness matrix. Memory now scales with the query asked, not the input size.

## From the original #134 plan
- **ros.log**: parse_file streams line-by-line (was ~3x file-size peak)
- **CAN**: one-pass metadata stats, windowed uncached records, no N+1 re-decodes
- **MDF4**: window-first channel slicing, one-sample schema inference, tail-only end_seconds
- **PyArrow**: zero readable files raises `InvalidPathError`; partial drops warn + `excluded_file_count` in metadata
- **Cache**: `CACHE_MAX_BYTES` (20 GB default) LRU eviction of the arrow query cache, utime-on-hit
- **Sinks**: `SINK_TOTAL_BUFFER_BYTES` admission control with `BufferCapacityExceededError`
- **Observability**: startup disk-usage log, optional `BAGEL_LARGE_FIXTURE` smoke test

## New: the big-bag OOM fix (matrix finding, 2026-08-14)
`_record_batches` retargets batch size at `ARROW_RECORD_BATCH_SIZE_BYTES` (1 GB of Arrow bytes); for IMU-sized rows that resolves to ~4M rows per batch, buffered as Python objects at 10-20x overhead — a 416 MB / 1.2M-message MCAP bag OOM-killed an 8 GB VM. New `MAX_ARROW_RECORD_BATCH_SIZE_COUNT` (100k rows) clamps the estimate.

**Repro verified on the exact failing workload**: 1.2M rows, correct aggregates (min = -15.0), 91 s, **peak RSS 783 MB** (previously: OOM kill).

## Verification
- 363 host tests green post-rebase; adversarial resource-limits suite 9/9; lint clean
- Plugin settings reference updated with the now-real knobs

Closes the last launch blocker from the readiness matrix. Addresses the Resource-limits checkboxes of #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdffiadRLDgXeP1gxP9eVs
