### PR TITLE
release: 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.0.1"
+version = "2.1.0"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.1.0",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.0.1",
+      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.1.0",
       "transport": {
         "type": "sse",
         "url": "http://127.0.0.1:8000/sse"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.0.1"
+version = "2.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 2.1.0 release: pyproject.toml, server.json (version + OCI identifier tag), uv.lock. Merge after #178 so the waffle snap tool ships in the tagged images.

Draft release notes (v2.1.0 tag after merge):

## Bagel 2.1.0: A Waffle Walks Into a Bagel Shop

- **Cloudini pointcloud compression**: compress a bag's PointCloud2 topics into CompressedPointCloud2, multi-part bags included, or decode compressed clouds in pipelines (#142)
- **Copper (copper-rs) logs**: summarize and query MCAP exports from Copper apps, no ROS image required (#174)
- **Hardware state as data, beta**: WaffleForm snapshots as a queryable source (#135), plus snap_hardware auto-detection and the waffle.snap pipeline task (#178). Snapshots accumulate, so "when did the camera firmware change?" is a SQL question
- **Lichtblick layouts fixed**: exported plots no longer open empty (#176)
- **Sample data ships in the images again**, so the quickstart prompts work on a pulled image (#173)
- **Localhost-only by default**: MCP and Jupyter ports bind to 127.0.0.1 on the host; containers opt in explicitly (#158, #160)
- **Big-bag memory safety**: streaming readers, bounded caches and buffers, no more OOM on million-message topics (#134, #156)
- **42 dead test files resurrected** with a CI guard that keeps every test reachable (#161, #163)
- Claude Code plugin, MCP registry listing, agent onboarding docs, README rework (#165-#171, #162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

