### PR TITLE
User-authored capabilities: save one in conversation or drop a markdown file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,8 @@ jobs:
         run: |
           mkdir -p "${HOME}/.bagel/artifacts"
           chmod 777 "${HOME}/.bagel/artifacts"
+          mkdir -p "${HOME}/.bagel/capabilities"
+          chmod 777 "${HOME}/.bagel/capabilities"
           docker compose run --rm \
             -e COVERAGE_FILE=/home/ubuntu/.bagel/artifacts/.coverage.${{ matrix.service }} \
             ${{ matrix.service }} \

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Bagel discovers your own capabilities from `~/.bagel/capabilities/`:
 Either way it shows up in `list_agent_capabilities` as `user/<name>` and runs
 with `run_poml_capability` — from Claude Code, Claude Desktop, or any MCP
 client. Teams: keep the directory in your own git repo and sync it to every
-robot; it's just files.
+robot; it's just files. On Linux, run `mkdir -p ~/.bagel/capabilities` once
+before starting the container so the mount is owned by you, not root.
 
 ## 📚 Guides
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,23 @@ Result:
 meow 🐱 4 topics 🐱💤🎯
 ```
 
+### Teach it your own tricks (no rebuild)
+
+Bagel discovers your own capabilities from `~/.bagel/capabilities/`:
+
+- **In conversation:** do a workflow once, then say *"save that as a
+  capability called battery-triage"* — Claude calls `save_agent_capability`
+  and it's reusable in any future session.
+- **As a file:** drop a markdown file with your steps (or a
+  [POML](https://github.com/microsoft/poml) file, if you want parameterized
+  templates — see `src/agent/compose/pipeline.poml` for the house style)
+  into `~/.bagel/capabilities/`.
+
+Either way it shows up in `list_agent_capabilities` as `user/<name>` and runs
+with `run_poml_capability` — from Claude Code, Claude Desktop, or any MCP
+client. Teams: keep the directory in your own git repo and sync it to every
+robot; it's just files.
+
 ## 📚 Guides
 
 - [Natural-language pipelines](./doc/runbooks/pipelines.md) — the model: a cadence, gates,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,14 @@ the product working as intended:
   socket. Bind it to localhost (`MCP_SERVER_HOST=127.0.0.1`) or keep it inside a
   trusted network; never expose the port to the public internet. The compose files
   publish it on the local host only for the documented single-machine setup.
+
+The `save_agent_capability` tool is the endpoint's first write-capable tool.
+Its writes are confined to `.poml`/`.md` files under the configured
+`USER_CAPABILITIES_DIRECTORY` (name slugs are validated; path traversal and
+absolute paths are rejected), and builtin capabilities are immutable through
+it. As with every tool on this endpoint, it is intended for trusted-network
+deployment.
+
 - Treat pipeline configs and startup manifests as sensitive: they can contain
   broker credentials, DSNs, and webhook URLs.
 - Cloud upload tasks use your ambient credentials (AWS/GCS/Azure SDK chains);

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,15 +44,13 @@ the product working as intended:
   socket. Bind it to localhost (`MCP_SERVER_HOST=127.0.0.1`) or keep it inside a
   trusted network; never expose the port to the public internet. The compose files
   publish it on the local host only for the documented single-machine setup.
-
-The `save_agent_capability` tool is the endpoint's first tool whose writes are
-driven by LLM-authored content rather than caller-specified paths or configuration.
-Its writes are confined to `.poml`/`.md` files under the configured
-`USER_CAPABILITIES_DIRECTORY` (name slugs are validated; path traversal and
-absolute paths are rejected), and builtin capabilities are immutable through
-it. As with every tool on this endpoint, it is intended for trusted-network
-deployment.
-
+- The `save_agent_capability` tool is the endpoint's first tool whose writes are
+  driven by LLM-authored content rather than caller-specified paths or configuration.
+  Its writes are confined to `.poml`/`.md` files under the configured
+  `USER_CAPABILITIES_DIRECTORY` (name slugs are validated; path traversal and
+  absolute paths are rejected), and builtin capabilities are immutable through
+  it. As with every tool on this endpoint, it is intended for trusted-network
+  deployment.
 - Treat pipeline configs and startup manifests as sensitive: they can contain
   broker credentials, DSNs, and webhook URLs.
 - Cloud upload tasks use your ambient credentials (AWS/GCS/Azure SDK chains);

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,8 @@ the product working as intended:
   trusted network; never expose the port to the public internet. The compose files
   publish it on the local host only for the documented single-machine setup.
 
-The `save_agent_capability` tool is the endpoint's first write-capable tool.
+The `save_agent_capability` tool is the endpoint's first tool whose writes are
+driven by LLM-authored content rather than caller-specified paths or configuration.
 Its writes are confined to `.poml`/`.md` files under the configured
 `USER_CAPABILITIES_DIRECTORY` (name slugs are validated; path traversal and
 absolute paths are rejected), and builtin capabilities are immutable through

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-jazzy:
@@ -49,6 +53,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-iron:
@@ -75,6 +83,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-humble:
@@ -101,6 +113,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic:
@@ -125,6 +141,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic-cv:
@@ -149,6 +169,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   px4:
@@ -172,6 +196,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   ardupilot:
@@ -195,6 +223,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   betaflight:
@@ -218,6 +250,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   apache-arrow:
@@ -241,6 +277,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   iot:
@@ -266,6 +306,10 @@ services:
       # tools like PlotJuggler can open them directly. On Linux, run
       # `mkdir -p ~/.bagel/artifacts` once so the directory is owned by you.
       - ${HOME}/.bagel/artifacts:/home/ubuntu/.bagel/artifacts
+      # User-authored capabilities (.poml/.md) — discovered by
+      # list_agent_capabilities and written by save_agent_capability. On Linux,
+      # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
+      - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
       # - <path-to-local-data>:/home/ubuntu/data
 
   # Local LLM for a fully offline stack: your data AND your model never leave

--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -8,6 +8,7 @@
 | `SINK_TOTAL_BUFFER_BYTES` | 0 (unbounded) | Total live-buffer budget per sink; when set, subscribe() refuses topics that would exceed it (`BufferCapacityExceededError`) |
 | `CACHE_MAX_BYTES` | 20 GB | LRU cap on the arrow query cache; 0 disables eviction. Never touches sink buffers or artifacts |
 | `ARTIFACT_DIRECTORY` | `~/.bagel/artifacts` | User deliverables (snippets, GIFs, exports). Never auto-deleted; `datestr=` partitions make external rotation easy |
+| `USER_CAPABILITIES_DIRECTORY` | `~/.bagel/capabilities` | User-authored capability files, discovered by `list_agent_capabilities`, written by `save_agent_capability`. Never auto-deleted |
 | `CACHE_DIRECTORY` | `~/.cache/bagel` | Query cache + sink buffers + repo clones |
 | `STARTUP_PIPELINES_FILE` | unset | YAML manifest of subscriptions/pipelines re-established on boot |
 

--- a/server.py
+++ b/server.py
@@ -399,7 +399,7 @@ def subscribe_live_topics(  # noqa: PLR0913
         "Discover available capabilities and their paths with "
         "`list_agent_capabilities`. The file specifies task instructions and "
         "output formats. Optional context values can be injected to customize "
-        "its behavior."
+        "its behavior. Capabilities may be POML (parameterizable via context) or markdown (static)."
     ),
 )
 def run_poml_capability(
@@ -441,6 +441,14 @@ def run_poml_capability(
     poml_file = pathlib.Path(poml_path)
     if not poml_file.exists():
         raise FileNotFoundError(poml_file)
+    if poml_file.suffix == ".md":
+        # Markdown capabilities are static instructions: no template engine,
+        # so parameterization is impossible rather than silently ignored.
+        if poml_context:
+            raise agent_capabilities.InvalidCapabilityError(
+                f"{poml_file} is a markdown capability; poml_context requires a POML file."
+            )
+        return [{"speaker": "human", "content": poml_file.read_text(encoding="utf-8")}]
     return poml(poml_file, context=poml_context)
 
 
@@ -473,6 +481,48 @@ def list_agent_capabilities() -> list[dict[str, str]]:
 
     """
     return agent_capabilities.list_capabilities()
+
+
+@server.tool(
+    title="Save a user capability",
+    description=(
+        "Save a reusable workflow as a named capability so it can be discovered "
+        "with `list_agent_capabilities` and run with `run_poml_capability` in any "
+        "future session. Content may be POML (validated before saving; supports "
+        "context parameterization) or plain markdown instructions. Writes only to "
+        "the user-capabilities directory; builtin capabilities cannot be modified."
+    ),
+)
+def save_agent_capability(name: str, content: str, overwrite: bool = False) -> dict[str, str]:
+    r"""Save a user-authored capability into the user-capabilities directory.
+
+    Args:
+        name (str): Capability slug (lowercase letters, digits, ``-``/``_``,
+            at most one ``/`` subdirectory level), e.g. ``fleet/battery-triage``.
+            The server chooses the file extension from the content.
+        content (str): The capability body — POML markup (starts with
+            ``<poml``) or markdown instructions.
+        overwrite (bool, optional): Replace an existing capability of the same
+            name. Defaults to False.
+
+    Returns:
+        dict[str, str]: The saved capability's ``name`` (``user/``-prefixed),
+            ``path``, and one-line ``summary`` — the same shape
+            ``list_agent_capabilities`` reports.
+
+    Raises:
+        InvalidCapabilityError: On an invalid name, empty content,
+            non-rendering POML, or a name collision without ``overwrite=True``.
+
+    Examples:
+        As an LLM prompt:
+            Save that workflow as a capability called battery-triage.
+
+        As a Python call:
+            >>> save_agent_capability("battery-triage", "# Battery triage\n\nSteps...")
+
+    """
+    return agent_capabilities.save_capability(name=name, content=content, overwrite=overwrite)
 
 
 @server.tool(

--- a/server.py
+++ b/server.py
@@ -406,24 +406,29 @@ def run_poml_capability(
     poml_path: str,
     poml_context: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Execute a structured capability from a POML file.
+    """Execute a structured capability from a POML or markdown file.
 
     Loads a `.poml` file containing instructions written in the POML
-    (Prompt-Oriented Markup Language) format. The file defines the task the
-    LLM should perform and how the output should be structured. This tool
-    produces a ready-to-use prompt for LLM execution.
+    (Prompt-Oriented Markup Language) format, or a `.md` file containing
+    static markdown instructions. The file defines the task the LLM should
+    perform and how the output should be structured. This tool produces a
+    ready-to-use prompt for LLM execution.
 
     Optionally, a context dictionary can be passed to substitute values in
-    the POML template, enabling dynamic parameterization.
+    the POML template, enabling dynamic parameterization. Markdown
+    capabilities have no template engine, so `poml_context` is rejected for
+    them rather than silently ignored.
 
     Args:
-        poml_path (str): Filesystem path to the `.poml` file containing the
-            capability definition.
+        poml_path (str): Filesystem path to the `.poml` or `.md` file
+            containing the capability definition.
         poml_context (dict[str, Any] | None, optional): Key-value pairs injected
             into the POML file to customize behavior. Defaults to None.
 
     Raises:
-        FileNotFoundError: If the `.poml` file cannot be found.
+        FileNotFoundError: If the file cannot be found.
+        InvalidCapabilityError: If `poml_context` is passed for a markdown
+            (`.md`) capability, which has no template engine to apply it to.
 
     Returns:
         list[dict[str, Any]]: A structured prompt representation, typically in the format:
@@ -455,10 +460,12 @@ def run_poml_capability(
 @server.tool(
     title="List agent capabilities",
     description=(
-        "List the predefined POML capabilities shipped with Bagel: each entry has "
-        "a `name`, a `path` to pass to `run_poml_capability`, and a one-line "
-        "`summary`. Use this to discover available capabilities instead of "
-        "guessing file paths."
+        "List every capability available to run: the predefined `.poml` capabilities "
+        "shipped with Bagel, plus any user-saved capabilities (`.poml` or `.md`, "
+        "named with a `user/` prefix) discovered under the user-capabilities "
+        "directory. Each entry has a `name`, a `path` to pass to "
+        "`run_poml_capability`, and a one-line `summary`. Use this to discover "
+        "available capabilities instead of guessing file paths."
     ),
 )
 def list_agent_capabilities() -> list[dict[str, str]]:

--- a/settings.py
+++ b/settings.py
@@ -29,6 +29,12 @@ class Settings(BaseSettings):
     # Directory for caching intermediate artifacts
     CACHE_DIRECTORY: str = str(pathlib.Path.home() / ".cache" / "bagel")
 
+    # Directory of user-authored capabilities (.poml or .md files) discovered by
+    # list_agent_capabilities alongside the builtins and writable via the
+    # save_agent_capability tool. Mounted from the host in compose.yaml so
+    # capabilities survive container restarts. Missing directory = builtins only.
+    USER_CAPABILITIES_DIRECTORY: str = str(pathlib.Path.home() / ".bagel" / "capabilities")
+
     # YAML manifest of live subscriptions (and their standing pipelines) to
     # establish when the server starts, so they survive container restarts.
     # If unset or missing, no startup subscriptions are made.

--- a/src/agent/capabilities.py
+++ b/src/agent/capabilities.py
@@ -42,6 +42,31 @@ def _user_root() -> pathlib.Path:
     return pathlib.Path(settings.USER_CAPABILITIES_DIRECTORY)
 
 
+def _is_confined(path: pathlib.Path, root: pathlib.Path) -> bool:
+    """Return True if ``path``'s resolved (symlink-followed) location is ``root`` or beneath it.
+
+    The single containment check used by both save and discovery: a leaf-level
+    ``.is_symlink()`` check alone misses an intermediate directory symlink (e.g.
+    ``<root>/escape -> /outside/dir``, then operating on ``escape/whatever``),
+    because resolving that path lands outside ``root`` even though no path
+    *component* by itself looked suspicious. Resolving both sides and checking
+    ``is_relative_to`` catches that regardless of which segment is the symlink.
+    """
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except OSError:
+        return False  # unresolvable (e.g. vanished mid-walk): treat as not confined
+
+
+def _assert_confined(path: pathlib.Path, root: pathlib.Path, action: str) -> None:
+    """Raise InvalidCapabilityError if ``path`` resolves outside ``root``."""
+    if not _is_confined(path, root):
+        raise InvalidCapabilityError(
+            f"Refusing to {action} {path}: it resolves to {path.resolve()}, "
+            f"outside the user-capabilities root {root.resolve()}."
+        )
+
+
 _LIST_MARKER_PATTERN = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+)")
 
 
@@ -111,6 +136,8 @@ def list_capabilities() -> list[dict[str, str]]:
             for user_file in user_root.rglob(pattern):
                 if user_file.is_symlink():
                     continue  # never read through a symlink, planted or otherwise
+                if not _is_confined(user_file, user_root):
+                    continue  # reached via a symlinked ancestor directory instead
                 try:
                     text = user_file.read_text(encoding="utf-8", errors="replace")
                 except OSError:
@@ -200,15 +227,21 @@ def _validate_poml_renders(content: str) -> None:
 
 
 def _write_capability_file(
-    target: pathlib.Path, existing: list[pathlib.Path], content: str
+    target: pathlib.Path, existing: list[pathlib.Path], content: str, user_root: pathlib.Path
 ) -> None:
     """Create the target's parent dir, drop stale same-name siblings, and write it.
 
     Raised OS errors (e.g. a non-writable directory on a fresh Linux bind mount)
     are translated to the module's typed error with a pointer to the likely fix.
+    After creating the parent dir, its resolved location is checked against
+    ``user_root``: a pre-planted *directory* symlink one level up (e.g.
+    ``<root>/escape -> /outside/dir``) would otherwise let a write land outside
+    the confinement guarantee even though no single path component looked like
+    a symlink from the target's own leaf-level check.
     """
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
+        _assert_confined(target.parent, user_root, action="save a capability under")
         for stale in existing:
             if stale != target:
                 stale.unlink(missing_ok=True)
@@ -240,8 +273,10 @@ def save_capability(name: str, content: str, overwrite: bool = False) -> dict[st
     Raises:
         InvalidCapabilityError: On an invalid name, empty content,
             non-rendering POML, a collision without ``overwrite=True``, an
-            attempt to write through a symlink, or an OS-level failure (e.g.
-            a non-writable directory) while creating or writing the file.
+            attempt to write through a symlinked file or a symlinked ancestor
+            directory (resolved location outside the user-capabilities root),
+            or an OS-level failure (e.g. a non-writable directory) while
+            creating or writing the file.
 
     """
     if name.startswith("user/"):
@@ -274,7 +309,7 @@ def save_capability(name: str, content: str, overwrite: bool = False) -> dict[st
             f"Capability {name!r} already exists ({existing[0].name}); "
             "pass overwrite=True to replace it."
         )
-    _write_capability_file(target, existing, content)
+    _write_capability_file(target, existing, content, user_root)
 
     summarize = _summary if is_poml else _markdown_summary
     relative = target.relative_to(user_root)

--- a/src/agent/capabilities.py
+++ b/src/agent/capabilities.py
@@ -1,14 +1,18 @@
-"""Discover the POML capability files shipped under ``src/agent``.
+"""Discover and author the capability files available to this server.
 
 Backs the ``list_agent_capabilities`` MCP tool: walks ``src/agent/**/*.poml``
 and reports each file's path and a one-line summary (the first sentence of its
 ``<task>`` element), so an LLM can discover and run capabilities via
 ``run_poml_capability`` without knowing any path in advance. Mirrors the
-filesystem-walk approach of ``src/pipeline/capabilities.py``.
+filesystem-walk approach of ``src/pipeline/capabilities.py``. User-authored
+capabilities — .poml or .md files under ``settings.USER_CAPABILITIES_DIRECTORY``
+— are discovered alongside the builtins with a ``user/`` name prefix.
 """
 
 import pathlib
 import re
+
+from settings import settings
 
 _AGENT_ROOT = pathlib.Path(__file__).parent
 
@@ -27,14 +31,36 @@ def _summary(poml_text: str, fallback: str) -> str:
     return text.split(". ", 1)[0].rstrip(".") + "."
 
 
+def _user_root() -> pathlib.Path:
+    """Return the user-capabilities directory, read live so tests can monkeypatch it."""
+    return pathlib.Path(settings.USER_CAPABILITIES_DIRECTORY)
+
+
+def _markdown_summary(md_text: str, fallback: str) -> str:
+    """First sentence of the body skipping headings, else the first H1, else fallback."""
+    heading = ""
+    for line in md_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            if not heading:
+                heading = stripped.lstrip("#").strip()
+            continue
+        return stripped.split(". ", 1)[0].rstrip(".") + "."
+    text = heading or fallback
+    return text.split(". ", 1)[0].rstrip(".") + "."
+
+
 def list_capabilities() -> list[dict[str, str]]:
-    """Return every POML capability under ``src/agent`` with path and summary.
+    """Return every POML and user-authored capability with path and summary.
 
     Returns:
-        list[dict[str, str]]: One dict per ``.poml`` file, sorted by ``name``:
-            ``name`` (relative path without suffix, e.g. ``compose/pipeline``),
-            ``path`` (repo-relative, ready for ``run_poml_capability``), and
-            ``summary`` (first sentence of the ``<task>`` element).
+        list[dict[str, str]]: One dict per ``.poml`` or ``.md`` file, sorted by ``name``:
+            ``name`` (relative path without suffix, e.g. ``compose/pipeline`` for builtins,
+            ``user/battery-triage`` for user entries), ``path`` (repo-relative for builtins,
+            absolute for user entries), and ``summary`` (first sentence of the ``<task>``
+            element or first body paragraph for markdown).
 
     """
     capabilities = []
@@ -48,5 +74,24 @@ def list_capabilities() -> list[dict[str, str]]:
                 "summary": _summary(text, fallback=relative.stem),
             }
         )
+
+    user_root = _user_root()
+    if user_root.is_dir():
+        for pattern in ("*.poml", "*.md"):
+            for user_file in user_root.rglob(pattern):
+                try:
+                    text = user_file.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue  # vanished/unreadable mid-walk: skip, never crash discovery
+                relative = user_file.relative_to(user_root)
+                summarize = _summary if user_file.suffix == ".poml" else _markdown_summary
+                capabilities.append(
+                    {
+                        "name": f"user/{relative.with_suffix('')}",
+                        "path": str(user_file.resolve()),
+                        "summary": summarize(text, relative.stem),
+                    }
+                )
+
     capabilities.sort(key=lambda capability: capability["name"])
     return capabilities

--- a/src/agent/capabilities.py
+++ b/src/agent/capabilities.py
@@ -42,18 +42,42 @@ def _user_root() -> pathlib.Path:
     return pathlib.Path(settings.USER_CAPABILITIES_DIRECTORY)
 
 
+_LIST_MARKER_PATTERN = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+)")
+
+
 def _markdown_summary(md_text: str, fallback: str) -> str:
-    """First sentence of the body skipping headings, else the first H1, else fallback."""
+    """First sentence of the body skipping headings, else the first heading, else fallback.
+
+    Fence lines (```` ``` ````) and front-matter/horizontal-rule delimiters (``---``,
+    ``***``) are skipped while scanning, as are lines inside a fenced block. Leading
+    list markers (``- ``, ``* ``, ``+ ``, and numbered ``N. ``/``N) `` markers) are
+    stripped from a candidate line before taking its first sentence, so a numbered-step
+    body (e.g. ``"1. Open the bag. 2. Check topics."``) summarizes to its first step
+    rather than to the literal ``"1."``. A candidate with no alphanumeric character is
+    skipped rather than returned.
+    """
     heading = ""
+    in_fence = False
     for line in md_text.splitlines():
         stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         if not stripped:
+            continue
+        if stripped in ("---", "***"):
             continue
         if stripped.startswith("#"):
             if not heading:
                 heading = stripped.lstrip("#").strip()
             continue
-        return stripped.split(". ", 1)[0].rstrip(".") + "."
+        candidate = _LIST_MARKER_PATTERN.sub("", stripped, count=1)
+        sentence = candidate.split(". ", 1)[0].rstrip(".") + "."
+        if not any(character.isalnum() for character in sentence):
+            continue
+        return sentence
     text = heading or fallback
     return text.split(". ", 1)[0].rstrip(".") + "."
 
@@ -85,6 +109,8 @@ def list_capabilities() -> list[dict[str, str]]:
     if user_root.is_dir():
         for pattern in ("*.poml", "*.md"):
             for user_file in user_root.rglob(pattern):
+                if user_file.is_symlink():
+                    continue  # never read through a symlink, planted or otherwise
                 try:
                     text = user_file.read_text(encoding="utf-8", errors="replace")
                 except OSError:
@@ -103,9 +129,41 @@ def list_capabilities() -> list[dict[str, str]]:
     return capabilities
 
 
+_ERROR_LINE_PATTERN = re.compile(r"^\w*Error:\s")
+
+
+def _renderer_diagnostic(stderr: str) -> str:
+    """Pull the useful line out of the POML Node renderer's stderr, if any.
+
+    The renderer crashes with an uncaught Node exception, whose default dump is a
+    source excerpt, then the actual ``SomeError: message`` line, then a long V8
+    stack trace, then (for some error types) a dump of the exception object's
+    extra properties, ending with a ``Node.js vX.Y.Z`` line. The real diagnostic
+    therefore usually sits a few lines from the *start*, not the end, of stderr —
+    grepping for the ``SomeError: `` line finds it directly. Falls back to the
+    last few non-blank lines when no such line is found (e.g. plain text on
+    stderr with no Node crash dump).
+    """
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    for line in lines:
+        if _ERROR_LINE_PATTERN.match(line):
+            return line
+    return "\n".join(lines[-3:])
+
+
 def _validate_poml_renders(content: str) -> None:
-    """Reject content that poml() cannot render, before anything is saved."""
+    """Reject content that poml() cannot render, before anything is saved.
+
+    poml() ignores the renderer subprocess's exit code and return value, so on
+    failure it only ever sees an empty output file and raises a bare
+    ``JSONDecodeError`` — the renderer's real diagnostic (e.g. "Component
+    bogus-elem not found") goes to stderr and is otherwise lost. On failure we
+    re-invoke the renderer ourselves via ``poml.cli.run(..., capture_output=True)``
+    — its kwargs pass straight through to the underlying ``subprocess.run`` —
+    solely to recover that stderr and fold it into the raised error.
+    """
     from poml import poml  # deferred: keep module import light for discovery-only callers
+    from poml.cli import run as poml_cli_run
 
     with tempfile.NamedTemporaryFile("w", suffix=".poml", encoding="utf-8", delete=False) as handle:
         handle.write(content)
@@ -115,11 +173,52 @@ def _validate_poml_renders(content: str) -> None:
     except Exception as exc:
         # poml's renderer raises implementation-defined exceptions for bad
         # markup; translate to the layer's typed error (#154 idiom).
-        raise InvalidCapabilityError(
-            f"Capability content does not render as POML: {type(exc).__name__}: {exc}"
-        ) from exc
+        diagnostic = ""
+        try:
+            with tempfile.NamedTemporaryFile("r", suffix=".json") as recapture_output:
+                completed = poml_cli_run(
+                    "-f",
+                    str(temp_path),
+                    "-o",
+                    recapture_output.name,
+                    "--chat",
+                    "true",
+                    capture_output=True,
+                    text=True,
+                )
+            diagnostic = _renderer_diagnostic(completed.stderr or "")
+        except Exception:
+            diagnostic = ""  # best-effort recapture; never mask the original error
+        message = f"Capability content does not render as POML: {type(exc).__name__}: {exc}"
+        if diagnostic:
+            message += f"\nRenderer diagnostic: {diagnostic}"
+        else:
+            message += " (the renderer's diagnostic may be in the server log)"
+        raise InvalidCapabilityError(message) from exc
     finally:
         temp_path.unlink(missing_ok=True)
+
+
+def _write_capability_file(
+    target: pathlib.Path, existing: list[pathlib.Path], content: str
+) -> None:
+    """Create the target's parent dir, drop stale same-name siblings, and write it.
+
+    Raised OS errors (e.g. a non-writable directory on a fresh Linux bind mount)
+    are translated to the module's typed error with a pointer to the likely fix.
+    """
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        for stale in existing:
+            if stale != target:
+                stale.unlink(missing_ok=True)
+        target.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise InvalidCapabilityError(
+            f"Could not write capability to {target.parent}: {exc}. On Linux, run "
+            "`mkdir -p ~/.bagel/capabilities` once before starting the container so "
+            "the mount is owned by you, not root."
+        ) from exc
 
 
 def save_capability(name: str, content: str, overwrite: bool = False) -> dict[str, str]:
@@ -130,11 +229,23 @@ def save_capability(name: str, content: str, overwrite: bool = False) -> dict[st
     confined to ``settings.USER_CAPABILITIES_DIRECTORY``; builtins cannot be
     modified through this function.
 
+    A single leading ``"user/"`` is stripped from ``name`` before validation,
+    so a name copied verbatim from a ``list_capabilities()`` entry (which
+    prefixes user-authored capabilities with ``user/``) round-trips onto the
+    same file instead of nesting under ``user/user/...``. Only the prefix
+    (i.e. ``"user/"`` followed by something) is stripped — ``name="user"``
+    alone is unaffected and still saves as a normal ``user.md``/``user.poml``
+    slug.
+
     Raises:
         InvalidCapabilityError: On an invalid name, empty content,
-            non-rendering POML, or a collision without ``overwrite=True``.
+            non-rendering POML, a collision without ``overwrite=True``, an
+            attempt to write through a symlink, or an OS-level failure (e.g.
+            a non-writable directory) while creating or writing the file.
 
     """
