### PR TITLE
fix: valid Codex authentication policy enum

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Robotics"
     }

--- a/test/plugin/test_plugin_manifests.py
+++ b/test/plugin/test_plugin_manifests.py
@@ -47,6 +47,6 @@ def test_codex_sideload_marketplace_entry_is_codex_shaped() -> None:
     (entry,) = marketplace["plugins"]
     assert entry["name"] == "bagel"
     assert entry["source"] == {"source": "local", "path": "./plugin"}
-    assert entry["policy"]["installation"] == "AVAILABLE"
-    assert entry["policy"]["authentication"]
+    assert entry["policy"]["installation"] in {"INSTALLED_BY_DEFAULT", "AVAILABLE", "NOT_AVAILABLE"}
+    assert entry["policy"]["authentication"] in {"ON_INSTALL", "ON_USE"}
     assert entry["category"]


### PR DESCRIPTION
Follow-up to #185 from the Codex re-review: policy.authentication accepts only ON_INSTALL or ON_USE; ON_FIRST_USE blocked marketplace ingestion entirely. Tests now assert the valid enums for both policy fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)