### PR TITLE
release: 2.1.1 (Copper verified against a real app)

### DIFF
--- a/doc/runbooks/copper.md
+++ b/doc/runbooks/copper.md
@@ -85,8 +85,18 @@ FROM "/filter"
   iterations where that task produced no payload (e.g. sinks). They are safe to
   ignore for analysis.
 - **Raw `.copper` files**: Bagel recognizes them by magic bytes and raises an
-  error pointing back to this workflow.
+  error pointing back to this workflow. Real logs are slab families
+  (`robot_0.copper`, `robot_1.copper`, ...) with `robot.copper` symlinked to
+  the first slab; the logreader takes the base name and finds the rest.
 
 A reference sample produced by a real Copper app (synthetic IMU pipeline) is
 committed at `data/sample/copper/imu_probe.mcap` and exercised by
 `test/pipeline/test_copper_mcap.py`.
+
+This whole workflow is verified against copper-rs's own `cu_caterpillar`
+example end to end: an 8 second run produced a 2.3 GB slab family, exported to
+a 19 GB MCAP (90 million messages, 17 channels), and Bagel summarized it in
+under 2 seconds and answered windowed SQL over it. Two reproduction notes:
+a fresh copper-rs clone expects sibling repos checked out next to it to build,
+and the caterpillar logreader needs only the `mcap` feature of `cu29-export`
+(the `python` feature wants a linkable libpython).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.1.0"
+version = "2.1.1"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.1.0",
+      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.1.1",
       "transport": {
         "type": "sse",
         "url": "http://127.0.0.1:8000/sse"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.1.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Docs + patch release. The Copper runbook now records real-world validation: we built copper-rs's own cu_caterpillar example, ran it, exported its unified log, and put the result through Bagel end to end.

- Raw .copper recognition and the export redirect verified against a real multi-slab log
- 19 GB exported MCAP (90 million messages, 17 channels): topic summary in under 2 seconds, windowed SQL answers correct
- Runbook notes: slab-family naming, copper-rs sibling-repo build quirk, cu29-export feature selection

Version 2.1.1 in pyproject.toml, server.json (version + OCI identifier), uv.lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
