### PR TITLE
release: 2.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.2.1"
+version = "2.2.2"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.2.1"
+version = "2.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Patch release: Copper `export-mcap` channels with unit newtypes (`Length`, `Velocity`, angles) now decode (#196). Found on copper-rs `cu_flight_controller`; companion upstream PR copper-project/copper-rs#1290.

Bumps `pyproject.toml`, `server.json`, `uv.lock` to 2.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frad4zX5V73LvnypyggvkJ