### PR TITLE
fix: Lichtblick layouts open empty (absolute-epoch X bounds)

### DIFF
--- a/src/pipeline/lichtblick.py
+++ b/src/pipeline/lichtblick.py
@@ -99,11 +99,16 @@ def write_mcap(relation: duckdb.DuckDBPyRelation, mcap_file: pathlib.Path) -> No
 
 def build_layout(
     paths: list[str],
-    x_range: tuple[float, float],
     y_range: tuple[float, float],
     tab_title: str,
 ) -> str:
-    """Build a Lichtblick layout JSON string with one pre-framed Plot panel."""
+    """Build a Lichtblick layout JSON string with one pre-framed Plot panel.
+
+    The X axis carries no explicit bounds: Lichtblick's ``timestamp`` axis is
+    elapsed seconds since playback start, so absolute-epoch bounds would park
+    the viewport far from the data. The exported MCAP contains only the kept
+    window, so the viewer's auto-fit frames it exactly.
+    """
     plot_id = "Plot!bagel"
     layout = {
         "configById": {
@@ -120,8 +125,6 @@ def build_layout(
                 "showPlotValuesInLegend": False,
                 "isSynced": True,
                 "xAxisVal": "timestamp",
-                "minXValue": x_range[0],
-                "maxXValue": x_range[1],
                 "minYValue": y_range[0],
                 "maxYValue": y_range[1],
                 "sidebarDimension": 240,
@@ -214,7 +217,6 @@ def export_window(  # noqa: PLR0913
     layout_file.write_text(
         build_layout(
             paths,
-            x_range=(start_seconds, end_seconds),
             y_range=(low - pad, high + pad),
             tab_title=name,
         )

--- a/test/pipeline/test_lichtblick_export.py
+++ b/test/pipeline/test_lichtblick_export.py
@@ -44,8 +44,11 @@ def test_layout_matches_lichtblick_schema() -> None:
 
     plot = layout["configById"]["Plot!bagel"]
     assert plot["xAxisVal"] == "timestamp"
-    assert plot["minXValue"] == 15.0
-    assert plot["maxXValue"] == 25.0
+    # Lichtblick's timestamp axis is elapsed-seconds-since-start; absolute-epoch
+    # bounds park the viewport ~1.7e9 units from the data (UAT 2026-08-15).
+    # The MCAP contains only the window, so omitting bounds auto-fits perfectly.
+    assert "minXValue" not in plot
+    assert "maxXValue" not in plot
     assert plot["minYValue"] < plot["maxYValue"]
     assert {"value", "enabled", "timestampMethod"} <= set(plot["paths"][0])
     assert "message.vel" in {p["value"] for p in plot["paths"]}


### PR DESCRIPTION
UAT finding (reproduced in a real Lichtblick session): exported layouts open with an empty plot because `minXValue`/`maxXValue` are written as absolute epoch seconds while Lichtblick's `timestamp` X axis is elapsed-seconds-since-playback-start — the preset viewport sits ~1.7e9 units from the data.

Fix: omit the X bounds entirely. The exported MCAP contains only the kept window, so the viewer's auto-fit frames it exactly; this is also robust where relative bounds wouldn't be (multi-source sessions shift playback start). Y framing unchanged. `build_layout` loses the now-unused `x_range` parameter.

TDD: schema test asserts the bounds are absent (watched fail → pass). Full `test/pipeline` suite green. Note: this test file runs in CI once #163's host-tests job lands; until then it's host-verified here.

Closes the workaround documented in #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9eM9YhDiDfqsVaodZwfw1