+    if name.startswith("user/"):
+        name = name[len("user/") :]
     if not _NAME_PATTERN.fullmatch(name):
         raise InvalidCapabilityError(
             f"Invalid capability name {name!r}: use lowercase letters, digits, '-' or '_', "
@@ -149,21 +260,21 @@ def save_capability(name: str, content: str, overwrite: bool = False) -> dict[st
 
     user_root = _user_root()
     target = user_root / f"{name}{'.poml' if is_poml else '.md'}"
-    existing = [
-        candidate
-        for candidate in (user_root / f"{name}.poml", user_root / f"{name}.md")
-        if candidate.exists()
-    ]
+    candidates = (user_root / f"{name}.poml", user_root / f"{name}.md")
+    for candidate in candidates:
+        if candidate.is_symlink():
+            raise InvalidCapabilityError(
+                f"Refusing to save over {candidate}: it is a symlink. "
+                "save_capability only writes plain files under the user-capabilities "
+                "directory; remove the symlink first if this was intentional."
+            )
+    existing = [candidate for candidate in candidates if candidate.exists()]
     if existing and not overwrite:
         raise InvalidCapabilityError(
             f"Capability {name!r} already exists ({existing[0].name}); "
             "pass overwrite=True to replace it."
         )
-    target.parent.mkdir(parents=True, exist_ok=True)
-    for stale in existing:
-        if stale != target:
-            stale.unlink(missing_ok=True)
-    target.write_text(content, encoding="utf-8")
+    _write_capability_file(target, existing, content)
 
     summarize = _summary if is_poml else _markdown_summary
     relative = target.relative_to(user_root)

--- a/src/agent/capabilities.py
+++ b/src/agent/capabilities.py
@@ -11,6 +11,7 @@ capabilities — .poml or .md files under ``settings.USER_CAPABILITIES_DIRECTORY
 
 import pathlib
 import re
+import tempfile
 
 from settings import settings
 
@@ -18,6 +19,11 @@ _AGENT_ROOT = pathlib.Path(__file__).parent
 
 _TASK_PATTERN = re.compile(r"<task>(.*?)</task>", re.DOTALL)
 _TAG_PATTERN = re.compile(r"<[^>]+>")
+_NAME_PATTERN = re.compile(r"^[a-z0-9_-]+(?:/[a-z0-9_-]+)?$")
+
+
+class InvalidCapabilityError(Exception):
+    """Raised when a capability cannot be saved or parameterized as requested."""
 
 
 def _summary(poml_text: str, fallback: str) -> str:
@@ -95,3 +101,74 @@ def list_capabilities() -> list[dict[str, str]]:
 
     capabilities.sort(key=lambda capability: capability["name"])
     return capabilities
+
+
+def _validate_poml_renders(content: str) -> None:
+    """Reject content that poml() cannot render, before anything is saved."""
+    from poml import poml  # deferred: keep module import light for discovery-only callers
+
+    with tempfile.NamedTemporaryFile("w", suffix=".poml", encoding="utf-8", delete=False) as handle:
+        handle.write(content)
+        temp_path = pathlib.Path(handle.name)
+    try:
+        poml(str(temp_path))
+    except Exception as exc:
+        # poml's renderer raises implementation-defined exceptions for bad
+        # markup; translate to the layer's typed error (#154 idiom).
+        raise InvalidCapabilityError(
+            f"Capability content does not render as POML: {type(exc).__name__}: {exc}"
+        ) from exc
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def save_capability(name: str, content: str, overwrite: bool = False) -> dict[str, str]:
+    """Save a user-authored capability and return its discovery entry.
+
+    Content starting with ``<poml`` is render-validated and saved as
+    ``.poml``; any other non-empty content is saved as markdown. Writes are
+    confined to ``settings.USER_CAPABILITIES_DIRECTORY``; builtins cannot be
+    modified through this function.
+
+    Raises:
+        InvalidCapabilityError: On an invalid name, empty content,
+            non-rendering POML, or a collision without ``overwrite=True``.
+
+    """
+    if not _NAME_PATTERN.fullmatch(name):
+        raise InvalidCapabilityError(
+            f"Invalid capability name {name!r}: use lowercase letters, digits, '-' or '_', "
+            "with at most one '/' subdirectory level. The server chooses the file extension."
+        )
+    stripped = content.strip()
+    if not stripped:
+        raise InvalidCapabilityError("Capability content is empty.")
+    is_poml = stripped.startswith("<poml")
+    if is_poml:
+        _validate_poml_renders(content)
+
+    user_root = _user_root()
+    target = user_root / f"{name}{'.poml' if is_poml else '.md'}"
+    existing = [
+        candidate
+        for candidate in (user_root / f"{name}.poml", user_root / f"{name}.md")
+        if candidate.exists()
+    ]
+    if existing and not overwrite:
+        raise InvalidCapabilityError(
+            f"Capability {name!r} already exists ({existing[0].name}); "
+            "pass overwrite=True to replace it."
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    for stale in existing:
+        if stale != target:
+            stale.unlink(missing_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+    summarize = _summary if is_poml else _markdown_summary
+    relative = target.relative_to(user_root)
+    return {
+        "name": f"user/{relative.with_suffix('')}",
+        "path": str(target.resolve()),
+        "summary": summarize(content, relative.stem),
+    }

--- a/test/agent/test_capabilities.py
+++ b/test/agent/test_capabilities.py
@@ -6,7 +6,11 @@ from src.agent.capabilities import list_capabilities
 
 
 def test_lists_every_poml_under_src_agent() -> None:
-    found = {capability["name"] for capability in list_capabilities()}
+    found = {
+        capability["name"]
+        for capability in list_capabilities()
+        if not capability["name"].startswith("user/")
+    }
     on_disk = {
         str(file.relative_to("src/agent").with_suffix(""))
         for file in pathlib.Path("src/agent").rglob("*.poml")

--- a/test/agent/test_user_capabilities.py
+++ b/test/agent/test_user_capabilities.py
@@ -252,3 +252,33 @@ def test_save_wraps_permission_error(
     monkeypatch.setattr(pathlib.Path, "mkdir", _raise_permission_error)
     with pytest.raises(capabilities.InvalidCapabilityError, match="mkdir -p"):
         capabilities.save_capability("battery", "Body text.\n")
+
+
+# --- Residual gap: directory-symlink escape (leaf-only checks missed this) -
+
+
+def test_save_refuses_directory_symlink_escape(
+    tmp_path: pathlib.Path, user_dir: pathlib.Path
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (user_dir / "escape").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(capabilities.InvalidCapabilityError, match="outside|escape|root"):
+        capabilities.save_capability("escape/pwn", "Body text.\n")
+    assert list(outside.iterdir()) == []
+
+
+def test_directory_symlink_contents_not_discovered(
+    tmp_path: pathlib.Path, user_dir: pathlib.Path
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "pwn.md").write_text("# Pwn\n\nSecret.\n", encoding="utf-8")
+    (user_dir / "escape").symlink_to(outside, target_is_directory=True)
+    assert "user/escape/pwn" not in _by_name()
+
+
+def test_save_into_normal_subdirectory_still_works(user_dir: pathlib.Path) -> None:
+    saved = capabilities.save_capability("fleet/battery2", "Check cells again.\n")
+    assert (user_dir / "fleet" / "battery2.md").exists()
+    assert saved["name"] == "user/fleet/battery2"

--- a/test/agent/test_user_capabilities.py
+++ b/test/agent/test_user_capabilities.py
@@ -1,0 +1,82 @@
+"""User-authored capabilities: discovery, markdown support, and saving.
+
+Before this feature, list_capabilities() walked only the builtin src/agent
+tree, so Docker users could not add capabilities without rebuilding the
+image. Now a second root (settings.USER_CAPABILITIES_DIRECTORY) is walked,
+accepting both .poml and .md files, with names prefixed "user/".
+"""
+
+import pathlib
+
+import pytest
+
+from settings import settings
+from src.agent import capabilities
+
+
+@pytest.fixture
+def user_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    directory = tmp_path / "capabilities"
+    directory.mkdir()
+    monkeypatch.setattr(settings, "USER_CAPABILITIES_DIRECTORY", str(directory))
+    return directory
+
+
+def _by_name() -> dict[str, dict[str, str]]:
+    return {capability["name"]: capability for capability in capabilities.list_capabilities()}
+
+
+def test_missing_user_dir_yields_builtins_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "USER_CAPABILITIES_DIRECTORY", "/nonexistent/bagel-capabilities")
+    names = set(_by_name())
+    assert "compose/pipeline" in names
+    assert not any(name.startswith("user/") for name in names)
+
+
+def test_user_poml_discovered_with_prefix_and_absolute_path(user_dir: pathlib.Path) -> None:
+    (user_dir / "battery-triage.poml").write_text(
+        "<poml><task>Check battery health after a flight. Then report.</task></poml>",
+        encoding="utf-8",
+    )
+    entry = _by_name()["user/battery-triage"]
+    assert pathlib.Path(entry["path"]).is_absolute()
+    assert entry["summary"] == "Check battery health after a flight."
+
+
+def test_user_markdown_discovered_and_summarized(user_dir: pathlib.Path) -> None:
+    (user_dir / "preflight.md").write_text(
+        "# Preflight check\n\nVerify props and battery before arming. Then log it.\n",
+        encoding="utf-8",
+    )
+    entry = _by_name()["user/preflight"]
+    assert entry["summary"] == "Verify props and battery before arming."
+
+
+def test_markdown_summary_falls_back_to_h1_then_stem(user_dir: pathlib.Path) -> None:
+    (user_dir / "only-heading.md").write_text("# Only A Heading\n", encoding="utf-8")
+    (user_dir / "empty.md").write_text("", encoding="utf-8")
+    by_name = _by_name()
+    assert by_name["user/only-heading"]["summary"] == "Only A Heading."
+    assert by_name["user/empty"]["summary"] == "empty."
+
+
+def test_same_stem_as_builtin_does_not_collide(user_dir: pathlib.Path) -> None:
+    (user_dir / "compose").mkdir()
+    (user_dir / "compose" / "pipeline.poml").write_text(
+        "<poml><task>My own pipeline recipe. Extra.</task></poml>", encoding="utf-8"
+    )
+    by_name = _by_name()
+    assert "compose/pipeline" in by_name  # builtin untouched
+    assert "user/compose/pipeline" in by_name  # user's version, distinct name
+
+
+def test_nested_subdirectory_preserved_in_name(user_dir: pathlib.Path) -> None:
+    (user_dir / "fleet").mkdir()
+    (user_dir / "fleet" / "battery-triage.md").write_text("Check cells.\n", encoding="utf-8")
+    assert "user/fleet/battery-triage" in _by_name()
+
+
+def test_combined_list_sorted_by_name(user_dir: pathlib.Path) -> None:
+    (user_dir / "aaa.md").write_text("First.\n", encoding="utf-8")
+    names = [capability["name"] for capability in capabilities.list_capabilities()]
+    assert names == sorted(names)

--- a/test/agent/test_user_capabilities.py
+++ b/test/agent/test_user_capabilities.py
@@ -162,3 +162,93 @@ def test_save_tool_round_trip(user_dir: pathlib.Path) -> None:
     assert saved["name"] == "user/via-tool"
     names = {capability["name"] for capability in server.list_agent_capabilities()}
     assert "user/via-tool" in names
+
+
+# --- Item 1: user/ round-trip double-prefix -------------------------------
+
+
+def test_save_with_discovered_user_prefix_overwrites_same_file(user_dir: pathlib.Path) -> None:
+    capabilities.save_capability("battery", "First.\n")
+    saved = capabilities.save_capability("user/battery", "Second.\n", overwrite=True)
+    assert saved["name"] == "user/battery"
+    assert (user_dir / "battery.md").exists()
+    assert not (user_dir / "user").exists()
+    assert (user_dir / "battery.md").read_text(encoding="utf-8") == "Second.\n"
+
+
+def test_bare_user_name_is_a_normal_slug(user_dir: pathlib.Path) -> None:
+    saved = capabilities.save_capability("user", "Just user.\n")
+    assert saved["name"] == "user/user"
+    assert (user_dir / "user.md").exists()
+    assert not (user_dir / "user").exists()
+
+
+# --- Item 2: _markdown_summary and numbered-step markdown ------------------
+
+
+def test_markdown_summary_strips_numbered_list_marker(user_dir: pathlib.Path) -> None:
+    (user_dir / "steps.md").write_text("1. Open the bag. 2. Check topics.\n", encoding="utf-8")
+    assert _by_name()["user/steps"]["summary"] == "Open the bag."
+
+
+def test_markdown_summary_skips_front_matter_delimiter(user_dir: pathlib.Path) -> None:
+    (user_dir / "fm.md").write_text(
+        "---\nCheck the props before flight. Then log it.\n", encoding="utf-8"
+    )
+    assert _by_name()["user/fm"]["summary"] == "Check the props before flight."
+
+
+def test_markdown_summary_skips_leading_code_fence(user_dir: pathlib.Path) -> None:
+    (user_dir / "fenced.md").write_text(
+        "```\ncode here\n```\n\nRun the checklist twice. Then verify.\n",
+        encoding="utf-8",
+    )
+    assert _by_name()["user/fenced"]["summary"] == "Run the checklist twice."
+
+
+# --- Item 3: render-failure diagnostics ------------------------------------
+
+
+def test_save_rejects_non_rendering_poml_with_diagnostic(user_dir: pathlib.Path) -> None:
+    with pytest.raises(capabilities.InvalidCapabilityError) as exc_info:
+        capabilities.save_capability(
+            "broken-component",
+            "<poml><bogus-elem>hi</bogus-elem><task>Do something.</task></poml>",
+        )
+    message = str(exc_info.value)
+    assert "not found" in message.lower() or "server log" in message.lower()
+
+
+# --- Item 4: symlink write-through and discovery ---------------------------
+
+
+def test_save_refuses_symlink_write_through(tmp_path: pathlib.Path, user_dir: pathlib.Path) -> None:
+    victim = tmp_path / "victim.md"
+    victim.write_text("original\n", encoding="utf-8")
+    (user_dir / "linked.md").symlink_to(pathlib.Path("../victim.md"))
+    with pytest.raises(capabilities.InvalidCapabilityError, match="symlink"):
+        capabilities.save_capability("linked", "New content.\n", overwrite=True)
+    assert victim.read_text(encoding="utf-8") == "original\n"
+
+
+def test_symlinked_capability_not_discovered(
+    tmp_path: pathlib.Path, user_dir: pathlib.Path
+) -> None:
+    victim = tmp_path / "victim.md"
+    victim.write_text("# Victim\n\nSecret content.\n", encoding="utf-8")
+    (user_dir / "linked.md").symlink_to(pathlib.Path("../victim.md"))
+    assert "user/linked" not in _by_name()
+
+
+# --- Item 5: first-save PermissionError on Linux ---------------------------
+
+
+def test_save_wraps_permission_error(
+    user_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _raise_permission_error(self: pathlib.Path, *args: object, **kwargs: object) -> None:
+        raise PermissionError("Permission denied")
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", _raise_permission_error)
+    with pytest.raises(capabilities.InvalidCapabilityError, match="mkdir -p"):
+        capabilities.save_capability("battery", "Body text.\n")

--- a/test/agent/test_user_capabilities.py
+++ b/test/agent/test_user_capabilities.py
@@ -80,3 +80,59 @@ def test_combined_list_sorted_by_name(user_dir: pathlib.Path) -> None:
     (user_dir / "aaa.md").write_text("First.\n", encoding="utf-8")
     names = [capability["name"] for capability in capabilities.list_capabilities()]
     assert names == sorted(names)
+
+
+VALID_POML = "<poml><task>Saved workflow. More detail.</task></poml>"
+
+
+def test_save_poml_round_trip(user_dir: pathlib.Path) -> None:
+    saved = capabilities.save_capability("battery-triage", VALID_POML)
+    assert saved["name"] == "user/battery-triage"
+    assert saved["path"].endswith("battery-triage.poml")
+    assert saved["summary"] == "Saved workflow."
+    assert "user/battery-triage" in _by_name()
+
+
+def test_save_markdown_round_trip(user_dir: pathlib.Path) -> None:
+    saved = capabilities.save_capability("preflight", "# Preflight\n\nCheck the props.\n")
+    assert saved["path"].endswith("preflight.md")
+    assert saved["summary"] == "Check the props."
+
+
+def test_save_into_subdirectory(user_dir: pathlib.Path) -> None:
+    saved = capabilities.save_capability("fleet/battery", "Check cells.\n")
+    assert (user_dir / "fleet" / "battery.md").exists()
+    assert saved["name"] == "user/fleet/battery"
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["../escape", "/absolute", "Upper", "a b", "a/b/c", "", "name.poml"],
+)
+def test_save_rejects_bad_names(user_dir: pathlib.Path, bad_name: str) -> None:
+    with pytest.raises(capabilities.InvalidCapabilityError):
+        capabilities.save_capability(bad_name, "content")
+
+
+def test_save_rejects_empty_content(user_dir: pathlib.Path) -> None:
+    with pytest.raises(capabilities.InvalidCapabilityError, match="empty"):
+        capabilities.save_capability("blank", "   \n")
+
+
+def test_save_rejects_non_rendering_poml_and_writes_nothing(user_dir: pathlib.Path) -> None:
+    with pytest.raises(capabilities.InvalidCapabilityError, match="render"):
+        capabilities.save_capability("broken", "<poml><task>unclosed")
+    assert list(user_dir.rglob("*")) == []
+
+
+def test_save_collision_requires_overwrite(user_dir: pathlib.Path) -> None:
+    capabilities.save_capability("dupe", "First.\n")
+    with pytest.raises(capabilities.InvalidCapabilityError, match="overwrite=True"):
+        capabilities.save_capability("dupe", "Second.\n")
+
+
+def test_overwrite_replaces_across_formats(user_dir: pathlib.Path) -> None:
+    capabilities.save_capability("swap", "Markdown first.\n")
+    capabilities.save_capability("swap", VALID_POML, overwrite=True)
+    assert (user_dir / "swap.poml").exists()
+    assert not (user_dir / "swap.md").exists()

--- a/test/agent/test_user_capabilities.py
+++ b/test/agent/test_user_capabilities.py
@@ -136,3 +136,29 @@ def test_overwrite_replaces_across_formats(user_dir: pathlib.Path) -> None:
     capabilities.save_capability("swap", VALID_POML, overwrite=True)
     assert (user_dir / "swap.poml").exists()
     assert not (user_dir / "swap.md").exists()
+
+
+def test_run_markdown_capability_end_to_end(user_dir: pathlib.Path) -> None:
+    import server
+
+    saved = capabilities.save_capability("checklist", "# Checklist\n\nDo the thing.\n")
+    result = server.run_poml_capability(saved["path"])
+    assert isinstance(result, list) and len(result) == 1
+    assert "Do the thing." in result[0]["content"]
+
+
+def test_run_markdown_with_context_raises(user_dir: pathlib.Path) -> None:
+    import server
+
+    saved = capabilities.save_capability("static", "No variables here.\n")
+    with pytest.raises(capabilities.InvalidCapabilityError, match="POML"):
+        server.run_poml_capability(saved["path"], poml_context={"x": 1})
+
+
+def test_save_tool_round_trip(user_dir: pathlib.Path) -> None:
+    import server
+
+    saved = server.save_agent_capability("via-tool", VALID_POML)
+    assert saved["name"] == "user/via-tool"
+    names = {capability["name"] for capability in server.list_agent_capabilities()}
+    assert "user/via-tool" in names


### PR DESCRIPTION
Closes the extensibility gap for Docker users: today a capability can only be added by forking the repo and rebuilding the image. After this, a stock-container user creates one **in conversation** or **by dropping a file** — and both land in the same mounted directory.

## Two doors, one directory

**In conversation** (works in Claude Code, Claude Desktop, any MCP client):
> *"That triage we just did — save it as a capability called battery-triage."*

Claude calls the new **`save_agent_capability`** tool; bagel writes the file inside the container; the volume mount persists it on the host; it's immediately discoverable and runnable.

**As a file:** drop a `.md` (or `.poml`) into `~/.bagel/capabilities/` — no restart, no rebuild.

Either way it appears in `list_agent_capabilities` as `user/<name>` and runs via `run_poml_capability`.

## What's in it

- **`USER_CAPABILITIES_DIRECTORY`** (default `~/.bagel/capabilities`), mounted into all 11 compose services beside the existing artifacts mount. Missing directory = builtins only, no error.
- **Markdown capabilities**, not just POML — markdown is what people already write, and team runbooks drop in nearly verbatim. POML remains the upgrade path for parameterized templates (`poml_context` + a `.md` file raises a clean typed error rather than silently ignoring the context).
- **`save_agent_capability`**: name-slug validation, content sniffing (POML is render-validated *before* anything is written), one format per name, `overwrite` semantics, and discovery-shaped return so the LLM can confirm what it saved.
- Builtins under `src/agent/` stay POML-only and are **immutable through the tool**.

## Confinement

Writes are confined to the configured directory, enforced by a single resolved-root containment helper used by **both** the write and discovery paths — so neither a leaf-file symlink nor a directory symlink can escape. Review probed the name parameter with 7 traversal variants plus two purpose-built bypass attempts (round-tripping through the `user/` prefix; symlink resolving back inside the root): all blocked, normal one-level subdirectory saves unaffected. Failed POML renders now surface the renderer's actual diagnostic (e.g. *"Component bogus-elem not found"*) instead of a JSON parse error, so the authoring loop can self-correct. SECURITY.md documents the tool as the first whose writes are driven by LLM-authored *content* (several tools already write to disk) and records the guarantees.

## Notes

- **Merge order: #156 → #157 → this** (stacked on `feat/claude-skills-plugin`).
- Linux users: `mkdir -p ~/.bagel/capabilities` once before first start, so the bind-mount is owned by you rather than root — documented in the README, and the save path now raises a typed error with that guidance instead of a raw `PermissionError`. CI mirrors the artifacts mkdir/chmod for parity.
- Zero behavior change for anyone who never uses the feature: the default directory simply doesn't exist until first use.

Tests: 26 new (discovery, markdown summaries incl. numbered-list/front-matter/fence handling, save validation and confinement, symlink guards, server round-trip); full local suite 443 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdffiadRLDgXeP1gxP9eVs
