### PR TITLE
Add hardware auto-detection: snap_hardware tool + waffle.snap task (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ depends entirely on your workload.
 | **Drones**   | PX4, ArduPilot, Betaflight     |
 | **Automotive** | ASAM MDF4 (`.mf4`), CAN captures (`.blf`/`.asc` + DBC) · *beta* |
 | **IoT**      | MQTT (live, Sparkplug B), PostgreSQL / TimescaleDB, InfluxDB 3 |
+| **Hardware state** | [WaffleForm](./doc/runbooks/waffle.md) snapshots (`.waffleform.yaml`), auto-detected via waffle-iron · *experimental* |
 
 ## 🆚 Bagel vs. the Tools You Already Use
 

--- a/doc/runbooks/waffle.md
+++ b/doc/runbooks/waffle.md
@@ -32,6 +32,28 @@ Point the batch tools at a fleet's worth of forms:
 
 > Across ./fleet/*.waffleform.yaml, which robots still run nav2 1.1.12?
 
+## Automatic detection: snapshot the live robot
+
+You don't have to write the WaffleForm by hand. With waffle-iron installed on the
+robot (`cargo install waffle-iron`), ask Bagel:
+
+> What hardware is this robot actually running right now?
+
+The `snap_hardware` tool runs `waffle snap` (or `waffle init` on first contact),
+which auto-detects connected hardware, firmware, and software versions, then
+returns the parsed state. For continuous history, add the `waffle.snap` pipeline
+task on a cadence — every snapshot lands in the artifact directory as a
+timestamped, queryable `.waffleform.yaml`:
+
+> Every hour, snapshot the hardware state.
+
+Then later: *"when did robot 7's camera firmware change?"* is a SQL question over
+the accumulated snaps.
+
+**Docker note:** hardware detection needs to see the hardware. Run waffle-iron on
+the robot host (or a privileged container with device mounts); a stock Bagel
+container can read and archive the form, but can't scan USB devices itself.
+
 ## Experimental beta status
 
 This is the first slice of the Waffle Iron integration (WaffleForm as a data

--- a/server.py
+++ b/server.py
@@ -26,6 +26,7 @@ from src.pipeline import (
     rerun_export,
     windows,
 )
+from src.pipeline.tasks.waffle import snap as waffle_snap
 from src.sink import startup
 
 server = mcp_compat.create_server(
@@ -1008,6 +1009,45 @@ def export_for_lerobot(  # noqa: PLR0913
         name=name,
         robot_type=robot_type,
     )
+
+
+@server.tool(
+    title="Snapshot robot hardware into a WaffleForm (experimental beta)",
+    description=(
+        "Auto-detect the robot's current hardware, firmware, and software using "
+        "waffle-iron and return the resulting hardware state. Requires the waffle "
+        "CLI on PATH (cargo install waffle-iron). The WaffleForm it writes is "
+        "immediately queryable as a data source."
+    ),
+)
+def snap_hardware(directory: str = ".") -> dict[str, Any]:
+    """Snapshot live hardware state via waffle-iron.
+
+    Runs `waffle snap` in the given directory (or `waffle init` on first contact,
+    scanning connected hardware and scaffolding the form), then parses the
+    resulting `robot.waffleform.yaml` and returns its summary. Use
+    `describe_data_source` and `query_messages` on the returned form path for
+    deeper questions.
+
+    Args:
+        directory (str, optional): Directory holding (or receiving) the robot's
+            `robot.waffleform.yaml`. Defaults to the current directory.
+
+    Returns:
+        dict[str, Any]: The `form` path, robot identity, component `categories`
+            with counts, and the snap timestamp.
+
+    Examples:
+        As an LLM prompt:
+            What hardware is this robot actually running right now?
+
+    """
+    form = waffle_snap.run_waffle(directory)
+    ds_type = resolve(str(form))
+    factory = module.provide(
+        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": str(form)}
+    )
+    return {"form": str(form), **factory.metadata}
 
 
 if __name__ == "__main__":

--- a/src/pipeline/tasks/waffle/snap.py
+++ b/src/pipeline/tasks/waffle/snap.py
@@ -1,0 +1,112 @@
+"""Snapshot live robot hardware into a WaffleForm via waffle-iron. EXPERIMENTAL BETA.
+
+Runs the `waffle` CLI (https://github.com/arunvenkatadri/waffle-iron), which
+auto-detects connected hardware, firmware, and software, and writes the state to
+`robot.waffleform.yaml`. Each snapshot is copied into the artifact directory with
+a timestamped name, so accumulated snaps make hardware state a queryable history.
+
+Requires the waffle-iron binary on PATH: ``cargo install waffle-iron``.
+"""
+
+import logging
+import pathlib
+import shutil
+import subprocess
+from typing import Any
+
+from settings import settings
+from src.di import module
+from src.pipeline import base
+
+DEFAULT_TIMEOUT_SECONDS = 120
+
+
+def run_waffle(
+    workdir: str,
+    binary: str = "waffle",
+    init_if_missing: bool = True,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> pathlib.Path:
+    """Run `waffle snap` (or `waffle init` on first contact) and return the form path.
+
+    Raises:
+        RuntimeError: If the waffle binary is not installed.
+        subprocess.CalledProcessError: If the CLI exits non-zero.
+
+    """
+    executable = shutil.which(binary)
+    if executable is None:
+        raise RuntimeError(
+            f"'{binary}' not found on PATH. Hardware snapshots need waffle-iron: "
+            "cargo install waffle-iron (https://github.com/arunvenkatadri/waffle-iron)"
+        )
+    form = pathlib.Path(workdir) / "robot.waffleform.yaml"
+    command = "init" if init_if_missing and not form.exists() else "snap"
+    result = subprocess.run(  # noqa: S603 -- fixed argv, no shell; binary resolved via which
+        [executable, command],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=True,
+    )
+    logging.info("waffle %s: %s", command, result.stdout.strip()[:200])
+    if not form.exists():
+        raise RuntimeError(f"waffle {command} completed but {form} was not written.")
+    return form
+
+
+class WaffleSnap(base.Task):
+    """Snapshot live hardware state into a timestamped WaffleForm artifact.
+
+    On each execution, runs `waffle snap` (auto-detecting hardware, firmware, and
+    software versions) and copies the resulting WaffleForm into the artifact
+    directory as `<asof>.waffleform.yaml` -- immediately queryable as a Bagel data
+    source, and a growing history of the robot's hardware state.
+    """
+
+    def __init__(
+        self,
+        workdir: str = ".",
+        binary: str = "waffle",
+        init_if_missing: bool = True,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            workdir (str, optional): Directory holding (or receiving) the robot's
+                `robot.waffleform.yaml`. Defaults to the current directory.
+            binary (str, optional): The waffle-iron executable name or path.
+            init_if_missing (bool, optional): Run `waffle init` (scan and scaffold)
+                when no WaffleForm exists yet; otherwise `waffle snap`.
+            timeout_seconds (int, optional): CLI timeout.
+
+        """
+        self._workdir = workdir
+        self._binary = binary
+        self._init_if_missing = init_if_missing
+        self._timeout_seconds = timeout_seconds
+
+    def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
+        """Nothing to set up in this task."""
+
+    def execute(self, asof_seconds: float, lookback: Any = None) -> list[pathlib.Path]:  # noqa: ANN401
+        """Snapshot the hardware and archive the WaffleForm."""
+        form = run_waffle(
+            self._workdir,
+            binary=self._binary,
+            init_if_missing=self._init_if_missing,
+            timeout_seconds=self._timeout_seconds,
+        )
+        directory = pathlib.Path(settings.ARTIFACT_DIRECTORY) / "waffle" / self.pipeline
+        directory.mkdir(parents=True, exist_ok=True)
+        # Keep the .waffleform.yaml suffix so every snapshot resolves as a data source.
+        destination = directory / f"{asof_seconds:.0f}.waffleform.yaml"
+        shutil.copyfile(form, destination)
+        return [destination]
+
+
+def register() -> None:
+    """Register module for dependency injection."""
+    module.global_registry[__name__] = WaffleSnap

--- a/test/pipeline/tasks/waffle/test_snap.py
+++ b/test/pipeline/tasks/waffle/test_snap.py
@@ -1,0 +1,83 @@
+"""Tests for the waffle snapshot task and tool, against a fake waffle binary."""
+
+import pathlib
+import stat
+
+import pytest
+
+import server
+from settings import settings
+from src.di.types.data_source import DataSource, resolve
+from src.pipeline.tasks.waffle.snap import WaffleSnap, run_waffle
+
+FORM = """robot:
+  name: fake-bot
+  platform: test-rig
+  sensors:
+    camera:
+      model: realsense-d435i
+      firmware: "5.14.0"
+"""
+
+
+@pytest.fixture()
+def fake_waffle(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """A fake `waffle` on PATH: `init`/`snap` write a fixture WaffleForm to cwd."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / "waffle"
+    script.write_text(
+        f"#!/bin/sh\necho \"scanned 2 devices\"\ncat > robot.waffleform.yaml <<'EOF'\n{FORM}EOF\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{bin_dir}:/usr/bin:/bin")
+    workdir = tmp_path / "robot"
+    workdir.mkdir()
+    return workdir
+
+
+def test_run_waffle_inits_then_snaps(fake_waffle: pathlib.Path) -> None:
+    form = run_waffle(str(fake_waffle))
+
+    assert form.name == "robot.waffleform.yaml"
+    assert form.exists()
+    assert resolve(str(form)) is DataSource.WAFFLE_FORM
+
+
+def test_missing_binary_fails_with_install_hint(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path))
+    with pytest.raises(RuntimeError, match="cargo install waffle-iron"):
+        run_waffle(str(tmp_path))
+
+
+def test_task_archives_timestamped_queryable_snapshots(
+    fake_waffle: pathlib.Path, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+    task = WaffleSnap(workdir=str(fake_waffle))
+    task._name = "snap"
+    task._pipeline = "hardware_history"
+    task._site = "warehouse"
+    task._asset = "amr_07"
+    task._path = str(fake_waffle)
+    task._log_id = "log"
+    task._upload = False
+
+    produced = task.execute(asof_seconds=1662400000.0)
+
+    assert len(produced) == 1
+    artifact = produced[0]
+    assert artifact.name == "1662400000.waffleform.yaml"
+    assert "waffle/hardware_history" in str(artifact)
+    # The archived snapshot is itself a queryable Bagel data source.
+    assert resolve(str(artifact)) is DataSource.WAFFLE_FORM
+
+
+def test_snap_hardware_tool_returns_summary(fake_waffle: pathlib.Path) -> None:
+    result = server.snap_hardware(directory=str(fake_waffle))
+
+    assert result["form"].endswith("robot.waffleform.yaml")
+    assert result["robot"]["name"] == "fake-bot"
+    assert result["categories"] == {"sensors": 1, "robot": 1}


### PR DESCRIPTION
Clean rebuild of #136 on current main: its single feature commit cherry-picked, conflicts with the merged #135 resolved, plus a README formats-table row listing WaffleForm as experimental.

The snap_hardware MCP tool runs `waffle snap` (or `waffle init` on first contact) so waffle-iron auto-detects connected hardware, firmware, and software versions, then returns the parsed state. The waffle.snap pipeline task does the same on a cadence, archiving timestamped .waffleform.yaml snapshots that each resolve as a data source.

Left behind from #136: the five-week base drift and an unrelated .gitignore commit (terraform state and local-notes guards; say the word if you want that separately).

Supersedes #136; #141 (the umbrella pair PR) is superseded once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)