### PR TITLE
feat: agent onboarding (AGENTS.md, CLAUDE.md, MCP instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Bagel for agents
+
+Instructions for AI agents asked to set up, use, or develop Bagel.
+
+## Set up Bagel for a user
+
+1. Requires Docker. Pick the service matching their stack (see the table in
+   README Quickstart): `ros2-kilted`, `ros2-jazzy`, `ros2-iron`, `ros2-humble`,
+   `ros1-noetic`, `ros1-noetic-cv`, `px4`, `ardupilot`, `betaflight`, or `iot`.
+2. Start it: `docker compose run --service-ports <service>` and wait for
+   `Uvicorn running on http://0.0.0.0:8000`.
+   - Port 8000 taken? `MCP_SERVER_PORT=8100 docker compose run --service-ports
+     <service>` and use 8100 below.
+3. Connect the MCP client to `http://localhost:8000/sse` (SSE transport).
+   Claude Code: `claude mcp add --transport sse bagel http://localhost:8000/sse`
+4. Verify with a smoke test on bundled data:
+   "Summarize the metadata of the ROS2 bag ./data/sample/ros2/mcap".
+5. To analyze the user's own files, mount them: uncomment `volumes` under the
+   chosen service in `compose.yaml` before starting.
+
+## Use Bagel well
+
+- Answers come from DuckDB SQL over real messages. Do not do the math yourself;
+  ask Bagel and show the user the generated query.
+- Call `describe_source` first, and `describe_topic` before writing predicates
+  (field paths and units vary by source).
+- Reduction etiquette: `preview_pipeline` first, report detected events and
+  kept seconds, get user confirmation, then `run_pipeline`.
+- Output artifacts are written under the artifacts directory; tools return the
+  paths.
+
+## Develop on Bagel
+
+- Runtime-independent tests run on the host: `uv sync` then
+  `uv run pytest test/*.py test/pipeline test/sink` (full list in
+  `.github/workflows/test.yaml`, job `host-tests`).
+- Service-bound tests run inside the images:
+  `docker compose build <service> --build-arg DEV_MODE=true` then
+  `docker compose run --rm <service> uv run pytest ./test`.
+- Every test file must be reachable by CI: `test/test_ci_reachability.py`
+  fails the build otherwise (add new paths to `host-tests` or a Dockerfile).
+- Lint: `uv run ruff check` and `uv run ruff format` before committing.
+- Versioning: image tags and `server.json` follow `pyproject.toml`; published
+  semver image tags are immutable (bump the version instead of retagging).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+See [AGENTS.md](./AGENTS.md) for setup, usage etiquette, and development
+workflow. It is the single source of truth for agent instructions in this repo.

--- a/server.py
+++ b/server.py
@@ -30,6 +30,18 @@ server = mcp_compat.create_server(
     name="Bagel MCP Server",
     host=settings.MCP_SERVER_HOST,
     port=settings.MCP_SERVER_PORT,
+    instructions=(
+        "Bagel answers questions about robotics, drone, and IoT data (ROS 1/2 "
+        "bags, MCAP, PX4/ArduPilot/Betaflight logs, CAN/MF4, live MQTT) by "
+        "generating DuckDB SQL over the actual messages: never estimate a "
+        "numeric answer yourself, and show the user the query you ran. "
+        "Workflow: describe_source first for an overview; describe_topic before "
+        "writing any predicate (field paths and units differ per source). For "
+        "event detection and data reduction, always preview_pipeline and report "
+        "events/kept-seconds before run_pipeline writes anything. Sample data "
+        "for smoke tests lives in ./data/sample/. Outputs land under the "
+        "artifacts directory and paths are returned by the tools."
+    ),
 )
 
 
@@ -565,9 +577,7 @@ def preview_pipeline(  # noqa: PLR0913
         "run later with `run.py`. Returns the path to the written file."
     ),
 )
-def save_pipeline(
-    config: dict[str, Any], name: str, directory: str = "pipelines"
-) -> str:
+def save_pipeline(config: dict[str, Any], name: str, directory: str = "pipelines") -> str:
     """Write a pipeline configuration to a YAML file.
 
     Args:
@@ -726,7 +736,8 @@ def export_for_plotjuggler(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -795,7 +806,8 @@ def export_for_rerun(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -864,7 +876,8 @@ def export_for_lichtblick(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
@@ -937,7 +950,8 @@ def export_for_lerobot(  # noqa: PLR0913
     ds_type = resolve(path)
     factory = module.provide(
         # args first: the explicit `path` parameter must always win.
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}",
+        {**(args or {}), "path": path},
     )
     registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
     dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})

--- a/src/mcp_compat.py
+++ b/src/mcp_compat.py
@@ -23,14 +23,16 @@ except ImportError:  # mcp 1.x
     MCP_SDK_V2 = False
 
 
-def create_server(name: str, host: str, port: int) -> Any:  # noqa: ANN401 -- SDK type varies by major version
+def create_server(name: str, host: str, port: int, instructions: str | None = None) -> Any:  # noqa: ANN401 -- SDK type varies by major version
     """Create the MCP server object for whichever SDK major version is installed.
 
     v1 takes host/port at construction; v2 takes them at `run()` (see `run_server`).
+    `instructions` is delivered to every client at the initialize handshake on
+    both majors: it is the one server-authored prompt surface agents read.
     """
     if MCP_SDK_V2:
-        return _Server(name=name)
-    return _Server(name=name, host=host, port=port)
+        return _Server(name=name, instructions=instructions)
+    return _Server(name=name, instructions=instructions, host=host, port=port)
 
 
 def run_server(server: Any, transport: str, host: str, port: int) -> None:  # noqa: ANN401

--- a/test/test_mcp_compat.py
+++ b/test/test_mcp_compat.py
@@ -37,3 +37,11 @@ def test_exactly_one_sdk_branch_is_active() -> None:
     # Under the project venv this is v1; under the v2 beta venv it flips. Either
     # way the flag must be a real bool and the server class importable.
     assert isinstance(mcp_compat.MCP_SDK_V2, bool)
+
+
+def test_create_server_passes_instructions_to_the_client_handshake() -> None:
+    """Server-level instructions must reach the SDK so clients get them at init."""
+    server = mcp_compat.create_server(
+        name="test", host="127.0.0.1", port=18001, instructions="Use preview before run."
+    )
+    assert server.instructions == "Use preview before run."


### PR DESCRIPTION
Agents are a first-class audience now (registry live, `chatgpt.com` already in the referrer table). Three pieces:

- **AGENTS.md**: rails for an agent asked to set up, use, or develop Bagel: service table, port-collision fix, connect URL, bundled smoke test, tool etiquette (describe before predicates, preview before run), dev workflow.
- **CLAUDE.md**: pointer to AGENTS.md (single source of truth).
- **MCP `instructions` field**: `create_server()` now passes `instructions=` through the v1/v2 compat layer (test-first), and `server.py` sets server-level guidance delivered at every client handshake: the SQL-not-guessing contract and preview-before-run etiquette.

Independent of the #160/#163/#162 stack (new files + a small `server.py`/`mcp_compat.py` hunk away from stack edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1