### PR TITLE
fix: registry namespace casing + 2.0.1

### DIFF
--- a/.github/workflows/mcp-registry-publish.yaml
+++ b/.github/workflows/mcp-registry-publish.yaml
@@ -5,7 +5,7 @@
 # org-namespace permission from the user's OAuth token, which org third-party
 # access policies can silently block (and its registry JWT expires in 5
 # minutes). The OIDC token minted by Actions carries the repository owner
-# directly, so a run in this repo is authorized for io.github.extelligence-ai/*
+# directly, so a run in this repo is authorized for io.github.Extelligence-ai/*
 # with no user tokens involved.
 #
 # Run it manually (Actions tab or `gh workflow run mcp-registry-publish`)
@@ -47,6 +47,6 @@ jobs:
         run: |
           sleep 5
           curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=extelligence" \
-            | grep -q "io.github.extelligence-ai/bagel" \
+            | grep -q "io.github.Extelligence-ai/bagel" \
             && echo "Listed on the official MCP registry." \
             || { echo "Server not found in registry search"; exit 1; }

--- a/docker/Dockerfile.ardupilot
+++ b/docker/Dockerfile.ardupilot
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools
 # hadolint ignore=DL3008

--- a/docker/Dockerfile.arrow
+++ b/docker/Dockerfile.arrow
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools
 # hadolint ignore=DL3008

--- a/docker/Dockerfile.betaflight
+++ b/docker/Dockerfile.betaflight
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools
 # hadolint ignore=DL3008

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools
 # hadolint ignore=DL3008

--- a/docker/Dockerfile.px4
+++ b/docker/Dockerfile.px4
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools
 # hadolint ignore=DL3008

--- a/docker/Dockerfile.ros1
+++ b/docker/Dockerfile.ros1
@@ -3,7 +3,7 @@
 FROM ros:noetic
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Set the shell to use for RUN commands, enabling pipefail for robust scripting
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -2,7 +2,7 @@ ARG ROS_DISTRO
 FROM ros:${ROS_DISTRO}-ros-core
 # MCP registry ownership proof: registry.modelcontextprotocol.io validates
 # this label on the public image before accepting the server record.
-LABEL io.modelcontextprotocol.server.name="io.github.extelligence-ai/bagel"
+LABEL io.modelcontextprotocol.server.name="io.github.Extelligence-ai/bagel"
 
 # Install common tools and ROS2 packages
 # hadolint ignore=DL3008

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.0.0"
+version = "2.0.1"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.extelligence-ai/bagel",
+  "name": "io.github.Extelligence-ai/bagel",
   "title": "Bagel",
   "description": "Plain-English analysis of robotics, drone, and IoT data, with intelligent edge data reduction.",
   "repository": {
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.0.0",
+      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.0.1",
       "transport": {
         "type": "sse",
         "url": "http://127.0.0.1:8000/sse"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.0.0"
+version = "2.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
The OIDC publish (#166) authenticated successfully and received org-namespace permission: `io.github.Extelligence-ai/*` — canonical GitHub casing from the OIDC `repository_owner` claim. The 403 was a case mismatch with `server.json`'s lowercase name, and the registry's OCI label check is also case-sensitive (`mcpName != serverName`, strict equality).

- `server.json`: name → `io.github.Extelligence-ai/bagel`, version → 2.0.1, package pin → `:2.0.1`
- All 7 Dockerfile `LABEL`s → canonical casing (ghcr *paths* stay lowercase as ghcr requires; only name/label carry org casing)
- `pyproject.toml`/`uv.lock` → 2.0.1, because `:2.0.0` is immutable by the push-once guard and the relabeled images need a fresh pinnable tag

After merge: publish pushes `:2.0.1` with the corrected label (~15 min), then dispatch `mcp-registry-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1