### PR TITLE
chore: add CODEOWNERS (maintainer-only approvals)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every change needs a review from a maintainer (enforced via the main
+# ruleset's "Require review from Code Owners" setting).
+* @arunvenkatadri @shouhengyi


### PR DESCRIPTION
Names @arunvenkatadri and @shouhengyi as code owners for everything.

On its own this file changes nothing. It takes effect when "Require review from Code Owners" is ticked in the main ruleset's pull-request rule: from then on, a contributor PR only unblocks when one of the two named maintainers approves. Reviews from other write-access users no longer satisfy the requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)