### PR TITLE
ci: publish to the MCP registry via GitHub Actions OIDC

### DIFF
--- a/.github/workflows/mcp-registry-publish.yaml
+++ b/.github/workflows/mcp-registry-publish.yaml
@@ -1,0 +1,43 @@
+# Publishes server.json to the official MCP registry
+# (registry.modelcontextprotocol.io) using GitHub Actions OIDC.
+#
+# Why OIDC and not `mcp-publisher login github`: the interactive flow derives
+# org-namespace permission from the user's OAuth token, which org third-party
+# access policies can silently block (and its registry JWT expires in 5
+# minutes). The OIDC token minted by Actions carries the repository owner
+# directly, so a run in this repo is authorized for io.github.extelligence-ai/*
+# with no user tokens involved.
+#
+# Run it manually (Actions tab or `gh workflow run mcp-registry-publish`)
+# after bumping the version in pyproject.toml and server.json and letting
+# `publish` push the matching image tag.
+
+name: mcp-registry-publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # mint the OIDC token mcp-publisher exchanges
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL -o mcp-publisher.tar.gz \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+      - name: Publish server.json to the MCP registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+      - name: Verify listing
+        run: |
+          sleep 5
+          curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=extelligence" \
+            | grep -q "io.github.extelligence-ai/bagel" \
+            && echo "Listed on the official MCP registry." \
+            || { echo "Server not found in registry search"; exit 1; }

--- a/.github/workflows/mcp-registry-publish.yaml
+++ b/.github/workflows/mcp-registry-publish.yaml
@@ -20,6 +20,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # The environment's deployment branch policy only allows main, so the
+    # org-scoped OIDC token can only be minted by workflow code that went
+    # through review -- a writer cannot dispatch a modified copy from a side
+    # branch (Copilot finding on #166).
+    environment: mcp-registry
     permissions:
       id-token: write # mint the OIDC token mcp-publisher exchanges
       contents: read
@@ -29,6 +34,10 @@ jobs:
         run: |
           curl -fsSL -o mcp-publisher.tar.gz \
             https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+          # Release assets are mutable; pin the digest (verified locally
+          # against the v1.8.1 asset) so a substituted binary cannot run
+          # with this job's OIDC access.
+          echo "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc  mcp-publisher.tar.gz" | sha256sum -c -
           tar -xzf mcp-publisher.tar.gz mcp-publisher
       - name: Publish server.json to the MCP registry
         run: |


### PR DESCRIPTION
The interactive `mcp-publisher login github` flow cannot get the org namespace here: the registry's GitHub App token is filtered by org third-party access policy (registry only grants `io.github.arunvenkatadri/*` even though the user is an org Owner), and its 5-minute JWT makes the login→publish handoff race-prone. The registry's documented CI path (`github-oidc`) authorizes `io.github.extelligence-ai/*` from the workflow's OIDC token directly.

Manual `workflow_dispatch`: run it after a version bump once `publish` has pushed the matching image tag. Includes a post-publish verification step that fails the run if the server doesn't appear in registry search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1