### PR TITLE
docs: three UAT findings (synth location, run_pipeline config, lichtblick workaround)

### DIFF
--- a/doc/runbooks/data_reduction.md
+++ b/doc/runbooks/data_reduction.md
@@ -60,8 +60,12 @@ docker compose run --rm ros2-jazzy \
 The reduced bag is written under the artifact directory
 (`~/.bagel/artifacts/pipeline=hard_decel_reduce/...`).
 
-Or drive it conversationally from an MCP client with `run_pipeline` (build + run a config)
-and `save_pipeline` (persist a config as YAML for reuse).
+Or drive it conversationally from an MCP client: `preview_pipeline` takes the
+flat arguments shown above, but `run_pipeline` takes a full pipeline `config`
+dict (the same shape as the YAML: `name`, `path`, `cadence`, `tasks`), and
+`save_pipeline` persists a config as YAML for reuse. Your LLM assembles the
+config from the preview parameters; the reduce task module for MCAP output is
+`src.pipeline.tasks.reduce.mcap`.
 
 ## Reduce an MCAP bag
 
@@ -216,6 +220,10 @@ To generate a standalone synthetic telemetry bag (db3 or mcap) for manual experi
 ```bash
 uv run python -m test.pipeline.integration.synth --directory ./data/synthetic --storage mcap
 ```
+
+> [!NOTE]
+> Run the synthesizer from a repo checkout on the host: published images strip
+> the `test/` tree, so the module is not available inside a pulled container.
 
 > [!NOTE]
 > The bundled ROS2 sample (`data/sample/ros2/db3`) contains only `std_msgs/String`

--- a/doc/runbooks/lichtblick.md
+++ b/doc/runbooks/lichtblick.md
@@ -42,3 +42,11 @@ framed to the window.
   [Rerun](./rerun.md) exports; pick the viewer your team already uses.
 - If Bagel runs in Docker, artifacts land in `~/.bagel/artifacts` on the host
   (the compose services mount it).
+
+## Troubleshooting
+
+- **Plot panel opens empty** with the exported layout: clear the plot's X-axis
+  min/max (panel settings) and it will auto-fit. Exported layouts currently
+  write absolute-epoch X bounds while Lichtblick's timestamp axis uses elapsed
+  seconds, which parks the preset viewport far from the data: a fix in
+  `export_for_lichtblick` is tracked. Y-axis framing is unaffected.


### PR DESCRIPTION
Documentation gaps found during manual UAT, all reproduced in session:

1. **data_reduction**: `python -m test.pipeline.integration.synth` fails inside pulled containers (`test/` is stripped from published images) — noted that it runs from a host checkout.
2. **data_reduction**: `preview_pipeline` takes flat args, `run_pipeline` takes a full `config` dict — the conversational flow now states the shape and names `src.pipeline.tasks.reduce.mcap`.
3. **lichtblick**: workaround for the empty-plot-on-open issue (clear X-axis bounds) until the `export_for_lichtblick` absolute-epoch X-range fix lands (bug being fixed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1