### PR TITLE
release: 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.1.1"
+version = "2.2.0"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.2.0",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.1.1",
+      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.2.0",
       "transport": {
         "type": "sse",
         "url": "http://127.0.0.1:8000/sse"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.1.1"
+version = "2.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for 2.2.0: both MCP transports served on one port by default, Codex plugin support, and the Copper runbook quickstart.

Draft release notes (v2.2.0 tag after merge):

## Bagel 2.2.0: Everything Bagel with Strawberry Cream Cheese

- **Both MCP transports by default** (#168, #188): the server now serves streamable HTTP at /mcp alongside legacy SSE at /sse on one port. Existing SSE client configs keep working; streamable-only clients (Codex's native MCP client) connect with zero configuration
- **Codex plugin** (#185, #186): the bundled plugin now serves OpenAI Codex as well as Claude Code from one plugin/ directory: same four skills, shared MCP config (now type http at /mcp, native in both), repo sideload via /plugins today, marketplace submission in flight
- **Codex setup runbook rewritten** (#188): the mcp-proxy adapter is no longer needed
- **Copper runbook quickstart** (#187): copy-paste start block (apache-arrow container, no ROS) and a first-win sample prompt
- Verified live in Codex CLI: native tool calls against /mcp, skills routing, correct answers on the committed Copper sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)
