### PR TITLE
feat: serve both MCP transports on one port (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,9 +357,6 @@ Rough edges we know about, so you don't find them the hard way:
   event-window duration over total duration: quiet recordings reduce dramatically,
   eventful ones much less. The figures in this README are illustrative demo output,
   not a measured benchmark.
-- **SSE is the documented transport.** Streamable HTTP is already wired
-  (`MCP_TRANSPORT=streamable-http`), but compose does not forward the setting and
-  no client runbook covers it yet, so SSE is the supported path today (#168).
 - **No authentication on the MCP endpoint.** By design it binds to localhost only;
   treat it like a database socket and see [SECURITY.md](./SECURITY.md) before
   sharing it beyond your machine.

--- a/doc/runbooks/setup/codex.md
+++ b/doc/runbooks/setup/codex.md
@@ -8,13 +8,16 @@ But first, make sure the Bagel MCP server is already running in a separate termi
 
 If not, follow the [⚡️ Quickstart](../../../README.md#️-quickstart) guide to start it.
 
-You can check if it’s running by visiting [http://localhost:8000/sse](http://localhost:8000/sse)
-in your browser. You should see output like:
+You can check it is running:
 
+```bash
+curl -si http://localhost:8000/mcp -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' | head -1
 ```
-event: endpoint
-data: /messages/?session_id=d3daa0110c1041dead46bc6646dc4dc7
-```
+
+You should see `HTTP/1.1 200 OK`.
 
 ## 🛠️ Install Codex
 
@@ -33,54 +36,24 @@ Verify the installation:
 codex --version
 ```
 
-You should see output like:
-
-```bash
-codex-cli 0.31.0
-```
-
 Visit the [Codex CLI doc](https://developers.openai.com/codex/cli/) for more details.
-
-## 🛠️ Install mcp-proxy
-
-Because Bagel uses SSE transport and Codex currently supports only stdio transport,
-we need an adapter: [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy).
-
-To install `mcp-proxy`, first [install](https://docs.astral.sh/uv/getting-started/installation/)
-`uv` (skip this step if already installed):
-
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Then run:
-
-```bash
-uv tool install mcp-proxy
-```
-
-Verify the installation:
-
-```bash
-mcp-proxy --version
-```
-
-You should see output like:
-
-```bash
-mcp-proxy 0.8.2
-```
 
 ## 🔗 Connect Bagel
 
-To add the Bagel MCP server to Codex, open `~/.codex/config.toml` and add:
+Codex speaks MCP's streamable HTTP transport natively, and Bagel serves it at
+`/mcp` by default: no proxy or adapter needed. The easiest path is the bundled
+plugin: run Codex inside this repository and install `bagel` from `/plugins`
+(the repo carries the marketplace entry).
+
+To connect manually instead, open `~/.codex/config.toml` and add:
 
 ```toml
 [mcp_servers.bagel]
-command = "mcp-proxy"
-args = ["http://localhost:8000/sse"]
-env = { "API_KEY" = "<YOUR_OPENAI_API_KEY>" }
+url = "http://localhost:8000/mcp"
 ```
+
+If you changed `MCP_SERVER_PORT` (for example because another service holds
+8000), use that port in the URL.
 
 Now confirm the connection. Launch Codex and run:
 
@@ -88,19 +61,11 @@ Now confirm the connection. Launch Codex and run:
 /mcp list
 ```
 
-You should see output like:
-
-```bash
-🔌  MCP Tools
-
-  • Server: bagel
-    • Command: mcp-proxy http://localhost:8000/sse
-    • Tools: ...
-```
+You should see the `bagel` server with its tools.
 
 For more details on connecting MCP servers to Codex, see the
 [Codex on GitHub](https://github.com/openai/codex/blob/main/docs/config.md#mcp_servers).
 
 ## 🎉 Congrats! You are all set.
 
-Still having trouble? 🤦 It’s not your fault. [File a ticket](https://github.com/Extelligence-ai/bagel/issues) and let us know.
+Still having trouble? 🤦 It's not your fault. [File a ticket](https://github.com/Extelligence-ai/bagel/issues) and let us know.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bagel",
   "description": "Skills and MCP connection for Bagel: query rosbags, MCAP, CAN, MDF4, PX4/ArduPilot/Betaflight logs and live robot data in plain language; author event-windowed data-reduction pipelines; export to Rerun, Lichtblick, PlotJuggler, and LeRobot.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Extelligence",
     "url": "https://github.com/Extelligence-ai/bagel"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bagel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Skills and MCP connection for Bagel: query rosbags, MCAP, CAN, MDF4, PX4/ArduPilot/Betaflight logs and live robot data in plain language; author event-windowed data-reduction pipelines; export to Rerun, Lichtblick, PlotJuggler, and LeRobot.",
   "author": {
     "name": "Extelligence",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "bagel": {
-      "type": "sse",
-      "url": "http://localhost:8000/sse"
+      "type": "http",
+      "url": "http://localhost:8000/mcp"
     }
   }
 }

--- a/settings.py
+++ b/settings.py
@@ -105,9 +105,11 @@ class Settings(BaseSettings):
     # Port of the MCP server
     MCP_SERVER_PORT: int = 8000
 
-    # MCP transport: "sse" (current default, matches the README quickstart) or
-    # "streamable-http" (the newer transport; both are supported by MCP SDK v1 and v2)
-    MCP_TRANSPORT: str = "sse"
+    # MCP transport: "both" (default) serves legacy SSE at /sse and streamable
+    # HTTP at /mcp on one port, so SSE-configured clients and streamable-only
+    # clients (Codex's native MCP client) connect without configuration (#168).
+    # Set "sse" or "streamable-http" to pin a single transport.
+    MCP_TRANSPORT: str = "both"
 
 
 settings = Settings()

--- a/src/mcp_compat.py
+++ b/src/mcp_compat.py
@@ -11,6 +11,7 @@ major version. Verified against `mcp==2.0.0b1` and the pinned 1.x release.
 See https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/.
 """
 
+import inspect
 from typing import Any
 
 try:  # mcp >= 2.0
@@ -35,16 +36,26 @@ def create_server(name: str, host: str, port: int, instructions: str | None = No
     return _Server(name=name, instructions=instructions, host=host, port=port)
 
 
-def combined_app(server: Any) -> Any:  # noqa: ANN401
+def combined_app(server: Any, host: str | None = None) -> Any:  # noqa: ANN401
     """One ASGI app serving both transports: /sse (+ /messages/) and /mcp.
 
     Codex's native MCP client speaks only streamable HTTP, while the setup
     runbooks and existing user configs speak SSE. Route sets are disjoint, so
     the streamable app (whose lifespan owns the session manager) absorbs the
     SSE routes.
+
+    On SDK v2 the app factories take the host and use it for DNS-rebinding
+    validation; without it a non-loopback bind rejects LAN requests with 421.
+    v1 factories take no arguments (host arrived at construction).
     """
-    http_app = server.streamable_http_app()
-    http_app.router.routes.extend(server.sse_app().routes)
+
+    def _build(factory: Any) -> Any:  # noqa: ANN401
+        if host is not None and "host" in inspect.signature(factory).parameters:
+            return factory(host=host)
+        return factory()
+
+    http_app = _build(server.streamable_http_app)
+    http_app.router.routes.extend(_build(server.sse_app).routes)
     return http_app
 
 
@@ -58,7 +69,7 @@ def run_server(server: Any, transport: str, host: str, port: int) -> None:  # no
     if transport == "both" and hasattr(server, "streamable_http_app"):
         import uvicorn
 
-        uvicorn.run(combined_app(server), host=host, port=port)
+        uvicorn.run(combined_app(server, host=host), host=host, port=port)
         return
     if transport == "both":  # SDK without app composition: closest single transport
         transport = "streamable-http"

--- a/src/mcp_compat.py
+++ b/src/mcp_compat.py
@@ -35,12 +35,33 @@ def create_server(name: str, host: str, port: int, instructions: str | None = No
     return _Server(name=name, instructions=instructions, host=host, port=port)
 
 
-def run_server(server: Any, transport: str, host: str, port: int) -> None:  # noqa: ANN401
-    """Run the server on the given transport ("sse" or "streamable-http").
+def combined_app(server: Any) -> Any:  # noqa: ANN401
+    """One ASGI app serving both transports: /sse (+ /messages/) and /mcp.
 
-    v2 accepts host/port as transport kwargs; v1 already received them at
-    construction and accepts only the transport name.
+    Codex's native MCP client speaks only streamable HTTP, while the setup
+    runbooks and existing user configs speak SSE. Route sets are disjoint, so
+    the streamable app (whose lifespan owns the session manager) absorbs the
+    SSE routes.
     """
+    http_app = server.streamable_http_app()
+    http_app.router.routes.extend(server.sse_app().routes)
+    return http_app
+
+
+def run_server(server: Any, transport: str, host: str, port: int) -> None:  # noqa: ANN401
+    """Run the server: "both" (default), "sse", or "streamable-http".
+
+    "both" composes the two transport apps onto one uvicorn (#168). A single
+    named transport falls through to the SDK's own runner: v2 accepts
+    host/port as transport kwargs; v1 already received them at construction.
+    """
+    if transport == "both" and hasattr(server, "streamable_http_app"):
+        import uvicorn
+
+        uvicorn.run(combined_app(server), host=host, port=port)
+        return
+    if transport == "both":  # SDK without app composition: closest single transport
+        transport = "streamable-http"
     if MCP_SDK_V2:
         server.run(transport=transport, host=host, port=port)
     else:

--- a/test/plugin/test_plugin_manifests.py
+++ b/test/plugin/test_plugin_manifests.py
@@ -14,7 +14,10 @@ def test_plugin_manifest_is_valid_json_with_required_fields() -> None:
 def test_bundled_mcp_config_points_at_default_local_server() -> None:
     config = json.loads(pathlib.Path("plugin/.mcp.json").read_text())
     bagel = config["mcpServers"]["bagel"]
-    assert bagel["url"] == "http://localhost:8000/sse"
+    # Streamable HTTP: natively supported by Claude Code AND Codex (#168);
+    # the default server serves it alongside legacy /sse.
+    assert bagel["url"] == "http://localhost:8000/mcp"
+    assert bagel["type"] == "http"
 
 
 def test_marketplace_lists_the_plugin() -> None:

--- a/test/test_mcp_transports.py
+++ b/test/test_mcp_transports.py
@@ -64,3 +64,43 @@ def test_legacy_sse_endpoint_still_streams() -> None:
     finally:
         uv_server.should_exit = True
         thread.join(timeout=10)
+
+
+def test_combined_app_threads_host_into_factories_that_accept_it() -> None:
+    # On MCP SDK v2 the app factories take the host and use it for
+    # DNS-rebinding validation; a combined app built without it rejects
+    # non-localhost requests with 421. Factories without the parameter
+    # (SDK v1) must still be called plainly.
+    received = {}
+
+    class _V2Style:
+        def streamable_http_app(self, host: str | None = None):  # noqa: ANN202
+            received["http"] = host
+            return _stub_app()
+
+        def sse_app(self, host: str | None = None):  # noqa: ANN202
+            received["sse"] = host
+            return _stub_app()
+
+    class _V1Style:
+        def streamable_http_app(self):  # noqa: ANN202
+            return _stub_app()
+
+        def sse_app(self):  # noqa: ANN202
+            return _stub_app()
+
+    def _stub_app():  # noqa: ANN202
+        class _Router:
+            def __init__(self) -> None:
+                self.routes: list = []
+
+        class _App:
+            def __init__(self) -> None:
+                self.router = _Router()
+                self.routes: list = []
+
+        return _App()
+
+    mcp_compat.combined_app(_V2Style(), host="0.0.0.0")  # noqa: S104
+    assert received == {"http": "0.0.0.0", "sse": "0.0.0.0"}  # noqa: S104
+    mcp_compat.combined_app(_V1Style(), host="0.0.0.0")  # noqa: S104 -- must not raise

--- a/test/test_mcp_transports.py
+++ b/test/test_mcp_transports.py
@@ -1,0 +1,66 @@
+"""Both MCP transports must be reachable on one port (#168).
+
+Codex's native MCP client speaks only streamable HTTP (/mcp); every setup
+runbook and existing user config speaks SSE (/sse). The default server must
+serve both so neither side needs transport configuration.
+"""
+
+import threading
+import time
+
+import httpx
+import uvicorn
+from starlette.testclient import TestClient
+
+from src import mcp_compat
+
+INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "transport-guard", "version": "0"},
+    },
+}
+
+
+def _client() -> TestClient:
+    server = mcp_compat.create_server(name="guard", host="127.0.0.1", port=0)
+    return TestClient(mcp_compat.combined_app(server))
+
+
+def test_streamable_http_initialize_succeeds_on_mcp() -> None:
+    with _client() as client:
+        response = client.post(
+            "/mcp",
+            json=INITIALIZE,
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+        assert response.status_code == 200, response.text
+
+
+def test_legacy_sse_endpoint_still_streams() -> None:
+    # A real server on an ephemeral port: the in-process TestClient deadlocks
+    # on the endless SSE stream, so read only the response headers over a
+    # socket with a hard timeout.
+    server = mcp_compat.create_server(name="guard-sse", host="127.0.0.1", port=0)
+    app = mcp_compat.combined_app(server)
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
+    uv_server = uvicorn.Server(config)
+    thread = threading.Thread(target=uv_server.run, daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while not uv_server.started:
+        assert time.time() < deadline, "server did not start"
+        time.sleep(0.05)
+    (socket_info,) = uv_server.servers[0].sockets
+    port = socket_info.getsockname()[1]
+    try:
+        with httpx.stream("GET", f"http://127.0.0.1:{port}/sse", timeout=5) as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+    finally:
+        uv_server.should_exit = True
+        thread.join(timeout=10)


### PR DESCRIPTION
Codex's native MCP client speaks only streamable HTTP and 405'd on /sse during plugin validation. Rather than flipping the documented transport (breaking every existing SSE client config), the server now defaults to MCP_TRANSPORT=both: one uvicorn serving streamable HTTP at /mcp alongside legacy SSE at /sse and /messages/.

- src/mcp_compat.py: combined_app() merges the two Starlette route sets (streamable app keeps its session-manager lifespan); run_server grows the "both" mode with graceful fallback for SDKs without app composition
- settings.py: MCP_TRANSPORT defaults to "both"; "sse" and "streamable-http" still pin a single transport
- plugin/.mcp.json: type http at /mcp, natively supported by BOTH Claude Code and Codex; plugin bumped to 0.2.0
- doc/runbooks/setup/codex.md: rewritten, mcp-proxy adapter no longer needed
- README: the #168 limitation bullet retired
- test/test_mcp_transports.py: real initialize round-trip on /mcp, SSE handshake against an ephemeral uvicorn (in-process TestClient deadlocks on endless SSE streams)

Verified live in Codex CLI 0.147: native tool calls (run_poml_capability, describe_data_source) against the streamable endpoint. Closes #168; unblocks the Codex marketplace submission (their MCP checks use the native client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)