### PR TITLE
docs: OpenAI Plugins Directory install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,19 @@ directory serves both Claude Code and OpenAI Codex.
 
 Codex and ChatGPT users: install bagel from the
 [OpenAI Plugins Directory](https://chatgpt.com/plugins/plugins_6a8623a0fe288191833ee0ca3fa883e7)
-(one click, skills only), or clone the repo and add it as a plugin
-marketplace (the repo carries `.agents/plugins/marketplace.json`) to get the
-MCP connection wired automatically too.
+(one click), or clone the repo and add it as a plugin marketplace (the repo
+carries `.agents/plugins/marketplace.json`). Directory installs bundle the
+skills only, so also connect the server once in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.bagel]
+url = "http://localhost:8000/mcp"
+```
+
+Repo-marketplace and Claude Code installs wire this connection automatically.
 
 Then start the container for your data format (see Quickstart): the plugin
-connects to `http://localhost:8000/sse` by default. Any other MCP client can
+connects to `http://localhost:8000/mcp` by default. Any other MCP client can
 discover the same workflows server-side via the `list_agent_capabilities` tool.
 
 ## Keep what matters, drop the rest

--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ directory serves both Claude Code and OpenAI Codex.
 /plugin install bagel@bagel
 ```
 
-Codex users: clone the repo and add it as a plugin marketplace (the repo
-carries `.agents/plugins/marketplace.json`), then install `bagel` from
-`/plugins` in Codex.
+Codex and ChatGPT users: install bagel from the
+[OpenAI Plugins Directory](https://chatgpt.com/plugins/plugins_6a8623a0fe288191833ee0ca3fa883e7)
+(one click, skills only), or clone the repo and add it as a plugin
+marketplace (the repo carries `.agents/plugins/marketplace.json`) to get the
+MCP connection wired automatically too.
 
 Then start the container for your data format (see Quickstart): the plugin
 connects to `http://localhost:8000/sse` by default. Any other MCP client can


### PR DESCRIPTION
Bagel is published in the OpenAI Plugins Directory (approved and live today). The README plugin section now leads with the one-click directory install for Codex/ChatGPT users, keeping the repo-marketplace path for those who want the MCP connection wired automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)