### PR TITLE
feat: glama.json for claiming the Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "arunvenkatadri"
+  ]
+}


### PR DESCRIPTION
Glama's org-claim flow requires a `maintainers` manifest at the repo root before "Login with GitHub to claim" works. Lists @arunvenkatadri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1