### PR TITLE
ci: manual dispatch for the publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manual re-run for dropped push events (2026-08-19: GitHub silently skipped
+  # all workflows for a merge commit; images for that version never built).
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
GitHub dropped the push event for the #183 merge commit entirely (zero workflows ran), so the 2.1.1 images never built. This adds workflow_dispatch to publish.yaml so a dropped event can be re-fired by hand. Merging this PR also re-triggers publish on a main commit that carries version 2.1.1, which builds the missing images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)