### PR TITLE
ci: ghcr push retries + publish the missing arrow/iot images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,11 @@ jobs:
           - service: px4
           - service: ardupilot
           - service: betaflight
+          # Non-ROS services: the compose image name differs from the service
+          # name for apache-arrow (image path "arrow").
+          - service: apache-arrow
+            image: arrow
+          - service: iot
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -41,7 +46,7 @@ jobs:
         run: docker compose build ${{ matrix.service }}
       - name: Push ${{ matrix.service }}
         run: |
-          IMAGE=ghcr.io/extelligence-ai/bagel/${{ matrix.service }}
+          IMAGE=ghcr.io/extelligence-ai/bagel/${{ matrix.image || matrix.service }}
           TAG=sha-${{ github.sha }}
           # Semver tag from pyproject: the MCP registry rejects "latest", so
           # server.json pins this tag (see server.json at the repo root).

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,11 +50,22 @@ jobs:
           # Bump the pyproject version to publish a new one.
           VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
           docker tag $IMAGE:latest $IMAGE:$TAG
-          docker push $IMAGE:latest
-          docker push $IMAGE:$TAG
+          # ghcr intermittently drops a blob mid-push ("unknown blob"); a
+          # short-backoff retry has cleared it on every occurrence to date
+          # (2.1.0, 2.1.1, 2.2.0 all needed manual reruns for this).
+          push_with_retry() {
+            for attempt in 1 2 3; do
+              docker push "$1" && return 0
+              echo "push $1 failed (attempt $attempt); retrying in $((attempt * 20))s"
+              sleep $((attempt * 20))
+            done
+            docker push "$1"
+          }
+          push_with_retry $IMAGE:latest
+          push_with_retry $IMAGE:$TAG
           if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
             echo "$IMAGE:$VERSION already published; leaving it untouched"
           else
             docker tag $IMAGE:latest $IMAGE:$VERSION
-            docker push $IMAGE:$VERSION
+            push_with_retry $IMAGE:$VERSION
           fi


### PR DESCRIPTION
Two publish-workflow fixes:

1. ghcr dropped a blob mid-push on every release this week; pushes now retry three times with short backoff, final attempt uncaught so real failures still fail.
2. apache-arrow and iot were never in the publish matrix: no pulled image has ever existed for the Copper no-ROS path or the IoT quickstart. Both join the matrix; the push step maps service name to image name where they differ (apache-arrow -> arrow).

First merge to main publishes arrow:latest/2.2.0 and iot:latest/2.2.0 via the existing push-once semver guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)