### PR TITLE
fix: keep sample data in published images (quickstart's first prompt fails without it)

### DIFF
--- a/docker/Dockerfile.ardupilot
+++ b/docker/Dockerfile.ardupilot
@@ -91,7 +91,7 @@ COPY --chown=${USERNAME}:${USERNAME} test/topic/ardupilot ./test/topic/ardupilot
 COPY --chown=${USERNAME}:${USERNAME} test/message/ardupilot ./test/message/ardupilot
 COPY --chown=${USERNAME}:${USERNAME} test/logging/ardupilot ./test/logging/ardupilot
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.arrow
+++ b/docker/Dockerfile.arrow
@@ -82,7 +82,7 @@ RUN uv run python -c "import server"
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.betaflight
+++ b/docker/Dockerfile.betaflight
@@ -91,7 +91,7 @@ COPY --chown=${USERNAME}:${USERNAME} test/topic/betaflight ./test/topic/betaflig
 COPY --chown=${USERNAME}:${USERNAME} test/message/betaflight ./test/message/betaflight
 COPY --chown=${USERNAME}:${USERNAME} test/logging/betaflight ./test/logging/betaflight
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -86,7 +86,7 @@ RUN uv run python -c "import server"
 # Copy sample data
 COPY --chown=${USERNAME}:${USERNAME} data/sample/ ./data/sample/
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.px4
+++ b/docker/Dockerfile.px4
@@ -90,7 +90,7 @@ COPY --chown=${USERNAME}:${USERNAME} test/topic/px4 ./test/topic/px4
 COPY --chown=${USERNAME}:${USERNAME} test/message/px4 ./test/message/px4
 COPY --chown=${USERNAME}:${USERNAME} test/logging/px4 ./test/logging/px4
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.ros1
+++ b/docker/Dockerfile.ros1
@@ -161,7 +161,7 @@ COPY --chown=${USERNAME}:${USERNAME} test/topic/ros1 ./test/topic/ros1
 COPY --chown=${USERNAME}:${USERNAME} test/message/ros1 ./test/message/ros1
 COPY --chown=${USERNAME}:${USERNAME} test/logging/ros1 ./test/logging/ros1
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -99,7 +99,7 @@ COPY --chown=${USERNAME}:${USERNAME} test/topic/ros2 ./test/topic/ros2
 COPY --chown=${USERNAME}:${USERNAME} test/message/ros2 ./test/message/ros2
 COPY --chown=${USERNAME}:${USERNAME} test/logging/ros2 ./test/logging/ros2
 
-RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test ./data; fi
+RUN if [ "_$DEV_MODE" = "_false" ]; then rm -rf ./test; fi
 
 # By default, the Bagel MCP server will be launched
 CMD ["uv", "run", "server.py", "--transport", "sse"]


### PR DESCRIPTION
Launch-readiness matrix finding: `DEV_MODE=false` strips `./data` from every published image, so the README quickstart's first prompt fails for every pulled-image user with "Cannot resolve data source type: ./data/sample/ros2/mcap". Likely explains the cloners-up/retention-flat traffic pattern: first prompt fails, silent bounce.

One line per Dockerfile: strip only `./test`. Sample data is 21 MB against multi-GB images. Verified with a `DEV_MODE=false` build: `data/sample` present, `test` still stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1